### PR TITLE
fix(logs): fix loki addLogs engine method with koa ctx

### DIFF
--- a/src/server/controllers/logController.js
+++ b/src/server/controllers/logController.js
@@ -69,6 +69,7 @@ const addLogs = async (ctx) => {
       })
     })
   }
+  ctx.ok()
 }
 
 module.exports = { getLogs, addLogs }


### PR DESCRIPTION
Logs were properly sent to the loki instance through another OIBus, but the first OIBus received errors because the ctx.ok() was not called. The error was 'hidden' in the console of the first OIBus to avoid a bad loop of logs if the logger was called.