### PR TITLE
fix[cache]: #1014 - Properly split filename

### DIFF
--- a/src/engine/Cache.class.js
+++ b/src/engine/Cache.class.js
@@ -215,10 +215,8 @@ class Cache {
     this.logger.debug(`cacheFile(${filePath}) from ${dataSourceId}, preserveFiles:${preserveFiles}`)
     const timestamp = new Date().getTime()
     // When compressed file is received the name looks like filename.txt.gz
-    const filename = path.parse(filePath).base
-    const name = filename.substr(0, filename.indexOf('.'))
-    const ext = filename.substr(filename.indexOf('.'))
-    const cacheFilename = `${name}-${timestamp}${ext}`
+    const filenameInfo = path.parse(filePath)
+    const cacheFilename = `${filenameInfo.name}-${timestamp}${filenameInfo.ext}`
     const cachePath = path.join(this.cacheFolder, cacheFilename)
 
     try {


### PR DESCRIPTION
Fix #1014 