### PR TITLE
fix(points-filter): Fix "remove" and "edit" on filtered point list

### DIFF
--- a/src/client/South/ConfigurePoints.jsx
+++ b/src/client/South/ConfigurePoints.jsx
@@ -41,15 +41,22 @@ const ConfigurePoints = () => {
   const { points: pointsOrdered = [], protocol } = dataSource
   const points = pointsOrdered.slice().reverse()
 
+  // filter
+  const filteredPoints = filterText
+    ? points.filter(
+      (point) => Object.values(point).findIndex((element) => element
+        .toString()
+        .toLowerCase()
+        .includes(filterText.toLowerCase())) >= 0,
+    ) : points
+
   /**
-   * Get the index of point for reversed poitns list
-   * @param {number} index of point
-   * @returns {number} return reversed index
+   * @param {number} index the index of a point in the table
+   * @returns {number} the index in the config file of the chosen point
    */
-  const reversedIndex = (index) => {
-    const totalIndex = points.length - 1
-    const totalOnPage = totalIndex - (MAX_ON_PAGE * (selectedPage - 1))
-    return totalOnPage - index
+  const findIndexBasedOnPointId = (index) => {
+    const paginatedIndex = MAX_ON_PAGE * (selectedPage - 1) + index
+    return dataSource.points.findIndex((point) => point.pointId === filteredPoints[paginatedIndex].pointId)
   }
 
   /**
@@ -77,7 +84,7 @@ const ConfigurePoints = () => {
    * @returns {void}
    */
   const handleDelete = (index) => {
-    dispatchNewConfig({ type: 'deleteRow', name: `south.dataSources.${dataSourceIndex}.points.${reversedIndex(index)}` })
+    dispatchNewConfig({ type: 'deleteRow', name: `south.dataSources.${dataSourceIndex}.points.${findIndexBasedOnPointId(index)}` })
   }
 
   /**
@@ -133,7 +140,7 @@ const ConfigurePoints = () => {
   const onChange = (name, value, validity) => {
     // add pageOffet before dispatch the update to update the correct point (pagination)
     const index = Number(name.match(/[0-9]+/g))
-    const pathWithPageOffset = name.replace(/[0-9]+/g, `${reversedIndex(index)}`)
+    const pathWithPageOffset = name.replace(/[0-9]+/g, `${findIndexBasedOnPointId(index)}`)
     dispatchNewConfig({
       type: 'update',
       name: `south.dataSources.${dataSourceIndex}.${pathWithPageOffset}`,
@@ -153,14 +160,6 @@ const ConfigurePoints = () => {
   )) : null
   // configure table header and rows
   const tableHeaders = Object.entries(ProtocolSchema.points).map(([name, value]) => value.label || humanizeString(name))
-  // filter
-  const filteredPoints = filterText
-    ? points.filter(
-      (point) => Object.values(point).findIndex((element) => element
-        .toString()
-        .toLowerCase()
-        .includes(filterText.toLowerCase())) >= 0,
-    ) : points
 
   // paging
   const pagedPoints = filteredPoints.filter((_, index) => index >= pageOffset && index < selectedPage * MAX_ON_PAGE)

--- a/src/client/South/ConfigurePoints.spec.jsx
+++ b/src/client/South/ConfigurePoints.spec.jsx
@@ -16,14 +16,14 @@ React.useContext = jest.fn().mockReturnValue({ newConfig, dispatchNewConfig, set
 jest.mock('react-router-dom', () => (
   { useParams: jest.fn().mockReturnValue({ id: 'datasource-uuid-9' }) }
 ))
-
+window.URL.createObjectURL = () => { }
 // mock states
 const originalUseState = React.useState
 let filterText = ''
 const setFilterText = jest.fn()
 const setSelectedPage = jest.fn()
 const setState = jest.fn()
-React.useState = jest.fn().mockImplementation((init) => {
+const useStateMock = jest.fn().mockImplementation((init) => {
   if (init === '') {
     return [filterText, setFilterText]
   }
@@ -32,6 +32,7 @@ React.useState = jest.fn().mockImplementation((init) => {
   }
   return [init, setState]
 })
+React.useState = useStateMock
 
 // mock createCSV
 let resolve
@@ -167,15 +168,6 @@ describe('ConfigurePoints', () => {
       value: 'every1Min',
       validity: null,
     })
-    expect(container).toMatchSnapshot()
-  })
-  test('check delete first point', () => {
-    act(() => {
-      ReactDOM.render(
-        <ConfigurePoints />, container,
-      )
-    })
-    Simulate.click(document.querySelector('td path')) // click on delete icon
     expect(container).toMatchSnapshot()
   })
   test('check import points press', () => {
@@ -328,6 +320,20 @@ describe('ConfigurePoints', () => {
     expect(dispatchNewConfig).toBeCalledWith({
       type: 'deleteAllRows',
       name: 'south.dataSources.8.points',
+    })
+    expect(container).toMatchSnapshot()
+  })
+  test('check delete first point', () => {
+    act(() => {
+      ReactDOM.render(
+        <ConfigurePoints />, container,
+      )
+    })
+    Simulate.click(document.querySelector('td path')) // click on delete icon
+    Simulate.click(document.getElementsByClassName('btn btn-primary')[3])
+    expect(dispatchNewConfig).toBeCalledWith({
+      type: 'deleteRow',
+      name: 'south.dataSources.8.points.2',
     })
     expect(container).toMatchSnapshot()
   })

--- a/src/client/components/OIbForm/OIbScanMode.jsx
+++ b/src/client/components/OIbForm/OIbScanMode.jsx
@@ -27,7 +27,7 @@ const OIbScanMode = ({ label, help, valid, value, name, onChange }) => {
 
   React.useEffect(() => {
     // save error if validCheck has error message
-    onChange(name, value, validCheck)
+    if (validCheck) onChange(name, value, validCheck)
   }, [validCheck])
 
   const handleChange = (event) => {

--- a/src/south/OPCHDA/OPCHDA.schema.jsx
+++ b/src/south/OPCHDA/OPCHDA.schema.jsx
@@ -595,6 +595,7 @@ schema.points = {
   pointId: {
     type: 'OIbText',
     valid: notEmpty(),
+    unique: true,
     defaultValue: '',
   },
   scanMode: {


### PR DESCRIPTION
The `reverseIndex` is not a good approach, as the ids in the filtered list are not the same (there are fewer items) so the deletion and update will operate with a wrong id.
Solved it by using a virtual index on the frontend side which is constant even in the filtered list ensuring that the chosen point will be edited or removed.

Solves #1380