### PR TITLE
feat(south-modbus): Use two different fields for modbus points: 1 for modbusType (Registe…

### DIFF
--- a/src/migration/migration.service.js
+++ b/src/migration/migration.service.js
@@ -6,7 +6,7 @@ const Logger = require('../engine/Logger.class')
 
 const logger = new Logger('migration')
 
-const REQUIRED_SCHEMA_VERSION = 22
+const REQUIRED_SCHEMA_VERSION = 23
 const DEFAULT_VERSION = 1
 
 /**

--- a/src/migration/migrationRules.js
+++ b/src/migration/migrationRules.js
@@ -344,7 +344,7 @@ module.exports = {
         dataSource.points.forEach((point) => {
           if (!Object.prototype.hasOwnProperty.call(point, 'modbusType')) {
             point.modbusType = modbusTypes[point.address.charAt(0)]
-            point.address = '0x' + point.address.slice(1)
+            point.address = `0x${point.address.slice(1)}`
           }
         })
       }

--- a/src/migration/migrationRules.js
+++ b/src/migration/migrationRules.js
@@ -332,4 +332,22 @@ module.exports = {
       }
     })
   },
+  23: (config) => {
+    const modbusTypes = {
+      1: 'coil',
+      2: 'discreteInput',
+      3: 'inputRegister',
+      4: 'holdingRegister',
+    }
+    config.south.dataSources.forEach((dataSource) => {
+      if (dataSource.protocol === 'Modbus') {
+        dataSource.points.forEach((point) => {
+          if (!Object.prototype.hasOwnProperty.call(point, 'modbusType')) {
+            point.modbusType = modbusTypes[point.address.charAt(0)]
+            point.address = '0x' + point.address.slice(1)
+          }
+        })
+      }
+    })
+  },
 }

--- a/src/services/validation.service.js
+++ b/src/services/validation.service.js
@@ -27,6 +27,9 @@ const isHost = (name = 'Value') => (val) => (
 const isIp = (name = 'Value') => (val) => (
   (ipv4.test(val) || ipv6.test(val)) ? null : `${name} should be a valid ip`
 )
+const isHexaOrDecimal = (name = 'Value') => (val) => (
+  val?.match(/^0x[a-fA-F0-9]*$/i) !== null || val?.match(/^\d+$/i) !== null ? null : `${name} should be an hexa string (example: 0x3E61) or a decimal`
+)
 const isHexa = (name = 'Value') => (val) => (val?.match(/^[a-f0-9]*$/i) !== null ? null : `${name} should be an hexa string (example: 3E61)`)
 const minValue = (min, name = 'Value') => (val) => (val >= min ? null : `${name} should not greater than ${min}`)
 const maxValue = (max, name = 'Value') => (val) => (val >= max ? null : `${name} should not lower than ${max}`)
@@ -76,6 +79,7 @@ export {
   isIp,
   isHost,
   inRange,
+  isHexaOrDecimal,
   isHexa,
   minLength,
   maxLength,

--- a/src/south/Modbus/Modbus.class.spec.js
+++ b/src/south/Modbus/Modbus.class.spec.js
@@ -53,14 +53,14 @@ describe('Modbus south', () => {
     points: [
       {
         pointId: 'EtatBB2T0',
-        modbusType: "holdingRegister",
+        modbusType: 'holdingRegister',
         address: '0x3E80',
         type: 'number',
         scanMode: 'every10Seconds',
       },
       {
         pointId: 'EtatBB2T1',
-        modbusType: "holdingRegister",
+        modbusType: 'holdingRegister',
         scanMode: 'every10Seconds',
         address: '0x3E81',
         type: 'number',

--- a/src/south/Modbus/Modbus.class.spec.js
+++ b/src/south/Modbus/Modbus.class.spec.js
@@ -53,14 +53,16 @@ describe('Modbus south', () => {
     points: [
       {
         pointId: 'EtatBB2T0',
-        address: '43E80',
+        modbusType: "holdingRegister",
+        address: '0x3E80',
         type: 'number',
         scanMode: 'every10Seconds',
       },
       {
         pointId: 'EtatBB2T1',
+        modbusType: "holdingRegister",
         scanMode: 'every10Seconds',
-        address: '43E81',
+        address: '0x3E81',
         type: 'number',
       },
     ],

--- a/src/south/Modbus/Modbus.schema.jsx
+++ b/src/south/Modbus/Modbus.schema.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { inRange, isHost, notEmpty, isHexa, combinedValidations } from '../../services/validation.service'
+import { inRange, isHost, notEmpty, isHexaOrDecimal, combinedValidations } from '../../services/validation.service'
 
 const schema = { name: 'Modbus' }
 schema.form = {
@@ -61,10 +61,18 @@ schema.points = {
     valid: notEmpty(),
     defaultValue: '',
   },
+  modbusType: {
+    type: 'OIbSelect',
+    newRow: false,
+    options: ['coil', 'discreteInput', 'inputRegister', 'holdingRegister'],
+    label: 'Modbus type',
+    defaultValue: 'holdingRegister',
+    help: <div>Modbus data type (Coil, DiscreteInput, InputRegister, HoldingRegister)</div>,
+  },
   address: {
     type: 'OIbText',
     defaultValue: '',
-    valid: combinedValidations([isHexa(), notEmpty()]),
+    valid: combinedValidations([isHexaOrDecimal(), notEmpty()]),
   },
   scanMode: {
     type: 'OIbScanMode',

--- a/src/south/Modbus/config/getOptimizedConfig.js
+++ b/src/south/Modbus/config/getOptimizedConfig.js
@@ -88,10 +88,11 @@ const getOptimizedScanModes = (points, logger) => {
       // add modbusType and register address to each point
       scanModes[scanMode] = scanModes[scanMode].map((myPoint) => {
         const { modbusType } = myPoint
-        const address = Boolean(myPoint.address.match(/^0x[0-9a-f]+$/i)) ? parseInt(myPoint.address, 16) : myPoint.address
+        const address = myPoint.address.match(/^0x[0-9a-f]+$/i) ? parseInt(myPoint.address, 16) : myPoint.address
         const type = modbusTypes[myPoint.modbusType]
-        if (type === undefined || type === null)
+        if (type === undefined || type === null) {
           logger.error(`The modbus type ${modbusType} was not recognized.`)
+        }
         return {
           ...myPoint,
           modbusType,

--- a/src/south/Modbus/config/getOptimizedConfig.js
+++ b/src/south/Modbus/config/getOptimizedConfig.js
@@ -41,91 +41,6 @@ const findAddressesGroup = (object, address) => Object.keys(object)
   })
 
 /**
- * Return the modbusType and deduce the register address
- * @param {string} addr - the address in decimal
- * @param {Object} logger - the logger to display errors
- * @returns {{address: number, modbusType: string, type: string}} - The computed address for this modbusType
- */
-const getModbusType = (addr, logger) => {
-  const addrValue = parseInt(addr, 16)
-  if (addr.length < 6) {
-    // coil = [0x00001 - 0x09999 (=39321)]
-    if (addrValue <= 0x09999) {
-      return {
-        modbusType: 'coil',
-        address: addrValue, // the addr does not need to be change
-        type: 'boolean',
-      }
-    }
-    // discreteInput = [0x10001 (=65537) - 0x19999 (=104857)]
-    if (addrValue >= 0x10001 && addrValue <= 0x19999) {
-      return {
-        modbusType: 'discreteInput',
-        address: addrValue - 0x10000, // need to remove the address of discreteInput register to keep the value address only
-        type: 'number',
-      }
-    }
-    // inputRegister = [0x30001 (=196609) - 0x39999 (=235929)]
-    if (addrValue >= 0x30001 && addrValue <= 0x39999) {
-      return {
-        modbusType: 'inputRegister',
-        address: addrValue - 0x30000, // need to remove the address of inputRegister register to keep the value address only
-        type: 'number',
-      }
-    }
-    // holdingRegister = [0x40001 (=262145) - 0x49999 (=301465)]
-    if (addrValue >= 0x40001 && addrValue <= 0x49999) {
-      return {
-        modbusType: 'holdingRegister',
-        address: addrValue - 0x40000, // need to remove the address of holdingRegister register to keep the value address only
-        type: 'number',
-      }
-    }
-  } else if (addr.length === 6) {
-    // coil = [0x000001 - 0x065535]
-    if (addrValue <= 0x065535) {
-      return {
-        modbusType: 'coil',
-        address: addrValue, // the addr does not need to be change
-        type: 'boolean',
-      }
-    }
-    // discreteInput = [0x100001 - 0x165535]
-    if (addrValue >= 0x100001 && addrValue <= 0x165535) {
-      return {
-        modbusType: 'discreteInput',
-        address: addrValue - 0x100000, // need to remove the address of discreteInput register to keep the value address only
-        type: 'number',
-      }
-    }
-    // inputRegister = [0x300001 - 0x365535]
-    if (addrValue >= 0x300001 && addrValue <= 0x365535) {
-      return {
-        modbusType: 'inputRegister',
-        address: addrValue - 0x300000, // need to remove the address of inputRegister register to keep the value address only
-        type: 'number',
-      }
-    }
-    // holdingRegister = [0x400001 - 0x465535]
-    if (addrValue >= 0x400001 && addrValue <= 0x465535) {
-      return {
-        modbusType: 'holdingRegister',
-        address: addrValue - 0x400000, // need to remove the address of holdingRegister register to keep the value address only
-        type: 'number',
-      }
-    }
-  }
-
-  logger.error(`The address ${addr} (HEX : ${addr.toString(16)}) was not recognized.`)
-  // return invalid modbusType and address to trigger an error
-  return {
-    modbusType: 'unknown',
-    address: 999999,
-    type: 'unknown',
-  }
-}
-
-/**
  * Groups the data sources by addresses to optimize requests
  * @param {[ Object ]} array - Array of objects to group
  * @param {String} key - Key or nested key address to find it inside the objects
@@ -153,6 +68,13 @@ const groupAddresses = (array, key, maxGroupSize) => {
   }, {})
 }
 
+const modbusTypes = {
+  coil: 'boolean',
+  discreteInput: 'number',
+  inputRegister: 'number',
+  holdingRegister: 'number',
+}
+
 /**
  * Gets the configuration file
  * @param {Array} points - The list of points to request with ModBus
@@ -165,7 +87,11 @@ const getOptimizedScanModes = (points, logger) => {
     .forEach((scanMode) => {
       // add modbusType and register address to each point
       scanModes[scanMode] = scanModes[scanMode].map((myPoint) => {
-        const { modbusType, address, type } = getModbusType(myPoint.address, logger)
+        const { modbusType } = myPoint
+        const address = Boolean(myPoint.address.match(/^0x[0-9a-f]+$/i)) ? parseInt(myPoint.address, 16) : myPoint.address
+        const type = modbusTypes[myPoint.modbusType]
+        if (type === undefined || type === null)
+          logger.error(`The modbus type ${modbusType} was not recognized.`)
         return {
           ...myPoint,
           modbusType,


### PR DESCRIPTION
This feature allows you to configure the address of the points to be queried with two fields. The first field allows to choose the modbus type (Coil, discreteInput, inputRegister, holdingRegister), the second field allows to define the address of the point in the Modbus register. This allows the module to adapt to different address standards for the Modbus protocol.