### PR TITLE
fix(cache): migrate values cache and file errors folder

### DIFF
--- a/src/service/cache/file-cache.service.js
+++ b/src/service/cache/file-cache.service.js
@@ -6,9 +6,10 @@ const { createFolder } = require('../utils')
 // Time between two checks of the Archive Folder
 const ARCHIVE_TIMEOUT = 3600000 // one hour
 
-const ERROR_FOLDER = 'errors'
 const ARCHIVE_FOLDER = 'archive'
+
 const FILE_FOLDER = 'files'
+const ERROR_FOLDER = 'files-errors'
 
 /**
  * Local cache implementation to group events and store them when the communication with the North is down.

--- a/src/service/cache/file-cache.service.spec.js
+++ b/src/service/cache/file-cache.service.spec.js
@@ -35,7 +35,7 @@ describe('FileCache', () => {
     expect(cache.northId).toEqual('northId')
     expect(cache.baseFolder).toEqual('myCacheFolder')
     expect(createFolder).toHaveBeenCalledWith(path.resolve('myCacheFolder', 'files'))
-    expect(createFolder).toHaveBeenCalledWith(path.resolve('myCacheFolder', 'errors'))
+    expect(createFolder).toHaveBeenCalledWith(path.resolve('myCacheFolder', 'files-errors'))
     expect(createFolder).toHaveBeenCalledWith(path.resolve('myCacheFolder', 'archive'))
 
     expect(logger.debug).toHaveBeenCalledWith('1 files in cache.')
@@ -52,7 +52,7 @@ describe('FileCache', () => {
     expect(cache.northId).toEqual('northId')
     expect(cache.baseFolder).toEqual('myCacheFolder')
     expect(createFolder).toHaveBeenCalledWith(path.resolve('myCacheFolder', 'files'))
-    expect(createFolder).toHaveBeenCalledWith(path.resolve('myCacheFolder', 'errors'))
+    expect(createFolder).toHaveBeenCalledWith(path.resolve('myCacheFolder', 'files-errors'))
     expect(createFolder).toHaveBeenCalledWith(path.resolve('myCacheFolder', 'archive'))
 
     expect(logger.debug).toHaveBeenCalledWith('No files in cache.')
@@ -82,7 +82,7 @@ describe('FileCache', () => {
     cache.retentionDuration = 0
     await cache.start()
     expect(createFolder).toHaveBeenCalledWith(path.resolve('myCacheFolder', 'files'))
-    expect(createFolder).toHaveBeenCalledWith(path.resolve('myCacheFolder', 'errors'))
+    expect(createFolder).toHaveBeenCalledWith(path.resolve('myCacheFolder', 'files-errors'))
     expect(createFolder).toHaveBeenCalledTimes(2)
 
     expect(cache.refreshArchiveFolder).not.toHaveBeenCalled()


### PR DESCRIPTION
The migration of a 8,19GB outputs 6GB of files (6000 files). My guess is that the database stores uri encoded values where the new cache store regular JSON, reducing the size of the string stored. Such a migration takes 60s approximately on Mac M1.

With many files (~6000), OIBus initialisation takes some time (5/10s on Mac) at full CPU usage because the files are parsed to count the number of values. 

