### PR TITLE
north-fix

### DIFF
--- a/src/north/north-connector.js
+++ b/src/north/north-connector.js
@@ -1,4 +1,3 @@
-const fs = require('node:fs/promises')
 const path = require('node:path')
 
 const EncryptionService = require('../service/encryption.service')
@@ -245,21 +244,11 @@ class NorthConnector {
 
     const fileToSend = await this.fileCache.retrieveFileFromCache()
     if (!fileToSend) {
-      this.logger.trace('No file to send in the cache database.')
+      this.logger.trace('No file to send in the cache folder.')
       this.resetFilesTimeout(this.caching.sendInterval)
       return
     }
     this.logger.trace(`File to send: "${fileToSend.path}".`)
-
-    try {
-      await fs.stat(fileToSend.path)
-    } catch (error) {
-      // File in cache does not exist on filesystem
-      await this.fileCache.removeFileFromCache(fileToSend.path, false)
-      this.logger.error(`File "${fileToSend.path}" not found! The file has been removed from the cache.`)
-      this.resetFilesTimeout(this.caching.sendInterval)
-      return
-    }
 
     this.sendingFilesInProgress = true
     this.resendFilesImmediately = false

--- a/src/north/north-connector.spec.js
+++ b/src/north/north-connector.spec.js
@@ -1,4 +1,3 @@
-const fs = require('node:fs/promises')
 const NorthConnector = require('./north-connector')
 
 const { defaultConfig: config } = require('../../tests/test-config')
@@ -234,22 +233,8 @@ describe('NorthConnector', () => {
     north.resetFilesTimeout = jest.fn()
     await north.retrieveFromCacheAndSendFile()
 
-    expect(north.logger.trace).toHaveBeenCalledWith('No file to send in the cache database.')
+    expect(north.logger.trace).toHaveBeenCalledWith('No file to send in the cache folder.')
     expect(north.resetFilesTimeout).toHaveBeenCalledWith(settings.caching.sendInterval)
-  })
-
-  it('should not send files if it does not exist', async () => {
-    const fileToSend = { path: 'myFile' }
-    north.fileCache.retrieveFileFromCache = jest.fn(() => fileToSend)
-    north.fileCache.removeFileFromCache = jest.fn()
-    fs.stat = jest.fn().mockImplementationOnce(() => {
-      throw new Error('file does not exist')
-    })
-
-    await north.retrieveFromCacheAndSendFile()
-
-    expect(north.logger.error).toHaveBeenCalledWith(`File "${fileToSend.path}" not found! The file has been removed from the cache.`)
-    expect(north.fileCache.removeFileFromCache).toHaveBeenCalledWith(fileToSend.path, false)
   })
 
   it('should retry to send files if it fails', async () => {


### PR DESCRIPTION
In some cases, a file is being written by a south when the north scan its cache folder, yielding an error that was not caught.

Also, since the cache database does not exist anymore for files, the following block is not useful anymore, because  the retrieveFileFromCache method already returns the oldest file in cache.

```js
try {
      await fs.stat(fileToSend.path)
    } catch (error) {
```