### PR TITLE
feat(south-ads): structure filter

### DIFF
--- a/src/client/Health/__snapshots__/Health.spec.jsx.snap
+++ b/src/client/Health/__snapshots__/Health.spec.jsx.snap
@@ -483,7 +483,7 @@ exports[`Health display Health page based on config and status 1`] = `
             class="inline-button autosize oi-points-button btn btn-outline-success btn-sm"
             type="button"
           >
-            Points (7)
+            Points (24)
           </button>
         </div>
       </div>
@@ -1017,7 +1017,7 @@ exports[`Health display Health page based on config and status 2`] = `
             class="inline-button autosize oi-points-button btn btn-outline-success btn-sm"
             type="button"
           >
-            Points (7)
+            Points (24)
           </button>
         </div>
       </div>

--- a/src/client/Health/__snapshots__/Overview.spec.jsx.snap
+++ b/src/client/Health/__snapshots__/Overview.spec.jsx.snap
@@ -442,7 +442,7 @@ exports[`Overview display overview based on config 1`] = `
             class="inline-button autosize oi-points-button btn btn-outline-success btn-sm"
             type="button"
           >
-            Points (7)
+            Points (24)
           </button>
         </div>
       </div>

--- a/src/client/South/Form/__snapshots__/SouthForm.spec.jsx.snap
+++ b/src/client/South/Form/__snapshots__/SouthForm.spec.jsx.snap
@@ -46,7 +46,7 @@ exports[`SouthForm check SouthForm with dataSource: ADS - Test 1`] = `
           class="inline-button autosize oi-points-button btn btn-outline-success btn-sm"
           type="button"
         >
-          Points (7)
+          Points (24)
         </button>
       </div>
     </div>
