### PR TITLE
fix(deps): fix package dependency in executable bundler

### DIFF
--- a/.pkg.json
+++ b/.pkg.json
@@ -11,7 +11,7 @@
       "src/engine/LokiLoggerTransport.class.js",
       "src/engine/SqliteLoggerTransport.class.js",
       "node_modules/better-sqlite3",
-      "node_modules/better-sqlite3/build/Release/*.node",
+      "node_modules/better-sqlite3/build/Release/*",
       "node_modules/bindings",
       "node_modules/file-uri-to-path/index.js"
     ]


### PR DESCRIPTION
The better-sqlite3 package has several .node files (one per platform) and they do not all end with .node. The executable could not work on macos.