### PR TITLE
feat(south-modbus): Add possibility to do swapping operation (ON TOP OFF #1131)

### DIFF
--- a/src/client/South/Form/__snapshots__/SouthForm.spec.jsx.snap
+++ b/src/client/South/Form/__snapshots__/SouthForm.spec.jsx.snap
@@ -4501,6 +4501,15 @@ exports[`SouthForm check SouthForm with dataSource: PLC-35 1`] = `
       <div
         class="col-md-2"
       />
+      <div
+        class="col-md-1"
+      />
+      <div
+        class="col-md-1"
+      />
+      <div
+        class="col-md-1"
+      />
     </div>
   </form>
 </div>
@@ -5168,6 +5177,15 @@ exports[`SouthForm check SouthForm with dataSource: PLC-42 1`] = `
       />
       <div
         class="col-md-2"
+      />
+      <div
+        class="col-md-1"
+      />
+      <div
+        class="col-md-1"
+      />
+      <div
+        class="col-md-1"
       />
     </div>
   </form>

--- a/src/client/South/Form/__snapshots__/SouthForm.spec.jsx.snap
+++ b/src/client/South/Form/__snapshots__/SouthForm.spec.jsx.snap
@@ -4507,9 +4507,6 @@ exports[`SouthForm check SouthForm with dataSource: PLC-35 1`] = `
       <div
         class="col-md-1"
       />
-      <div
-        class="col-md-1"
-      />
     </div>
   </form>
 </div>
@@ -5177,9 +5174,6 @@ exports[`SouthForm check SouthForm with dataSource: PLC-42 1`] = `
       />
       <div
         class="col-md-2"
-      />
-      <div
-        class="col-md-1"
       />
       <div
         class="col-md-1"

--- a/src/migration/migration.service.js
+++ b/src/migration/migration.service.js
@@ -6,7 +6,7 @@ const Logger = require('../engine/Logger.class')
 
 const logger = new Logger('migration')
 
-const REQUIRED_SCHEMA_VERSION = 26
+const REQUIRED_SCHEMA_VERSION = 27
 const DEFAULT_VERSION = 1
 
 /**

--- a/src/migration/migrationRules.js
+++ b/src/migration/migrationRules.js
@@ -393,10 +393,6 @@ module.exports = {
           logger.info('Add swapWordsInDWords field to Modbus')
           dataSource.Modbus.swapWordsInDWords = false
         }
-        if (!Object.prototype.hasOwnProperty.call(dataSource.Modbus, 'swapDWords')) {
-          logger.info('Add swapDWords field to Modbus')
-          dataSource.Modbus.swapDWords = false
-        }
       }
     })
   },

--- a/src/migration/migrationRules.js
+++ b/src/migration/migrationRules.js
@@ -382,4 +382,22 @@ module.exports = {
       }
     })
   },
+  27: (config) => {
+    config.south.dataSources.forEach((dataSource) => {
+      if (dataSource.protocol === 'Modbus') {
+        if (!Object.prototype.hasOwnProperty.call(dataSource.Modbus, 'swapBytesinWords')) {
+          logger.info('Add swapBytesinWords field to Modbus')
+          dataSource.Modbus.swapBytesinWords = false
+        }
+        if (!Object.prototype.hasOwnProperty.call(dataSource.Modbus, 'swapWordsInDWords')) {
+          logger.info('Add swapWordsInDWords field to Modbus')
+          dataSource.Modbus.swapWordsInDWords = false
+        }
+        if (!Object.prototype.hasOwnProperty.call(dataSource.Modbus, 'swapDWords')) {
+          logger.info('Add swapDWords field to Modbus')
+          dataSource.Modbus.swapDWords = false
+        }
+      }
+    })
+  },
 }

--- a/src/south/Modbus/Modbus.class.js
+++ b/src/south/Modbus/Modbus.class.js
@@ -11,7 +11,7 @@ const ProtocolHandler = require('../ProtocolHandler.class')
  * @return {Number} Swapped data
  */
 const swapBytesinWords = (data) => {
-  const res = (data & 0x00FF00FF00FF00FF) << 8 | (data & 0xFF00FF00FF00FF00) >> 8 // eslint-disable-line no-bitwise, no-mixed-operators
+  const res = (data & 0x00FF00FF) << 8 | (data & 0xFF00FF00) >> 8 // eslint-disable-line no-bitwise, no-mixed-operators
   return res
 }
 
@@ -22,18 +22,7 @@ const swapBytesinWords = (data) => {
  * @return {Number} Swapped data
  */
 const swapWordsInDWords = (data) => {
-  const res = (data & 0x0000FFFF0000FFFF) << 16 | (data & 0xFFFF0000FFFF0000) >> 16 // eslint-disable-line no-bitwise, no-mixed-operators
-  return res
-}
-
-/**
- * Swap DWords (32 bits) in 64 bits
- * Example : 0101 0001 1110 0110 0111 1001 1100 0011 => 0111 1001 1100 0011 1110 0110 0101 0001
- * @param {Number} data on which to apply the swap
- * @return {Number} Swapped data
- */
-const swapDWords = (data) => {
-  const res = (data & 0x00000000FFFFFFFF) << 32 | (data & 0xFFFFFFFF00000000) >> 32 // eslint-disable-line no-bitwise, no-mixed-operators
+  const res = (data & 0x0000FFFF) << 16 | (data & 0xFFFF0000) >> 16 // eslint-disable-line no-bitwise, no-mixed-operators
   return res
 }
 
@@ -105,14 +94,11 @@ class Modbus extends ProtocolHandler {
    */
   swapData(data) {
     let res = data
-    if (this.dataSource.Modbus.swapBytesinWords) {
-      res = swapBytesinWords(res)
-    }
     if (this.dataSource.Modbus.swapWordsInDWords) {
       res = swapWordsInDWords(res)
     }
-    if (this.dataSource.Modbus.swapDWords) {
-      res = swapDWords(res)
+    if (this.dataSource.Modbus.swapBytesinWords) {
+      res = swapBytesinWords(res)
     }
     return res
   }

--- a/src/south/Modbus/Modbus.class.spec.js
+++ b/src/south/Modbus/Modbus.class.spec.js
@@ -51,6 +51,9 @@ describe('Modbus south', () => {
       slaveId: 1,
       addressOffset: 'Modbus',
       endianness: 'Big Endian',
+      swapBytesinWords: false,
+      swapWordsInDWords: false,
+      swapDWords: false,
     },
     points: [
       {
@@ -103,6 +106,9 @@ describe('Modbus south', () => {
       slaveId: 1,
       addressOffset: 'JBus',
       endianness: 'Big Endian',
+      swapBytesinWords: false,
+      swapWordsInDWords: false,
+      swapDWords: false,
     },
     points: [
       {

--- a/src/south/Modbus/Modbus.class.spec.js
+++ b/src/south/Modbus/Modbus.class.spec.js
@@ -53,7 +53,6 @@ describe('Modbus south', () => {
       endianness: 'Big Endian',
       swapBytesinWords: false,
       swapWordsInDWords: false,
-      swapDWords: false,
     },
     points: [
       {
@@ -108,7 +107,6 @@ describe('Modbus south', () => {
       endianness: 'Big Endian',
       swapBytesinWords: false,
       swapWordsInDWords: false,
-      swapDWords: false,
     },
     points: [
       {
@@ -149,6 +147,106 @@ describe('Modbus south', () => {
         ],
       },
     },
+  }
+
+  const modbusConfigAddressSwapDataAll = {
+    dataSourceId: 'Modbus',
+    protocol: 'Modbus',
+    enabled: true,
+    Modbus: {
+      port: 502,
+      host: '127.0.0.1',
+      slaveId: 1,
+      addressOffset: 'JBus',
+      endianness: 'Big Endian',
+      swapBytesinWords: true,
+      swapWordsInDWords: true,
+    },
+    points: [
+      {
+        pointId: 'EtatBB2T0',
+        modbusType: 'holdingRegister',
+        dataType: 'Int32',
+        address: '0x72',
+        type: 'number',
+        scanMode: 'every10Seconds',
+      },
+    ],
+  }
+
+  const modbusConfigAddressSwapData16 = {
+    dataSourceId: 'Modbus',
+    protocol: 'Modbus',
+    enabled: true,
+    Modbus: {
+      port: 502,
+      host: '127.0.0.1',
+      slaveId: 1,
+      addressOffset: 'JBus',
+      endianness: 'Big Endian',
+      swapBytesinWords: true,
+      swapWordsInDWords: false,
+    },
+    points: [
+      {
+        pointId: 'EtatBB2T0',
+        modbusType: 'holdingRegister',
+        dataType: 'Int32',
+        address: '0x72',
+        type: 'number',
+        scanMode: 'every10Seconds',
+      },
+    ],
+  }
+
+  const modbusConfigAddressSwapData32 = {
+    dataSourceId: 'Modbus',
+    protocol: 'Modbus',
+    enabled: true,
+    Modbus: {
+      port: 502,
+      host: '127.0.0.1',
+      slaveId: 1,
+      addressOffset: 'JBus',
+      endianness: 'Big Endian',
+      swapBytesinWords: false,
+      swapWordsInDWords: true,
+    },
+    points: [
+      {
+        pointId: 'EtatBB2T0',
+        modbusType: 'holdingRegister',
+        dataType: 'Int32',
+        address: '0x72',
+        type: 'number',
+        scanMode: 'every10Seconds',
+      },
+    ],
+  }
+
+  const modbusConfigAddressSwapDataNo = {
+    dataSourceId: 'Modbus',
+    protocol: 'Modbus',
+    enabled: true,
+    Modbus: {
+      port: 502,
+      host: '127.0.0.1',
+      slaveId: 1,
+      addressOffset: 'JBus',
+      endianness: 'Big Endian',
+      swapBytesinWords: false,
+      swapWordsInDWords: false,
+    },
+    points: [
+      {
+        pointId: 'EtatBB2T0',
+        modbusType: 'holdingRegister',
+        dataType: 'Int32',
+        address: '0x72',
+        type: 'number',
+        scanMode: 'every10Seconds',
+      },
+    ],
   }
 
   it('should be properly initialized', () => {
@@ -193,6 +291,28 @@ describe('Modbus south', () => {
       .toBeCalledWith(15984, 32) // see the optimizedScanModes to get the startAddress and range
     expect(modbusSouth.modbusClient.readHoldingRegisters)
       .toBeCalledTimes(1) // addresses are in the same group, so it makes one call
+  })
+
+  it('should properly swap data', async () => {
+    let modbusSouth = new Modbus(modbusConfigAddressSwapDataAll, engine)
+    await modbusSouth.connect()
+    let data = modbusSouth.swapData(432406529)
+    expect(data).toEqual(16827929)
+
+    modbusSouth = new Modbus(modbusConfigAddressSwapData16, engine)
+    await modbusSouth.connect()
+    data = modbusSouth.swapData(432406529)
+    expect(data).toEqual(-971439872)
+
+    modbusSouth = new Modbus(modbusConfigAddressSwapData32, engine)
+    await modbusSouth.connect()
+    data = modbusSouth.swapData(432406529)
+    expect(data).toEqual(72134)
+
+    modbusSouth = new Modbus(modbusConfigAddressSwapDataNo, engine)
+    await modbusSouth.connect()
+    data = modbusSouth.swapData(432406529)
+    expect(data).toEqual(432406529)
   })
 
   it('should properly disconnect', async () => {

--- a/src/south/Modbus/Modbus.schema.jsx
+++ b/src/south/Modbus/Modbus.schema.jsx
@@ -97,13 +97,6 @@ schema.form = {
     label: 'Swap Words (16 bits) in groups of 32 bits ?',
     defaultValue: false,
   },
-  swapDWords: {
-    type: 'OIbCheckBox',
-    md: 1,
-    newRow: false,
-    label: 'Swap DWords (32 bits) in groups of 64 bits ?',
-    defaultValue: false,
-  },
 }
 
 schema.points = {

--- a/src/south/Modbus/Modbus.schema.jsx
+++ b/src/south/Modbus/Modbus.schema.jsx
@@ -83,6 +83,27 @@ schema.form = {
     label: 'Endianness',
     defaultValue: 'Big Endian',
   },
+  swapBytesinWords: {
+    type: 'OIbCheckBox',
+    md: 1,
+    newRow: false,
+    label: 'Swap Bytes (8 bits) in groups of 16 bits ?',
+    defaultValue: false,
+  },
+  swapWordsInDWords: {
+    type: 'OIbCheckBox',
+    md: 1,
+    newRow: false,
+    label: 'Swap Words (16 bits) in groups of 32 bits ?',
+    defaultValue: false,
+  },
+  swapDWords: {
+    type: 'OIbCheckBox',
+    md: 1,
+    newRow: false,
+    label: 'Swap DWords (32 bits) in groups of 64 bits ?',
+    defaultValue: false,
+  },
 }
 
 schema.points = {


### PR DESCRIPTION
This allow to do swapping operations on retreived data. In order to read correctly data from specific modbus PLCs, 3 swapping operations are implemented in this PR :
 - swapBytesinWords : Swap Bytes (8 bits) in Words (16 bits) 
    - Example : 0101 0001 => 0001 0101
 - swapWordsInDWords : Swap Words (16 bits) in DWords (32 bits)
    - Example : 0101 0001 1110 0110 => 1110 0110 0101 0001
 - swapDWords : Swap DWords in 64 bits
    - Example : 0101 0001 1110 0110 0111 1001 1100 0011 => 0111 1001 1100 0011 1110 0110 0101 0001