### PR TITLE
Create default config file if it doesn't exists using defaultConfig.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,6 +90,6 @@
   },
   "bin": "./src/index.js",
   "pkg": {
-    "assets": "build/**/*"
+    "assets": ["build/**/*", "src/config/*"]
   }
 }

--- a/src/config/defaultConfig.json
+++ b/src/config/defaultConfig.json
@@ -1,0 +1,52 @@
+{
+  "engine": {
+    "port": 2223,
+    "user": "admin",
+    "password": "d74ff0ee8da3b9806b18c877dbf29bbde50b5bd8e4dad7a3a725000feb82e8f1",
+    "filter": ["127.0.0.1", "::1"],
+    "logParameters": {
+      "consoleLevel": "debug",
+      "fileLevel": "debug",
+      "filename": "./logs/journal.log",
+      "maxsize": 1000000,
+      "maxFiles": 5,
+      "tailable": true
+    },
+    "caching": {
+      "cacheFolder": "./cache",
+      "archiveMode": "archive",
+      "archiveFolder": "./cache/archived/"
+    },
+    "scanModes": [
+      {
+        "scanMode": "everySecond",
+        "cronTime": "* * * * * *"
+      },
+      {
+        "scanMode": "every10Second",
+        "cronTime": "* * * * * /10"
+      },
+      {
+        "scanMode": "every1Min",
+        "cronTime": "* * * * *"
+      }
+    ]
+  },
+  "south": {
+    "equipments": []
+  },
+  "north": {
+    "applications": [
+      {
+        "applicationId": "MyConsole",
+        "enabled": true,
+        "api": "Console",
+        "caching": {
+          "sendInterval": 1000,
+          "retryInterval": 1000,
+          "groupCount": 1
+        }
+      }
+    ]
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,7 @@
 const cluster = require('cluster')
 
-const { parseArgs } = require('./services/config.service')
+const { parseArgs, checkOrCreateConfigFile } = require('./services/config.service')
 const Engine = require('./engine/Engine.class')
-
-// retrieve config file
-const args = parseArgs() || {} // Arguments of the command
-const { config = './fTbus.json' } = args // Get the configuration file path
 
 if (cluster.isMaster) {
   // Fork a worker
@@ -21,6 +17,12 @@ if (cluster.isMaster) {
     cluster.fork()
   })
 } else {
+  const args = parseArgs() || {} // Arguments of the command
+
+  const { config = './fTbus.json' } = args // Get the configuration file path
+
+  checkOrCreateConfigFile(config) // Create default config file if it doesn't exist
+
   const engine = new Engine(config)
   engine.start()
 }

--- a/src/services/config.service.js
+++ b/src/services/config.service.js
@@ -25,7 +25,7 @@ const tryReadFile = (path) => {
  * @param {Object} args - Arguments of the command
  * @return {boolean} - Whether the right arguments have been passed or not
  */
-const isValidArgs = ({ config = './fTbus.config.json' }) => {
+const isValidArgs = ({ config }) => {
   if (!config) {
     console.error('No config file specified, example: --config ./config/config.json')
     return false
@@ -46,4 +46,17 @@ const parseArgs = () => {
   return null
 }
 
-module.exports = { parseArgs, tryReadFile }
+/**
+ * Check if config file exists
+ * @param {string} filePath - The location of the config file
+ * @return {void}
+ */
+const checkOrCreateConfigFile = (filePath) => {
+  if (!fs.existsSync(filePath)) {
+    console.info('Default config file does not exist. Creating it.')
+    const defaultConfig = JSON.parse(fs.readFileSync(`${__dirname}/../config/defaultConfig.json`, 'utf8'))
+    fs.writeFileSync(filePath, JSON.stringify(defaultConfig, null, 4), 'utf8')
+  }
+}
+
+module.exports = { parseArgs, tryReadFile, checkOrCreateConfigFile }


### PR DESCRIPTION
If there is no --config specified the default config file is ./fTbus.json.

If the config file doesn't exists the application will create it based on config/defaultConfig.json. You can review it and add/remove additional entries.

After packaging it will create fTbus.json in the same folder with the executable.

Do we still need JSON5 to add comments to the config file?