@@ -968,6 +968,217 @@ exports[`SouthForm check SouthForm with dataSource: ADS - Test 1`] = `
             class="invalid-feedback"
           />
         </div>
+      </div>
+    </div>
+    <div
+      class="row"
+    >
+      <div
+        class="col-md-12"
+      >
+        <div
+          class="row"
+        >
+          <h5>
+            Ads structures
+            <button
+              aria-label="Close"
+              class="close"
+              id="id"
+            >
+              <svg
+                class="oi-help"
+                fill="currentColor"
+                height="1em"
+                stroke="currentColor"
+                stroke-width="0"
+                viewBox="0 0 512 512"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z"
+                />
+              </svg>
+            </button>
+          </h5>
+        </div>
+        <div
+          class="container-fluid"
+        >
+          <div
+            class="collapse"
+            toggler="id"
+          >
+            <div
+              class="row"
+              style="margin-bottom: 15px;"
+            >
+              <div
+                class="col"
+              >
+                <div>
+                  Only specified structures will be taken into account. To take all fields of a structure, you can use the wildcard *. To take some of the fields only, specify them (case sensitive), separated by commas. For example, E_ANA is the name of the structure, and the fields to take are : Mesure,a,b
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="row"
+    >
+      <div
+        class="col-md-4"
+      >
+        <table
+          class="table table-sm table-striped table-hover"
+        >
+          <thead>
+            <tr>
+              <th
+                scope="col"
+              >
+                <svg
+                  class="oi-icon"
+                  fill="currentColor"
+                  height="1em"
+                  stroke="currentColor"
+                  stroke-width="0"
+                  viewBox="0 0 512 512"
+                  width="1em"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M256 8C119 8 8 119 8 256s111 248 248 248 248-111 248-248S393 8 256 8zm144 276c0 6.6-5.4 12-12 12h-92v92c0 6.6-5.4 12-12 12h-56c-6.6 0-12-5.4-12-12v-92h-92c-6.6 0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h92v-92c0-6.6 5.4-12 12-12h56c6.6 0 12 5.4 12 12v92h92c6.6 0 12 5.4 12 12v56z"
+                  />
+                </svg>
+                <span>
+                  Name
+                </span>
+              </th>
+              <th
+                scope="col"
+              >
+                Fields
+              </th>
+              <th
+                scope="col"
+              />
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>
+                <div
+                  class="form-group"
+                  style="margin-bottom: 0px;"
+                >
+                  <input
+                    aria-invalid="false"
+                    class="oi-form-input form-control"
+                    id="south.dataSources.0.ADS.structureFiltering.0.name"
+                    name="south.dataSources.0.ADS.structureFiltering.0.name"
+                    type="text"
+                    value="ST_Example"
+                  />
+                  <div
+                    class="invalid-feedback"
+                  />
+                </div>
+              </td>
+              <td>
+                <div
+                  class="form-group"
+                  style="margin-bottom: 0px;"
+                >
+                  <input
+                    aria-invalid="false"
+                    class="oi-form-input form-control"
+                    id="south.dataSources.0.ADS.structureFiltering.0.fields"
+                    name="south.dataSources.0.ADS.structureFiltering.0.fields"
+                    type="text"
+                    value="SomeReal,SomeDate"
+                  />
+                  <div
+                    class="invalid-feedback"
+                  />
+                </div>
+              </td>
+              <td>
+                <svg
+                  class="oi-icon"
+                  fill="currentColor"
+                  height="1em"
+                  stroke="currentColor"
+                  stroke-width="0"
+                  viewBox="0 0 448 512"
+                  width="1em"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M32 464a48 48 0 0 0 48 48h288a48 48 0 0 0 48-48V128H32zm272-256a16 16 0 0 1 32 0v224a16 16 0 0 1-32 0zm-96 0a16 16 0 0 1 32 0v224a16 16 0 0 1-32 0zm-96 0a16 16 0 0 1 32 0v224a16 16 0 0 1-32 0zM432 32H312l-9.4-18.7A24 24 0 0 0 281.1 0H166.8a23.72 23.72 0 0 0-21.4 13.3L136 32H16A16 16 0 0 0 0 48v32a16 16 0 0 0 16 16h416a16 16 0 0 0 16-16V48a16 16 0 0 0-16-16z"
+                  />
+                </svg>
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <div
+                  class="form-group"
+                  style="margin-bottom: 0px;"
+                >
+                  <input
+                    aria-invalid="false"
+                    class="oi-form-input form-control"
+                    id="south.dataSources.0.ADS.structureFiltering.1.name"
+                    name="south.dataSources.0.ADS.structureFiltering.1.name"
+                    type="text"
+                    value="Tc2_Standard.TON"
+                  />
+                  <div
+                    class="invalid-feedback"
+                  />
+                </div>
+              </td>
+              <td>
+                <div
+                  class="form-group"
+                  style="margin-bottom: 0px;"
+                >
+                  <input
+                    aria-invalid="false"
+                    class="oi-form-input form-control"
+                    id="south.dataSources.0.ADS.structureFiltering.1.fields"
+                    name="south.dataSources.0.ADS.structureFiltering.1.fields"
+                    type="text"
+                    value="*"
+                  />
+                  <div
+                    class="invalid-feedback"
+                  />
+                </div>
+              </td>
+              <td>
+                <svg
+                  class="oi-icon"
+                  fill="currentColor"
+                  height="1em"
+                  stroke="currentColor"
+                  stroke-width="0"
+                  viewBox="0 0 448 512"
+                  width="1em"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M32 464a48 48 0 0 0 48 48h288a48 48 0 0 0 48-48V128H32zm272-256a16 16 0 0 1 32 0v224a16 16 0 0 1-32 0zm-96 0a16 16 0 0 1 32 0v224a16 16 0 0 1-32 0zm-96 0a16 16 0 0 1 32 0v224a16 16 0 0 1-32 0zM432 32H312l-9.4-18.7A24 24 0 0 0 281.1 0H166.8a23.72 23.72 0 0 0-21.4 13.3L136 32H16A16 16 0 0 0 0 48v32a16 16 0 0 0 16 16h416a16 16 0 0 0 16-16V48a16 16 0 0 0-16-16z"
+                  />
+                </svg>
+              </td>
+            </tr>
+          </tbody>
+        </table>
       </div>
     </div>
   </form>

--- a/src/client/South/__snapshots__/South.spec.jsx.snap
+++ b/src/client/South/__snapshots__/South.spec.jsx.snap
@@ -1009,7 +1009,7 @@ exports[`South check South 1`] = `
               class="inline-button autosize oi-points-button btn btn-outline-success btn-sm"
               type="button"
             >
