### PR TITLE
 feat(south-modbus): Add possibility to specify the data type of a point (ON TOP OFF #1129)

### DIFF
--- a/src/client/South/Form/__snapshots__/SouthForm.spec.jsx.snap
+++ b/src/client/South/Form/__snapshots__/SouthForm.spec.jsx.snap
@@ -4368,6 +4368,23 @@ exports[`SouthForm check SouthForm with dataSource: PLC-35 1`] = `
                       Coil 156 (0x9C), enter 0x00009C for an extended Modicon Notation or enter 0x9C or 0x0009C for a standard Modicon Notation
                     </li>
                   </ul>
+                  <p>
+                    For each point you can specify extra configuration :
+                  </p>
+                  <ul>
+                    <li>
+                      addressOffset : Address offset to be applied for all points during requests (0 for the traditionnal Modbus protocol and 1 when using JBus)
+                    </li>
+                    <li>
+                      modbusType : Modbus data type (Coil, DiscreteInput, InputRegister, HoldingRegister)
+                    </li>
+                    <li>
+                      dataType : HoldingRegisters and inputRegisters can have one of the above types. Default type is UInt16. This field does not apply for coils and discreteInputs.
+                    </li>
+                    <li>
+                      endianness : Endianness of the data to read
+                    </li>
+                  </ul>
                 </div>
               </div>
             </div>
@@ -4478,6 +4495,9 @@ exports[`SouthForm check SouthForm with dataSource: PLC-35 1`] = `
           </small>
         </div>
       </div>
+      <div
+        class="col-md-2"
+      />
       <div
         class="col-md-2"
       />
@@ -5016,6 +5036,23 @@ exports[`SouthForm check SouthForm with dataSource: PLC-42 1`] = `
                       Coil 156 (0x9C), enter 0x00009C for an extended Modicon Notation or enter 0x9C or 0x0009C for a standard Modicon Notation
                     </li>
                   </ul>
+                  <p>
+                    For each point you can specify extra configuration :
+                  </p>
+                  <ul>
+                    <li>
+                      addressOffset : Address offset to be applied for all points during requests (0 for the traditionnal Modbus protocol and 1 when using JBus)
+                    </li>
+                    <li>
+                      modbusType : Modbus data type (Coil, DiscreteInput, InputRegister, HoldingRegister)
+                    </li>
+                    <li>
+                      dataType : HoldingRegisters and inputRegisters can have one of the above types. Default type is UInt16. This field does not apply for coils and discreteInputs.
+                    </li>
+                    <li>
+                      endianness : Endianness of the data to read
+                    </li>
+                  </ul>
                 </div>
               </div>
             </div>
@@ -5126,6 +5163,9 @@ exports[`SouthForm check SouthForm with dataSource: PLC-42 1`] = `
           </small>
         </div>
       </div>
+      <div
+        class="col-md-2"
+      />
       <div
         class="col-md-2"
       />

--- a/src/migration/migration.service.js
+++ b/src/migration/migration.service.js
@@ -6,7 +6,7 @@ const Logger = require('../engine/Logger.class')
 
 const logger = new Logger('migration')
 
-const REQUIRED_SCHEMA_VERSION = 24
+const REQUIRED_SCHEMA_VERSION = 25
 const DEFAULT_VERSION = 1
 
 /**

--- a/src/migration/migration.service.js
+++ b/src/migration/migration.service.js
@@ -6,7 +6,7 @@ const Logger = require('../engine/Logger.class')
 
 const logger = new Logger('migration')
 
-const REQUIRED_SCHEMA_VERSION = 25
+const REQUIRED_SCHEMA_VERSION = 26
 const DEFAULT_VERSION = 1
 
 /**

--- a/src/migration/migrationRules.js
+++ b/src/migration/migrationRules.js
@@ -360,4 +360,16 @@ module.exports = {
       }
     })
   },
+  25: (config) => {
+    config.south.dataSources.forEach((dataSource) => {
+      if (dataSource.protocol === 'Modbus') {
+        dataSource.points.forEach((point) => {
+          if (!Object.prototype.hasOwnProperty.call(point, 'dataType')) {
+            logger.info('Add dataType field to Modbus points')
+            point.dataType = 'UInt16'
+          }
+        })
+      }
+    })
+  },
 }

--- a/src/migration/migrationRules.js
+++ b/src/migration/migrationRules.js
@@ -372,4 +372,14 @@ module.exports = {
       }
     })
   },
+  26: (config) => {
+    config.south.dataSources.forEach((dataSource) => {
+      if (dataSource.protocol === 'Modbus') {
+        if (!Object.prototype.hasOwnProperty.call(dataSource.Modbus, 'endianness')) {
+          logger.info('Add endianness field to Modbus')
+          dataSource.Modbus.endianness = 'Big Endian'
+        }
+      }
+    })
+  },
 }

--- a/src/south/Modbus/Modbus.class.js
+++ b/src/south/Modbus/Modbus.class.js
@@ -5,21 +5,6 @@ const { getOptimizedScanModes } = require('./config/getOptimizedConfig')
 const ProtocolHandler = require('../ProtocolHandler.class')
 
 /**
- * Read point value according to it's data type (UInt16, UInt32, etc)
- * @param {Object} response Response of the modbus request
- * @param {Object} point The point to read
- * @param {Number} position Position of the point in the response
- * @return {Number} Value stored at the specified address
- */
-const readRegisterValue = (response, point, position) => {
-  if (response.body.constructor.name === 'ReadCoilsResponseBody' || response.body.constructor.name === 'ReadDiscreteInputsResponseBody') {
-    return response.body.valuesAsArray[position]
-  }
-  const funcName = `read${point.dataType}BE`
-  return response.body.valuesAsBuffer[funcName](position * 2)
-}
-
-/**
  * Class Modbus - Provides instruction for Modbus client connection
  */
 class Modbus extends ProtocolHandler {
@@ -63,6 +48,24 @@ class Modbus extends ProtocolHandler {
   }
 
   /**
+   * Read point value according to it's data type (UInt16, UInt32, etc)
+   * @param {Object} response Response of the modbus request
+   * @param {Object} point The point to read
+   * @param {Number} position Position of the point in the response
+   * @return {Number} Value stored at the specified address
+   */
+  readRegisterValue(response, point, position) {
+    if (response.body.constructor.name === 'ReadCoilsResponseBody' || response.body.constructor.name === 'ReadDiscreteInputsResponseBody') {
+      return response.body.valuesAsArray[position]
+    }
+    const endianness = this.dataSource.Modbus.endianness === 'Big Endian' ? 'BE' : 'LE'
+    const funcName = `read${point.dataType}${endianness}`
+    /* Here, the position must be multiplied by 2 because the jsmodbus library is set to read addresses values on 16 bits (2 bytes),
+      but in the valuesAsBuffer field each cell of the array contains 8 bits (1 byte) */
+    return response.body.valuesAsBuffer[funcName](position * 2)
+  }
+
+  /**
    * Dynamically call the right function based on the given name
    * @param {String} funcName - Name of the function to run
    * @param {Object} infos - Information about the group of addresses (first address of the group, size)
@@ -81,7 +84,7 @@ class Modbus extends ProtocolHandler {
               {
                 pointId: point.pointId,
                 timestamp,
-                data: { value: JSON.stringify(readRegisterValue(response, point, position)) },
+                data: { value: JSON.stringify(this.readRegisterValue(response, point, position)) },
               },
             ])
           })

--- a/src/south/Modbus/Modbus.class.js
+++ b/src/south/Modbus/Modbus.class.js
@@ -5,6 +5,21 @@ const { getOptimizedScanModes } = require('./config/getOptimizedConfig')
 const ProtocolHandler = require('../ProtocolHandler.class')
 
 /**
+ * Read point value according to it's data type (UInt16, UInt32, etc)
+ * @param {Object} response Response of the modbus request
+ * @param {Object} point The point to read
+ * @param {Number} position Position of the point in the response
+ * @return {Number} Value stored at the specified address
+ */
+const readRegisterValue = (response, point, position) => {
+  if (response.body.constructor.name === 'ReadCoilsResponseBody' || response.body.constructor.name === 'ReadDiscreteInputsResponseBody') {
+    return response.body.valuesAsArray[position]
+  }
+  const funcName = `read${point.dataType}BE`
+  return response.body.valuesAsBuffer[funcName](position * 2)
+}
+
+/**
  * Class Modbus - Provides instruction for Modbus client connection
  */
 class Modbus extends ProtocolHandler {
@@ -61,13 +76,12 @@ class Modbus extends ProtocolHandler {
           const timestamp = new Date().toISOString()
           points.forEach((point) => {
             const position = point.address - startAddress - 1
-            const data = response.body.valuesAsArray[position]
             /** @todo: below should send by batch instead of single points */
             this.addValues([
               {
                 pointId: point.pointId,
                 timestamp,
-                data: { value: JSON.stringify(data) },
+                data: { value: JSON.stringify(readRegisterValue(response, point, position)) },
               },
             ])
           })

--- a/src/south/Modbus/Modbus.class.spec.js
+++ b/src/south/Modbus/Modbus.class.spec.js
@@ -55,6 +55,7 @@ describe('Modbus south', () => {
       {
         pointId: 'EtatBB2T0',
         modbusType: 'holdingRegister',
+        dataType: 'UInt16',
         address: '0x3E80',
         type: 'number',
         scanMode: 'every10Seconds',
@@ -62,6 +63,7 @@ describe('Modbus south', () => {
       {
         pointId: 'EtatBB2T1',
         modbusType: 'holdingRegister',
+        dataType: 'UInt16',
         scanMode: 'every10Seconds',
         address: '0x3E81',
         type: 'number',
@@ -75,11 +77,13 @@ describe('Modbus south', () => {
         '15984-16016': [
           {
             pointId: 'EtatBB2T0',
+            dataType: 'UInt16',
             address: 16000,
             type: 'number',
           },
           {
             pointId: 'EtatBB2T1',
+            dataType: 'UInt16',
             address: 16001,
             type: 'number',
           },
@@ -102,6 +106,7 @@ describe('Modbus south', () => {
       {
         pointId: 'EtatBB2T0',
         modbusType: 'holdingRegister',
+        dataType: 'UInt16',
         address: '0x3E80',
         type: 'number',
         scanMode: 'every10Seconds',
@@ -109,6 +114,7 @@ describe('Modbus south', () => {
       {
         pointId: 'EtatBB2T1',
         modbusType: 'holdingRegister',
+        dataType: 'UInt16',
         scanMode: 'every10Seconds',
         address: '0x3E81',
         type: 'number',
@@ -122,11 +128,13 @@ describe('Modbus south', () => {
         '15984-16016': [
           {
             pointId: 'EtatBB2T0',
+            dataType: 'UInt16',
             address: 15999,
             type: 'number',
           },
           {
             pointId: 'EtatBB2T1',
+            dataType: 'UInt16',
             address: 16000,
             type: 'number',
           },

--- a/src/south/Modbus/Modbus.class.spec.js
+++ b/src/south/Modbus/Modbus.class.spec.js
@@ -50,6 +50,7 @@ describe('Modbus south', () => {
       host: '127.0.0.1',
       slaveId: 1,
       addressOffset: 'Modbus',
+      endianness: 'Big Endian',
     },
     points: [
       {
@@ -101,6 +102,7 @@ describe('Modbus south', () => {
       host: '127.0.0.1',
       slaveId: 1,
       addressOffset: 'JBus',
+      endianness: 'Big Endian',
     },
     points: [
       {

--- a/src/south/Modbus/Modbus.schema.jsx
+++ b/src/south/Modbus/Modbus.schema.jsx
@@ -78,6 +78,20 @@ schema.points = {
     defaultValue: 'holdingRegister',
     help: <div>Modbus data type (Coil, DiscreteInput, InputRegister, HoldingRegister)</div>,
   },
+  dataType: {
+    type: 'OIbSelect',
+    newRow: false,
+    options: ['UInt16', 'Int16', 'UInt32', 'Int32', 'UInt64', 'Int64', 'Float', 'Double'],
+    label: 'Data type',
+    defaultValue: 'Uint16',
+    help: (
+      <div>
+        In the case of a value from a holdingRegister or an inputRegister, what is the type of the data
+        (Is it an integer or a decimal number, on how many bits the value is stored and is the value signed or not.).
+        By default for these registers the value is stored on a UInt16
+      </div>
+    ),
+  },
   address: {
     type: 'OIbText',
     defaultValue: '',

--- a/src/south/Modbus/Modbus.schema.jsx
+++ b/src/south/Modbus/Modbus.schema.jsx
@@ -30,6 +30,20 @@ schema.form = {
           <li>Holding Register 16001 (0x3E81), enter 403E81 for an extended Modicon Notation or enter 43E81 for a standard Modicon Notation.</li>
           <li>Coil 156 (0x9C), enter 0x00009C for an extended Modicon Notation or enter 0x9C or 0x0009C for a standard Modicon Notation</li>
         </ul>
+
+        <p>For each point you can specify extra configuration :</p>
+        <ul>
+          <li>
+            addressOffset : Address offset to be applied for all points during requests
+            (0 for the traditionnal Modbus protocol and 1 when using JBus)
+          </li>
+          <li>modbusType : Modbus data type (Coil, DiscreteInput, InputRegister, HoldingRegister)</li>
+          <li>
+            dataType : HoldingRegisters and inputRegisters can have one of the above types.
+            Default type is UInt16. This field does not apply for coils and discreteInputs.
+          </li>
+          <li>endianness : Endianness of the data to read</li>
+        </ul>
       </div>
     ),
   },
@@ -60,7 +74,14 @@ schema.form = {
     options: ['Modbus', 'JBus'],
     label: 'Address Offset',
     defaultValue: 'Modbus',
-    help: <div>Address offset to be applied for all points during requests (0 for the traditionnal Modbus protocol and 1 when using JBus)</div>,
+  },
+  endianness: {
+    type: 'OIbSelect',
+    md: 2,
+    newRow: false,
+    options: ['Big Endian', 'Little Endian'],
+    label: 'Endianness',
+    defaultValue: 'Big Endian',
   },
 }
 
@@ -70,32 +91,22 @@ schema.points = {
     valid: notEmpty(),
     defaultValue: '',
   },
-  modbusType: {
-    type: 'OIbSelect',
-    newRow: false,
-    options: ['coil', 'discreteInput', 'inputRegister', 'holdingRegister'],
-    label: 'Modbus type',
-    defaultValue: 'holdingRegister',
-    help: <div>Modbus data type (Coil, DiscreteInput, InputRegister, HoldingRegister)</div>,
-  },
-  dataType: {
-    type: 'OIbSelect',
-    newRow: false,
-    options: ['UInt16', 'Int16', 'UInt32', 'Int32', 'UInt64', 'Int64', 'Float', 'Double'],
-    label: 'Data type',
-    defaultValue: 'Uint16',
-    help: (
-      <div>
-        In the case of a value from a holdingRegister or an inputRegister, what is the type of the data
-        (Is it an integer or a decimal number, on how many bits the value is stored and is the value signed or not.).
-        By default for these registers the value is stored on a UInt16
-      </div>
-    ),
-  },
   address: {
     type: 'OIbText',
     defaultValue: '',
     valid: combinedValidations([isHexaOrDecimal(), notEmpty()]),
+  },
+  modbusType: {
+    type: 'OIbSelect',
+    options: ['coil', 'discreteInput', 'inputRegister', 'holdingRegister'],
+    label: 'Modbus type',
+    defaultValue: 'holdingRegister',
+  },
+  dataType: {
+    type: 'OIbSelect',
+    options: ['UInt16', 'Int16', 'UInt32', 'Int32', 'UInt64', 'Int64', 'Float', 'Double'],
+    label: 'Data type',
+    defaultValue: 'Uint16',
   },
   scanMode: {
     type: 'OIbScanMode',


### PR DESCRIPTION
This feature allows you to define the type of values to be read. By default with the Modbus protocol, the values of the HoldingRegister and InputRegister registers are stored as UInt16. But it is more and more common to see Modbus PLCs storing these values on 32 bits (signed or unsigned), and sometimes these values can be decimal numbers and not integers. In rarer cases the values may even be stored on 64 bits. 