### PR TITLE
ontick only calls the equipments using the current scanMode

### DIFF
--- a/src/engine/Engine.class.js
+++ b/src/engine/Engine.class.js
@@ -62,6 +62,10 @@ class Engine {
       }
     })
     // prepare config
+    this.scanModes = {}
+    this.config.engine.scanModes.forEach(({ scanMode }) => {
+      this.scanModes[scanMode] = []
+    })
     this.config.south.equipments.forEach((equipment) => {
       equipment.points.forEach((point) => {
         // replace relative path into absolute paths
@@ -71,6 +75,9 @@ class Engine {
         // apply default scanmodes
         if (!point.scanMode) {
           point.scanMode = equipment.defaultScanMode
+        }
+        if (this.scanModes[point.scanMode] && !this.scanModes[point.scanMode].includes(equipment.protocol)) {
+          this.scanModes[point.scanMode].push(equipment.protocol)
         }
       })
     })
@@ -146,7 +153,10 @@ class Engine {
         onTick: () => {
           // on each scan, activate each protocols
           Object.values(this.activeProtocols).forEach((protocol) => {
-            protocol.onScan(scanMode)
+            // if (this.scanModes[scanMode][protocol.constructor.name]) {
+            if (this.scanModes[scanMode].includes(protocol.constructor.name)) {
+              protocol.onScan(scanMode)
+            }
           })
         },
         start: false,

--- a/src/south/OPCUA/OPCUA.class.js
+++ b/src/south/OPCUA/OPCUA.class.js
@@ -52,15 +52,6 @@ const fieldsFromPointId = (pointId, types) => {
     console.error('Unable to retrieve fields associated with this pointId ', pointId, scannedEquipment)
     return {}
   }
-  // let fields
-  // scannedEquipment.some((point) => {
-  //   console.log(point.pointId === pointId)
-  //   if (point.pointId === pointId) {
-  //     console.log(point.fields)
-  //     fields = point.fields
-  //     return true
-  //   }
-  // })
 }
 
 /**
@@ -75,7 +66,6 @@ class OPCUA extends ProtocolHandler {
     // as OPCUA can group multiple points in a single request
     // we group points based on scanMode
     this.optimizedConfig = getOptimizedConfig(equipment)
-    console.log(this.optimizedConfig)
     // define OPCUA connection parameters
     this.client = new Opcua.OPCUAClient({ endpoint_must_exist: false })
     this.url = sprintf(engine.config.south.OPCUA.connectionAddress.opc, equipment.OPCUA)

--- a/tests/fTbus.json
+++ b/tests/fTbus.json
@@ -123,7 +123,7 @@
       },
       {
         "equipmentId": "MQTTServer",
-        "enabled": true,
+        "enabled": false,
         "protocol": "MQTT",
         "pointIdRoot": "/fttest.base",
         "defaultScanMode": "listen",
@@ -201,7 +201,7 @@
       },
       {
         "equipmentId": "PLC-35",
-        "enabled": false,
+        "enabled": true,
         "protocol": "Modbus",
         "pointIdRoot": "/fttest.base",
         "defaultScanMode": "everySecond",
@@ -250,7 +250,7 @@
       },
       {
         "equipmentId": "PLC-42",
-        "enabled": false,
+        "enabled": true,
         "protocol": "Modbus",
         "pointIdRoot": "/fttest.base/Tank4.tank",
         "defaultScanMode": "everySecond",


### PR DESCRIPTION
also removed useless commentary in OPCUA
@todo engine.scanModes could be filled with active protocols only which would mean initializing it between the start and the new CronJob()