-              Points (7)
+              Points (24)
             </button>
           </td>
           <td>
@@ -2174,7 +2174,7 @@ exports[`South check add pressed with "new_datasource" id 1`] = `
               class="inline-button autosize oi-points-button btn btn-outline-success btn-sm"
               type="button"
             >
-              Points (7)
+              Points (24)
             </button>
           </td>
           <td>
@@ -3339,7 +3339,7 @@ exports[`South check delete first dataSource 1`] = `
               class="inline-button autosize oi-points-button btn btn-outline-success btn-sm"
               type="button"
             >
-              Points (7)
+              Points (24)
             </button>
           </td>
           <td>
@@ -4504,7 +4504,7 @@ exports[`South check duplicate first dataSource 1`] = `
               class="inline-button autosize oi-points-button btn btn-outline-success btn-sm"
               type="button"
             >
-              Points (7)
+              Points (24)
             </button>
           </td>
           <td>
@@ -5669,7 +5669,7 @@ exports[`South check duplicate first dataSource with countCopies 1`] = `
               class="inline-button autosize oi-points-button btn btn-outline-success btn-sm"
               type="button"
             >
-              Points (7)
+              Points (24)
             </button>
           </td>
           <td>
@@ -6834,7 +6834,7 @@ exports[`South check edit first dataSource id 1`] = `
               class="inline-button autosize oi-points-button btn btn-outline-success btn-sm"
               type="button"
             >
-              Points (7)
+              Points (24)
             </button>
           </td>
           <td>
@@ -8019,7 +8019,7 @@ exports[`South check open edit first application 1`] = `
               class="inline-button autosize oi-points-button btn btn-outline-success btn-sm"
               type="button"
             >
-              Points (7)
+              Points (24)
             </button>
           </td>
           <td>
@@ -9198,7 +9198,7 @@ exports[`South check press edit first dataSource id 1`] = `
               class="inline-button autosize oi-points-button btn btn-outline-success btn-sm"
               type="button"
             >
-              Points (7)
+              Points (24)
             </button>
           </td>
           <td>
@@ -10363,7 +10363,7 @@ exports[`South check sort pressed on dataSourceId 1`] = `
               class="inline-button autosize oi-points-button btn btn-outline-success btn-sm"
               type="button"
             >
-              Points (7)
+              Points (24)
             </button>
           </td>
           <td>
