### PR TITLE
fix(cache): improve perf on values query in sqlite cache

### DIFF
--- a/src/service/database.service.js
+++ b/src/service/database.service.js
@@ -108,15 +108,14 @@ const getCount = (database) => {
 const getValuesToSend = (database, count) => {
   const query = 'SELECT id, timestamp, data, point_id AS pointId, south as dataSourceId '
                 + `FROM ${CACHE_TABLE_NAME} `
-                + 'ORDER BY timestamp '
                 + `LIMIT ${count}`
-  const values = []
-  const stmt = database.prepare(query)
-  // eslint-disable-next-line no-restricted-syntax
-  for (const value of stmt.iterate()) {
-    values.push({ ...value, data: JSON.parse(decodeURI(value.data)) })
-  }
-  return values
+
+  return database.prepare(query).all().map((value) => ({
+    id: value.id,
+    timestamp: value.timestamp,
+    pointId: value.pointId,
+    data: JSON.parse(decodeURI(value.data)),
+  }))
 }
 
 /**

--- a/src/service/database.service.spec.js
+++ b/src/service/database.service.spec.js
@@ -1,8 +1,8 @@
 const databaseService = require('./database.service')
 
 const values = [
-  { timestamp: '2022-08-25T12:58:00.000Z', data: { value: 1, quality: 192 }, pointId: 'point001' },
-  { timestamp: '2022-08-25T12:59:00.000Z', data: { value: 2, quality: 192 }, pointId: 'point002' },
+  { id: 1, timestamp: '2022-08-25T12:58:00.000Z', data: { value: 1, quality: 192 }, pointId: 'point001' },
+  { id: 2, timestamp: '2022-08-25T12:59:00.000Z', data: { value: 2, quality: 192 }, pointId: 'point002' },
 ]
 
 let all
@@ -18,13 +18,14 @@ beforeEach(() => {
   jest.useFakeTimers()
 
   const retrievedValues = values.map((value) => ({
-    ...value,
+    id: value.id,
+    timestamp: value.timestamp,
+    pointId: value.pointId,
     data: encodeURI(JSON.stringify(value.data)),
   }))
-  all = jest.fn().mockReturnValue([{ path: 'myFilePath', timestamp: 123 }])
+  all = jest.fn().mockReturnValue(retrievedValues)
   get = jest.fn().mockReturnValue(retrievedValues)
   run = jest.fn()
-  iterate = jest.fn().mockReturnValue(retrievedValues)
   prepare = jest.fn()
   prepare.mockReturnValue({
     all,
@@ -122,7 +123,6 @@ describe('Database service', () => {
     expect(prepare).toHaveBeenCalledTimes(1)
     expect(prepare).toHaveBeenCalledWith('SELECT id, timestamp, data, point_id AS pointId, south as dataSourceId '
         + 'FROM cache '
-        + 'ORDER BY timestamp '
         + 'LIMIT 50')
 
     expect(valuesToSend).toEqual(values)


### PR DESCRIPTION
I've used the node-os-utils to keep track of the CPU usage. However, during the sqlite reading duration, the cpu usage did not log anything because the main thread was busy with sqlite. 

The test cache database has a size of 6Go (approximately 60 000 000 values).
Here we have the output without the fix:
```
2022-10-26T15:10:32.161Z || CPU:  11.06
2022-10-26T15:10:32.664Z || CPU:  7.96
2022-10-26T15:10:33.163Z || CPU:  12.89
2022-10-26T15:10:33.665Z || CPU:  14.16
2022-10-26T15:10:34.165Z || CPU:  8.14
2022-10-26T15:10:34.667Z || CPU:  7.59
2022-10-26T15:10:35.166Z || CPU:  6.36
2022-10-26T15:10:37.222Z || CPU:  16.58
2022-10-26T15:10:37.223Z || CPU:  19.16
retrieve: 3.747s
North Console sent 10000 values.
remove: 12.186ms
2022-10-26T15:10:40.983Z || CPU:  19.42
```

And with the fix:
```
2022-10-26T15:09:38.694Z || CPU:  8.12
2022-10-26T15:09:39.197Z || CPU:  6.37
2022-10-26T15:09:39.699Z || CPU:  7.64
2022-10-26T15:09:40.201Z || CPU:  7.64
2022-10-26T15:09:42.217Z || CPU:  15.71
2022-10-26T15:09:42.218Z || CPU:  18.02
retrieve: 18.738ms
North Console sent 10000 values.
remove: 11.992ms
2022-10-26T15:09:43.219Z || CPU:  12.06
2022-10-26T15:09:43.720Z || CPU:  10.32
2022-10-26T15:09:44.221Z || CPU:  12.83
```

I think the cpu usage take the average cpu which is overall lower with the fix since the cpu is used less in the fix case.

The retrieve time is greatly improved (from 3,7s to 19ms)

About the fix:
I've removed the `ORDER BY timestamp `clause which is not useful since we already have a FIFO logic and the cache is now separated for each North (thank to the refactor !)

I've also remove the iterate method to use the all method, [slightly better according to the documentation](https://github.com/WiseLibs/better-sqlite3/blob/master/docs/api.md#iteratebindparameters---iterator).