@@ -11528,7 +11528,7 @@ exports[`South check sort pressed on dataSourceId ascending 1`] = `
               class="inline-button autosize oi-points-button btn btn-outline-success btn-sm"
               type="button"
             >
-              Points (7)
+              Points (24)
             </button>
           </td>
           <td>

--- a/src/south/ADS/ADS.class.spec.js
+++ b/src/south/ADS/ADS.class.spec.js
@@ -22,6 +22,61 @@ engine.configService = { getConfig: () => ({ engineConfig: config.engine }) }
 engine.addValues = jest.fn()
 
 // Global variable used to simulate ADS library returned values
+const GVLTestByte = {
+  value: 1234,
+  type: {
+    name: '',
+    type: 'BYTE',
+  },
+  symbol: {
+    name: 'GVL_Test.TestByte',
+    type: 'BYTE',
+  },
+}
+const GVLTestWord = {
+  value: 1234,
+  type: {
+    name: '',
+    type: 'WORD',
+  },
+  symbol: {
+    name: 'GVL_Test.TestWord',
+    type: 'WORD',
+  },
+}
+const GVLTestDWord = {
+  value: 1234,
+  type: {
+    name: '',
+    type: 'DWORD',
+  },
+  symbol: {
+    name: 'GVL_Test.TestDWord',
+    type: 'DWORD',
+  },
+}
+const GVLTestSINT = {
+  value: 1234,
+  type: {
+    name: '',
+    type: 'SINT',
+  },
+  symbol: {
+    name: 'GVL_Test.TestSINT',
+    type: 'SINT',
+  },
+}
+const GVLTestUSINT = {
+  value: 1234,
+  type: {
+    name: '',
+    type: 'USINT',
+  },
+  symbol: {
+    name: 'GVL_Test.TestUSINT',
+    type: 'USINT',
+  },
+}
 const GVLTestINT = {
   value: 1234,
   type: {
@@ -56,6 +111,127 @@ const GVLTestINT = {
     typeGuid: '95190718000000000000000000000006',
     attributes: [],
     reserved: { type: 'Buffer', data: [0, 0, 0, 0] },
+  },
+}
+const GVLTestUINT = {
+  value: 1234,
+  type: {
+    name: '',
+    type: 'UINT',
+  },
+  symbol: {
+    name: 'GVL_Test.TestUINT',
+    type: 'UINT',
+  },
+}
+const GVLTestDINT = {
+  value: 1234,
+  type: {
+    name: '',
+    type: 'DINT',
+  },
+  symbol: {
+    name: 'GVL_Test.TestDINT',
+    type: 'DINT',
+  },
+}
+const GVLTestUDINT = {
+  value: 1234,
+  type: {
+    name: '',
+    type: 'UDINT',
+  },
+  symbol: {
+    name: 'GVL_Test.TestUDINT',
+    type: 'UDINT',
+  },
+}
+const GVLTestLINT = {
+  value: 1234,
+  type: {
+    name: '',
+    type: 'LINT',
+  },
+  symbol: {
+    name: 'GVL_Test.TestLINT',
+    type: 'LINT',
+  },
+}
+const GVLTestULINT = {
+  value: 1234,
+  type: {
+    name: '',
+    type: 'ULINT',
+  },
+  symbol: {
+    name: 'GVL_Test.TestULINT',
+    type: 'ULINT',
+  },
+}
+const GVLTestTIME = {
+  value: 1234,
+  type: {
+    name: '',
+    type: 'TIME',
+  },
+  symbol: {
+    name: 'GVL_Test.TestTIME',
+    type: 'TIME',
+  },
+}
+const GVLTestTimeOfDay = {
+  value: 1234,
+  type: {
+    name: '',
+    type: 'TIME_OF_DAY',
+  },
+  symbol: {
+    name: 'GVL_Test.TestTIME_OF_DAY',
+    type: 'TIME_OF_DAY',
+  },
+}
+const GVLTestREAL = {
+  value: 1234,
+  type: {
+    name: '',
+    type: 'REAL',
+  },
+  symbol: {
+    name: 'GVL_Test.TestREAL',
+    type: 'REAL',
+  },
+}
+const GVLTestLREAL = {
+  value: 1234,
+  type: {
+    name: '',
+    type: 'LREAL',
+  },
+  symbol: {
+    name: 'GVL_Test.TestLREAL',
+    type: 'LREAL',
+  },
+}
+const GVLTestDATE = {
+  value: '2020-02-02',
+  type: {
+    name: '',
+    type: 'DATE',
+  },
+  symbol: {
+    name: 'GVL_Test.TestDATE',
+    type: 'DATE',
+  },
+}
+const GVLTestDateAndTime = {
+  value: '2020-02-02 02:02:02.222',
+  type: {
+    name: '',
+    type: 'DATE_AND_TIME',
+  },
+  symbol: {
+    name: 'GVL_Test.TestDATE_AND_TIME',
+    type: 'DATE_AND_TIME',
   },
 }
 const GVLTestENUM = {
@@ -102,7 +278,7 @@ const GVLTestSTRING = {
   value: 'Hello this is a test string',
   type: {
     name: '',
-    type: 'STRING(80)',
+    type: 'STRING',
     size: 81,
     offset: 0,
     adsDataType: 30,
@@ -126,7 +302,7 @@ const GVLTestSTRING = {
     typeLength: 10,
     commentLength: 0,
     name: 'GVL_Test.TestSTRING',
-    type: 'STRING(80)',
+    type: 'STRING',
     comment: '',
     arrayData: [],
     typeGuid: '95190718000000000000000100000050',
@@ -171,7 +347,7 @@ const GVLTestARRAY = {
   },
 }
 const GVLTestTimer = {
-  value: { IN: false, PT: 2500, Q: false, ET: 0, M: false, StartTime: 0 },
+  value: { IN: false, PT: 2500, Q: false, ET: 0, M: true, StartTime: 0 },
   type: {
     name: '',
     type: 'Tc2_Standard.TON',
@@ -438,6 +614,17 @@ const GVLTestARRAY2 = {
     reserved: { type: 'Buffer', data: [0, 0] },
   },
 }
+const GVLTestBadType = {
+  value: 1234,
+  type: {
+    name: '',
+    type: 'BAD_TYPE',
+  },
+  symbol: {
+    name: 'GVL_Test.TestBadType',
+    type: 'BAD_TYPE',
+  },
+}
 const nowDateString = '2020-02-02T02:02:02.222Z'
 // End of global variables
 
@@ -525,6 +712,11 @@ describe('ADS south', () => {
         'ADS - Test',
         [{ pointId: 'PLC_TEST.GVL_Test.TestTimer.Q', timestamp: nowDateString, data: { value: '0' } }],
       )
+    expect(engine.addValues)
+      .toHaveBeenCalledWith(
+        'ADS - Test',
+        [{ pointId: 'PLC_TEST.GVL_Test.TestTimer.M', timestamp: nowDateString, data: { value: '1' } }],
+      )
     // Test enum value as text
     expect(engine.addValues).toHaveBeenCalledWith(
       'ADS - Test',
@@ -538,6 +730,25 @@ describe('ADS south', () => {
     expect(adsSouth.client.readSymbol).toBeCalledWith('GVL_Test.ExampleSTRUCT')
     expect(adsSouth.logger.error)
       .toBeCalledTimes(0)
+    // The SomeText field is not called because not specified in the structure filtering config
+    expect(engine.addValues)
+      .not.toHaveBeenCalledWith(
+        'ADS - Test',
+        [{ pointId: 'PLC_TEST.GVL_Test.ExampleSTRUCT.SomeText', timestamp: nowDateString, data: { value: 'Hello ads-client' } }],
+      )
+
+    adsSouth.structureFiltering = [
+      {
+        name: 'Tc2_Standard.TON',
+        fields: '*',
+      },
+    ]
+
+    adsSouth.client.readSymbol.mockReturnValueOnce(new Promise((resolve) => resolve(GVLExampleSTRUCT)))
+    await adsSouth.onScan('everySecond')
+
+    expect(adsSouth.logger.debug)
+      .toHaveBeenCalledWith('Data Structure ST_Example not parsed for data PLC_TEST.GVL_Test.ExampleSTRUCT. To parse it, please specify it in the connector settings.') // eslint-disable-line max-len
 
     adsSouth.boolAsText = 'Text'
     adsSouth.enumAsText = 'Integer'
@@ -555,9 +766,44 @@ describe('ADS south', () => {
       'ADS - Test',
       [{ pointId: 'PLC_TEST.GVL_Test.TestTimer.Q', timestamp: nowDateString, data: { value: 'false' } }],
     )
+    expect(engine.addValues)
+      .toHaveBeenCalledWith(
+        'ADS - Test',
+        [{ pointId: 'PLC_TEST.GVL_Test.TestTimer.M', timestamp: nowDateString, data: { value: 'true' } }],
+      )
     // Test enum value as integer
     expect(engine.addValues).toHaveBeenCalledWith('ADS - Test',
       [{ pointId: 'PLC_TEST.GVL_Test.TestENUM', timestamp: nowDateString, data: { value: '100' } }])
+
+    adsSouth.client.readSymbol.mockReturnValueOnce(new Promise((resolve) => resolve(GVLTestBadType)))
+    await adsSouth.onScan('every1Hour')
+    expect(adsSouth.logger.warn)
+      .toHaveBeenCalledWith('dataType BAD_TYPE not supported yet for point PLC_TEST.GVL_Test.TestBadType. Value was 1234')
+
+    // Tests other data types
+    adsSouth.client.readSymbol.mockReturnValueOnce(new Promise((resolve) => resolve(GVLTestByte)))
+      .mockReturnValueOnce(new Promise((resolve) => resolve(GVLTestWord)))
+      .mockReturnValueOnce(new Promise((resolve) => resolve(GVLTestDWord)))
+      .mockReturnValueOnce(new Promise((resolve) => resolve(GVLTestSINT)))
+      .mockReturnValueOnce(new Promise((resolve) => resolve(GVLTestUSINT)))
+      .mockReturnValueOnce(new Promise((resolve) => resolve(GVLTestUINT)))
+      .mockReturnValueOnce(new Promise((resolve) => resolve(GVLTestDINT)))
+      .mockReturnValueOnce(new Promise((resolve) => resolve(GVLTestUDINT)))
+      .mockReturnValueOnce(new Promise((resolve) => resolve(GVLTestLINT)))
+      .mockReturnValueOnce(new Promise((resolve) => resolve(GVLTestULINT)))
+      .mockReturnValueOnce(new Promise((resolve) => resolve(GVLTestTIME)))
+      .mockReturnValueOnce(new Promise((resolve) => resolve(GVLTestTimeOfDay)))
+      .mockReturnValueOnce(new Promise((resolve) => resolve(GVLTestREAL)))
+      .mockReturnValueOnce(new Promise((resolve) => resolve(GVLTestLREAL)))
+      .mockReturnValueOnce(new Promise((resolve) => resolve(GVLTestDATE)))
+      .mockReturnValueOnce(new Promise((resolve) => resolve(GVLTestDateAndTime)))
+
+    engine.addValues.mockClear()
+    await adsSouth.onScan('every3Hours')
+
+    expect(engine.addValues)
+      .toHaveBeenCalledTimes(16)
+
     global.Date = RealDate
   })
 

--- a/src/south/ADS/ADS.schema.jsx
+++ b/src/south/ADS/ADS.schema.jsx
@@ -149,6 +149,35 @@ schema.form = {
     options: ['Text', 'Integer'],
     label: 'Boolean value',
   },
+  AdsStructures: {
+    type: 'OIbTitle',
+    children: (
+      <div>
+        Only specified structures will be taken into account. To take all fields of a structure, you can use the wildcard *.
+        To take some of the fields only, specify them (case sensitive), separated by commas.
+        For example, E_ANA is the name of the structure, and the fields to take are : Mesure,a,b
+      </div>
+    ),
+  },
+  structureFiltering: {
+    type: 'OIbTable',
+    rows: {
+      name: {
+        type: 'OIbText',
+        newRow: false,
+        label: 'Name',
+        valid: notEmpty(),
+        defaultValue: '',
+      },
+      fields: {
+        type: 'OIbText',
+        newRow: false,
+        label: 'Fields',
+        valid: notEmpty(),
+        defaultValue: '',
+      },
+    },
+  },
 }
 
 schema.points = {

--- a/tests/testConfig.js
+++ b/tests/testConfig.js
@@ -271,42 +271,113 @@ const testConfig = {
           plcName: 'PLC_TEST.',
           boolAsText: 'Integer',
           enumAsText: 'Text',
+          structureFiltering: [
+            {
+              name: 'ST_Example',
+              fields: 'SomeReal,SomeDate',
+            },
+            {
+              name: 'Tc2_Standard.TON',
+              fields: '*',
+            },
+          ],
         },
         points: [
           {
             pointId: 'GVL_Test.TestENUM',
-            address: 'GVL_Test.TestENUM',
             scanMode: 'every10Seconds',
           },
           {
             pointId: 'GVL_Test.TestINT',
-            address: 'GVL_Test.TestINT',
             scanMode: 'every10Seconds',
           },
           {
             pointId: 'GVL_Test.TestSTRING',
-            address: 'GVL_Test.TestSTRING',
             scanMode: 'every10Seconds',
           },
           {
             pointId: 'GVL_Test.ExampleSTRUCT',
-            address: 'GVL_Test.ExampleSTRUCT',
             scanMode: 'everySecond',
           },
           {
             pointId: 'GVL_Test.TestARRAY',
-            address: 'GVL_Test.TestARRAY',
             scanMode: 'every10Seconds',
           },
           {
             pointId: 'GVL_Test.TestARRAY2',
-            address: 'GVL_Test.TestARRAY2',
             scanMode: 'every10Seconds',
           },
           {
             pointId: 'GVL_Test.TestTimer',
-            address: 'GVL_Test.TestTimer',
             scanMode: 'every10Seconds',
+          },
+          {
+            pointId: 'GVL_Test.TestBadType',
+            scanMode: 'every1Hour',
+          },
+          {
+            pointId: 'GVL_Test.TestByte',
+            scanMode: 'every3Hours',
+          },
+          {
+            pointId: 'GVL_Test.TestWord',
+            scanMode: 'every3Hours',
+          },
+          {
+            pointId: 'GVL_Test.TestDWord',
+            scanMode: 'every3Hours',
+          },
+          {
+            pointId: 'GVL_Test.TestSINT',
+            scanMode: 'every3Hours',
+          },
+          {
+            pointId: 'GVL_Test.TestUSINT',
+            scanMode: 'every3Hours',
+          },
+          {
+            pointId: 'GVL_Test.TestUINT',
+            scanMode: 'every3Hours',
+          },
+          {
+            pointId: 'GVL_Test.TestDINT',
+            scanMode: 'every3Hours',
+          },
+          {
+            pointId: 'GVL_Test.TestUDINT',
+            scanMode: 'every3Hours',
+          },
+          {
+            pointId: 'GVL_Test.TestLINT',
+            scanMode: 'every3Hours',
+          },
+          {
+            pointId: 'GVL_Test.TestULINT',
+            scanMode: 'every3Hours',
+          },
+          {
+            pointId: 'GVL_Test.TestTIME',
+            scanMode: 'every3Hours',
+          },
+          {
+            pointId: 'GVL_Test.TestTIME_OF_DAY',
+            scanMode: 'every3Hours',
+          },
+          {
+            pointId: 'GVL_Test.TestREAL',
+            scanMode: 'every3Hours',
+          },
+          {
+            pointId: 'GVL_Test.TestLREAL',
+            scanMode: 'every3Hours',
+          },
+          {
+            pointId: 'GVL_Test.TestDATE',
+            scanMode: 'every3Hours',
+          },
+          {
+            pointId: 'GVL_Test.TestDATE_AND_TIME',
+            scanMode: 'every3Hours',
           },
         ],
       },


### PR DESCRIPTION
This feature allows the user to specify which fields (separated by commas) of a struct data type to take into account.

The field will be added at the end of the pointId.

The "*" wildcard allows the user to select all fields of a structure. Structures not specified in the settings will be ignored, even if a point of that structure type is requested. In this case a debug message is shown in the logger.

