### PR TITLE
feat(proxy): use a proxy service to manage proxy in connectors

### DIFF
--- a/src/engine/base-engine.js
+++ b/src/engine/base-engine.js
@@ -25,6 +25,7 @@ import OPCHDA from '../south/south-opchda/south-opchda.js'
 import RestApi from '../south/south-rest/south-rest.js'
 
 import StatusService from '../service/status.service.js'
+import ProxyService from '../service/proxy.service.js'
 
 const northList = {
   OIAnalytics,
@@ -86,6 +87,7 @@ export default class BaseEngine {
 
     // Variable initialized in initEngineServices
     this.statusService = null
+    this.proxyService = null
     this.logger = null
   }
 
@@ -97,7 +99,7 @@ export default class BaseEngine {
   async initEngineServices(engineConfig) {
     this.oibusName = engineConfig.name
     this.defaultLogParameters = engineConfig.logParameters
-    this.proxies = engineConfig.proxies
+    this.proxyService = new ProxyService(engineConfig.proxies, this.encryptionService)
     this.statusService = new StatusService()
   }
 
@@ -152,7 +154,7 @@ export default class BaseEngine {
     try {
       const SouthConnector = this.installedSouthConnectors[configuration.type]
       if (SouthConnector) {
-        return new SouthConnector(configuration, this.addValues.bind(this), this.addFile.bind(this), logger)
+        return new SouthConnector(configuration, this.proxyService, this.addValues.bind(this), this.addFile.bind(this), logger)
       }
       this.logger.error(`South connector for "${configuration.name}" is not found: ${configuration.type}`)
     } catch (error) {
@@ -183,7 +185,7 @@ export default class BaseEngine {
     try {
       const NorthConnector = this.installedNorthConnectors[configuration.type]
       if (NorthConnector) {
-        return new NorthConnector(configuration, this.proxies, logger)
+        return new NorthConnector(configuration, this.proxyService, logger)
       }
       this.logger.error(`North connector for "${configuration.name}" is not found: ${configuration.type}`)
     } catch (error) {

--- a/src/north/north-amazon-s3/north-amazon-s3.js
+++ b/src/north/north-amazon-s3/north-amazon-s3.js
@@ -28,18 +28,18 @@ export default class NorthAmazonS3 extends NorthConnector {
    * Constructor for NorthAmazonS3
    * @constructor
    * @param {Object} configuration - The North connector configuration
-   * @param {Object[]} proxies - The list of available proxies
+   * @param {ProxyService} proxyService - The proxy service
    * @param {Object} logger - The Pino child logger to use
    * @return {void}
    */
   constructor(
     configuration,
-    proxies,
+    proxyService,
     logger,
   ) {
     super(
       configuration,
-      proxies,
+      proxyService,
       logger,
       manifest,
     )
@@ -50,26 +50,26 @@ export default class NorthAmazonS3 extends NorthConnector {
     this.folder = folder
     this.region = region
     this.authentication = authentication
-    this.proxySettings = proxy
+    this.proxyName = proxy
   }
 
   /**
    * Initialize services (logger, certificate, status data) at startup
    * @param {String} baseFolder - The base cache folder
    * @param {String} oibusName - The OIBus name
-   * @param {Object} defaultLogParameters - The default logs parameters
    * @returns {Promise<void>} - The result promise
    */
-  async start(baseFolder, oibusName, defaultLogParameters) {
-    await super.start(baseFolder, oibusName, defaultLogParameters)
+  async start(baseFolder, oibusName) {
+    await super.start(baseFolder, oibusName)
 
+    const proxyAgent = await this.proxyService.getProxy(this.proxyName)
     this.s3 = new S3Client({
       region: this.region,
       credentials: {
         accessKeyId: this.authentication.key,
         secretAccessKey: await this.encryptionService.decryptText(this.authentication.secret),
       },
-      requestHandler: this.proxyAgent ? new NodeHttpHandler({ httpAgent: this.proxyAgent }) : null,
+      requestHandler: proxyAgent ? new NodeHttpHandler({ httpAgent: proxyAgent }) : null,
     })
   }
 

--- a/src/north/north-connector.spec.js
+++ b/src/north/north-connector.spec.js
@@ -1,7 +1,5 @@
 import NorthConnector from './north-connector.js'
 
-import * as httpRequestStaticFunctions from '../service/http-request-static-functions.js'
-
 // Mock fs
 jest.mock('node:fs/promises')
 
@@ -11,7 +9,6 @@ jest.mock('../service/status.service')
 jest.mock('../service/certificate.service')
 jest.mock('../service/encryption.service', () => ({ getInstance: () => ({ decryptText: (password) => password }) }))
 jest.mock('../service/utils')
-jest.mock('../service/http-request-static-functions')
 jest.mock('../service/cache/value-cache.service')
 jest.mock('../service/cache/file-cache.service')
 jest.mock('../service/cache/archive.service')
@@ -59,7 +56,7 @@ describe('NorthConnector', () => {
         },
       },
     }
-    north = new NorthConnector(configuration, [{ name: 'proxyTest' }], logger, manifest)
+    north = new NorthConnector(configuration, {}, logger, manifest)
     await north.start('baseFolder', 'oibusName')
   })
 
@@ -114,13 +111,6 @@ describe('NorthConnector', () => {
   it('should properly cache file', () => {
     north.cacheFile('myFilePath', new Date().getTime())
     expect(north.fileCache.cacheFile).toHaveBeenCalledWith('myFilePath')
-  })
-
-  it('should get proxy', async () => {
-    httpRequestStaticFunctions.createProxyAgent.mockImplementation(() => ({ proxyAgent: 'a field' }))
-    expect(await north.getProxy()).toBeNull()
-    expect(await north.getProxy('proxyTest')).toEqual({ proxyAgent: 'a field' })
-    expect(await north.getProxy('anotherProxy')).toBeNull()
   })
 
   it('should properly check if a north is subscribed to a south', () => {

--- a/src/north/north-console/north-console.js
+++ b/src/north/north-console/north-console.js
@@ -13,18 +13,18 @@ export default class Console extends NorthConnector {
    * Constructor for Console
    * @constructor
    * @param {Object} configuration - The North connector configuration
-   * @param {Object[]} proxies - The list of available proxies
+   * @param {ProxyService} proxyService - The proxy service
    * @param {Object} logger - The Pino child logger to use
    * @return {void}
    */
   constructor(
     configuration,
-    proxies,
+    proxyService,
     logger,
   ) {
     super(
       configuration,
-      proxies,
+      proxyService,
       logger,
       manifest,
     )

--- a/src/north/north-console/north-console.spec.js
+++ b/src/north/north-console/north-console.spec.js
@@ -49,7 +49,7 @@ describe('North Console', () => {
         },
       },
     }
-    north = new Console(configuration, [], logger)
+    north = new Console(configuration, {}, logger)
     await north.start('baseFolder', 'oibusName')
   })
 

--- a/src/north/north-csv-to-http/north-csv-to-http.js
+++ b/src/north/north-csv-to-http/north-csv-to-http.js
@@ -19,18 +19,18 @@ export default class NorthCsvToHttp extends NorthConnector {
    * Constructor for NorthCsvToHttp
    * @constructor
    * @param {Object} configuration - The North connector configuration
-   * @param {Object[]} proxies - The list of available proxies
+   * @param {ProxyService} proxyService - The proxy service
    * @param {Object} logger - The Pino child logger to use
    * @return {void}
    */
   constructor(
     configuration,
-    proxies,
+    proxyService,
     logger,
   ) {
     super(
       configuration,
-      proxies,
+      proxyService,
       logger,
       manifest,
     )
@@ -57,7 +57,18 @@ export default class NorthCsvToHttp extends NorthConnector {
     this.acceptUnconvertedRows = acceptUnconvertedRows
     this.mapping = mapping || {}
     this.csvDelimiter = csvDelimiter
-    this.proxySettings = proxy
+    this.proxyName = proxy
+  }
+
+  /**
+   * Initialize services (logger, certificate, status data) at startup
+   * @param {String} baseFolder - The base cache folder
+   * @param {String} _oibusName - The OIBus name
+   * @returns {Promise<void>} - The result promise
+   */
+  async start(baseFolder, _oibusName) {
+    await super.start(baseFolder, _oibusName)
+    this.proxyAgent = await this.proxyService.getProxy(this.proxyName)
   }
 
   /**

--- a/src/north/north-csv-to-http/north-csv-to-http.spec.js
+++ b/src/north/north-csv-to-http/north-csv-to-http.spec.js
@@ -22,6 +22,7 @@ jest.mock('../../service/cache/file-cache.service')
 jest.mock('../../service/cache/archive.service')
 jest.mock('../../service/utils')
 jest.mock('../../service/http-request-static-functions')
+jest.mock('../../service/proxy.service')
 
 // Mock logger
 const logger = {
@@ -32,6 +33,8 @@ const logger = {
   trace: jest.fn(),
 }
 
+const proxyService = { getProxy: jest.fn() }
+
 let configuration = null
 let north = null
 
@@ -40,6 +43,7 @@ describe('NorthCsvToHttp', () => {
     jest.resetAllMocks()
     jest.useFakeTimers()
 
+    proxyService.getProxy.mockReturnValue(null)
     utils.isHeaderValid.mockReturnValue(true)
 
     configuration = {
@@ -85,12 +89,15 @@ describe('NorthCsvToHttp', () => {
       },
       subscribedTo: [],
     }
-    north = new CsvToHttp(configuration, [], logger)
+    north = new CsvToHttp(configuration, proxyService, logger)
   })
 
   it('should be properly initialized', async () => {
+    await north.start('baseFolder', 'oibusName')
+
     expect(north.manifest.modes.points).toBeFalsy()
     expect(north.manifest.modes.files).toBeTruthy()
+    expect(proxyService.getProxy).toHaveBeenCalledWith('')
   })
 
   it('should properly reject file if type is other than csv', async () => {

--- a/src/north/north-file-writer/north-file-writer.js
+++ b/src/north/north-file-writer/north-file-writer.js
@@ -14,18 +14,18 @@ export default class NorthFileWriter extends NorthConnector {
    * Constructor for NorthFileWriter
    * @constructor
    * @param {Object} configuration - The North connector configuration
-   * @param {Object[]} proxies - The list of available proxies
+   * @param {ProxyService} proxyService - The proxy service
    * @param {Object} logger - The Pino child logger to use
    * @return {void}
    */
   constructor(
     configuration,
-    proxies,
+    proxyService,
     logger,
   ) {
     super(
       configuration,
-      proxies,
+      proxyService,
       logger,
       manifest,
     )

--- a/src/north/north-file-writer/north-file-writer.spec.js
+++ b/src/north/north-file-writer/north-file-writer.spec.js
@@ -55,7 +55,7 @@ describe('NorthFileWriter', () => {
       },
       subscribedTo: [],
     }
-    north = new FileWriter(configuration, [], logger)
+    north = new FileWriter(configuration, {}, logger)
     await north.start('baseFolder', 'oibusName')
   })
 

--- a/src/north/north-influx-db/north-influx-db.js
+++ b/src/north/north-influx-db/north-influx-db.js
@@ -40,18 +40,18 @@ export default class NorthInfluxDB extends NorthConnector {
    * Constructor for NorthInfluxDB
    * @constructor
    * @param {Object} configuration - The North connector configuration
-   * @param {Object[]} proxies - The list of available proxies
+   * @param {ProxyService} proxyService - The proxy service
    * @param {Object} logger - The Pino child logger to use
    * @return {void}
    */
   constructor(
     configuration,
-    proxies,
+    proxyService,
     logger,
   ) {
     super(
       configuration,
-      proxies,
+      proxyService,
       logger,
       manifest,
     )

--- a/src/north/north-influx-db/north-influx-db.spec.js
+++ b/src/north/north-influx-db/north-influx-db.spec.js
@@ -71,7 +71,7 @@ describe('North InfluxDB', () => {
         },
       },
     }
-    north = new InfluxDB(configuration, [], logger)
+    north = new InfluxDB(configuration, {}, logger)
   })
 
   it('should call makeRequest and manage error', async () => {

--- a/src/north/north-mongo-db/north-mongo-db.js
+++ b/src/north/north-mongo-db/north-mongo-db.js
@@ -15,18 +15,18 @@ export default class NorthMongoDB extends NorthConnector {
    * Constructor for NorthMongoDB
    * @constructor
    * @param {Object} configuration - The North connector configuration
-   * @param {Object[]} proxies - The list of available proxies
+   * @param {ProxyService} proxyService - The proxy service
    * @param {Object} logger - The Pino child logger to use
    * @return {void}
    */
   constructor(
     configuration,
-    proxies,
+    proxyService,
     logger,
   ) {
     super(
       configuration,
-      proxies,
+      proxyService,
       logger,
       manifest,
     )

--- a/src/north/north-mongo-db/north-mongo-db.spec.js
+++ b/src/north/north-mongo-db/north-mongo-db.spec.js
@@ -72,7 +72,7 @@ describe('NorthMongoDB', () => {
         },
       },
     }
-    north = new MongoDB(configuration, [], logger)
+    north = new MongoDB(configuration, {}, logger)
   })
 
   it('should properly connect and disconnect', async () => {

--- a/src/north/north-mqtt/north-mqtt.js
+++ b/src/north/north-mqtt/north-mqtt.js
@@ -15,18 +15,18 @@ export default class NorthMQTT extends NorthConnector {
    * Constructor for NorthMQTT
    * @constructor
    * @param {Object} configuration - The North connector configuration
-   * @param {Object[]} proxies - The list of available proxies
+   * @param {ProxyService} proxyService - The proxy service
    * @param {Object} logger - The Pino child logger to use
    * @return {void}
    */
   constructor(
     configuration,
-    proxies,
+    proxyService,
     logger,
   ) {
     super(
       configuration,
-      proxies,
+      proxyService,
       logger,
       manifest,
     )

--- a/src/north/north-mqtt/north-mqtt.spec.js
+++ b/src/north/north-mqtt/north-mqtt.spec.js
@@ -67,7 +67,7 @@ describe('NorthMQTT', () => {
       },
       subscribedTo: [],
     }
-    north = new MQTT(configuration, [], logger)
+    north = new MQTT(configuration, {}, logger)
     await north.start('baseFolder', 'oibusName')
   })
 

--- a/src/north/north-oianalytics/north-oianalytics.js
+++ b/src/north/north-oianalytics/north-oianalytics.js
@@ -14,18 +14,18 @@ export default class NorthOIAnalytics extends NorthConnector {
    * Constructor for NorthOIAnalytics
    * @constructor
    * @param {Object} configuration - The North connector configuration
-   * @param {Object[]} proxies - The list of available proxies
+   * @param {ProxyService} proxyService - The proxy service
    * @param {Object} logger - The Pino child logger to use
    * @return {void}
    */
   constructor(
     configuration,
-    proxies,
+    proxyService,
     logger,
   ) {
     super(
       configuration,
-      proxies,
+      proxyService,
       logger,
       manifest,
     )
@@ -39,7 +39,18 @@ export default class NorthOIAnalytics extends NorthConnector {
     this.valuesUrl = `${host}/api/oianalytics/oibus/time-values${queryParam}`
     this.fileUrl = `${host}/api/oianalytics/value-upload/file${queryParam}`
     this.authentication = authentication
-    this.proxySettings = proxy
+    this.proxyName = proxy
+  }
+
+  /**
+   * Initialize services (logger, certificate, status data) at startup
+   * @param {String} baseFolder - The base cache folder
+   * @param {String} _oibusName - The OIBus name
+   * @returns {Promise<void>} - The result promise
+   */
+  async start(baseFolder, _oibusName) {
+    await super.start(baseFolder, _oibusName)
+    this.proxyAgent = await this.proxyService.getProxy(this.proxyName)
   }
 
   /**

--- a/src/north/north-oianalytics/north-oianalytics.spec.js
+++ b/src/north/north-oianalytics/north-oianalytics.spec.js
@@ -15,6 +15,7 @@ jest.mock('../../service/encryption.service', () => ({ getInstance: () => ({ dec
 jest.mock('../../service/cache/value-cache.service')
 jest.mock('../../service/cache/file-cache.service')
 jest.mock('../../service/cache/archive.service')
+jest.mock('../../service/proxy.service')
 jest.mock('../../service/utils')
 jest.mock('../../service/http-request-static-functions')
 
@@ -27,6 +28,8 @@ const logger = {
   trace: jest.fn(),
 }
 
+const proxyService = { getProxy: jest.fn() }
+
 const nowDateString = '2020-02-02T02:02:02.222Z'
 let configuration = null
 let north = null
@@ -35,6 +38,8 @@ describe('NorthOIAnalytics', () => {
   beforeEach(async () => {
     jest.resetAllMocks()
     jest.useFakeTimers().setSystemTime(new Date(nowDateString))
+
+    proxyService.getProxy.mockReturnValue(null)
 
     configuration = {
       id: 'northId',
@@ -60,17 +65,18 @@ describe('NorthOIAnalytics', () => {
           username: 'anyuser',
           password: 'anypass',
         },
+        proxy: '',
       },
-      proxy: '',
       subscribedTo: [],
     }
-    north = new OIAnalytics(configuration, [], logger)
+    north = new OIAnalytics(configuration, proxyService, logger)
     await north.start('baseFolder', 'oibusName')
   })
 
   it('should be properly initialized', () => {
     expect(north.manifest.modes.points).toBeTruthy()
     expect(north.manifest.modes.files).toBeTruthy()
+    expect(north.proxyService.getProxy).toHaveBeenCalledWith('')
   })
 
   it('should properly handle values', async () => {

--- a/src/north/north-oiconnect/north-oiconnect.js
+++ b/src/north/north-oiconnect/north-oiconnect.js
@@ -16,18 +16,18 @@ export default class NorthOIConnect extends NorthConnector {
    * Constructor for NorthOIConnect
    * @constructor
    * @param {Object} configuration - The North connector configuration
-   * @param {Object[]} proxies - The list of available proxies
+   * @param {ProxyService} proxyService - The proxy service
    * @param {Object} logger - The Pino child logger to use
    * @return {void}
    */
   constructor(
     configuration,
-    proxies,
+    proxyService,
     logger,
   ) {
     super(
       configuration,
-      proxies,
+      proxyService,
       logger,
       manifest,
     )
@@ -43,7 +43,7 @@ export default class NorthOIConnect extends NorthConnector {
     this.valuesEndpoint = valuesEndpoint
     this.fileEndpoint = fileEndpoint
     this.authentication = authentication
-    this.proxySettings = proxy
+    this.proxyName = proxy
 
     // Initialized at connection or init
     this.valuesUrl = null
@@ -61,6 +61,7 @@ export default class NorthOIConnect extends NorthConnector {
     const name = `${oibusName}:${this.name}`
     this.valuesUrl = `${this.host}${this.valuesEndpoint}?name=${name}`
     this.fileUrl = `${this.host}${this.fileEndpoint}?name=${name}`
+    this.proxyAgent = await this.proxyService.getProxy(this.proxyName)
   }
 
   /**

--- a/src/north/north-oiconnect/north-oiconnect.spec.js
+++ b/src/north/north-oiconnect/north-oiconnect.spec.js
@@ -3,6 +3,7 @@ import fs from 'node:fs/promises'
 import OIConnect from './north-oiconnect.js'
 
 import * as httpRequestStaticFunctions from '../../service/http-request-static-functions.js'
+
 // Mock fs
 jest.mock('node:fs/promises')
 
@@ -14,6 +15,7 @@ jest.mock('../../service/encryption.service', () => ({ getInstance: () => ({ dec
 jest.mock('../../service/cache/value-cache.service')
 jest.mock('../../service/cache/file-cache.service')
 jest.mock('../../service/cache/archive.service')
+jest.mock('../../service/proxy.service')
 jest.mock('../../service/utils')
 jest.mock('../../service/http-request-static-functions')
 
@@ -26,6 +28,8 @@ const logger = {
   trace: jest.fn(),
 }
 
+const proxyService = { getProxy: jest.fn() }
+
 const nowDateString = '2020-02-02T02:02:02.222Z'
 let configuration = null
 let north = null
@@ -34,6 +38,8 @@ describe('NorthOIConnect', () => {
   beforeEach(async () => {
     jest.resetAllMocks()
     jest.useFakeTimers().setSystemTime(new Date(nowDateString))
+
+    proxyService.getProxy.mockReturnValue(null)
 
     configuration = {
       id: 'northId',
@@ -62,13 +68,14 @@ describe('NorthOIConnect', () => {
       },
       subscribedTo: [],
     }
-    north = new OIConnect(configuration, [], logger)
+    north = new OIConnect(configuration, proxyService, logger)
     await north.start('baseFolder', 'oibusName')
   })
 
   it('should be properly initialized', () => {
     expect(north.manifest.modes.points).toBeTruthy()
     expect(north.manifest.modes.files).toBeTruthy()
+    expect(north.proxyService.getProxy).toHaveBeenCalledWith('')
   })
 
   it('should properly handle values', async () => {

--- a/src/north/north-timescale-db/north-timescale-db.js
+++ b/src/north/north-timescale-db/north-timescale-db.js
@@ -15,18 +15,18 @@ export default class NorthTimescaleDB extends NorthConnector {
    * Constructor for NorthTimescaleDB
    * @constructor
    * @param {Object} configuration - The North connector configuration
-   * @param {Object[]} proxies - The list of available proxies
+   * @param {ProxyService} proxyService - The proxy service
    * @param {Object} logger - The Pino child logger to use
    * @return {void}
    */
   constructor(
     configuration,
-    proxies,
+    proxyService,
     logger,
   ) {
     super(
       configuration,
-      proxies,
+      proxyService,
       logger,
       manifest,
     )

--- a/src/north/north-timescale-db/north-timescale-db.spec.js
+++ b/src/north/north-timescale-db/north-timescale-db.spec.js
@@ -70,7 +70,7 @@ describe('North TimescaleDB', () => {
       },
       subscribedTo: [],
     }
-    north = new TimescaleDB(configuration, [], logger)
+    north = new TimescaleDB(configuration, {}, logger)
   })
 
   it('should properly handle values and publish them', async () => {

--- a/src/north/north-watsy/north-watsy.js
+++ b/src/north/north-watsy/north-watsy.js
@@ -30,18 +30,18 @@ export default class NorthWATSY extends NorthConnector {
    * Constructor for NorthWATSY
    * @constructor
    * @param {Object} configuration - The North connector configuration
-   * @param {Object[]} proxies - The list of available proxies
+   * @param {ProxyService} proxyService - The proxy service
    * @param {Object} logger - The Pino child logger to use
    * @return {void}
    */
   constructor(
     configuration,
-    proxies,
+    proxyService,
     logger,
   ) {
     super(
       configuration,
-      proxies,
+      proxyService,
       logger,
       manifest,
     )

--- a/src/north/north-watsy/north-watsy.spec.js
+++ b/src/north/north-watsy/north-watsy.spec.js
@@ -69,7 +69,7 @@ describe('NorthWATSY', () => {
       },
       subscribedTo: [],
     }
-    north = new WATSYConnect(configuration, [], logger)
+    north = new WATSYConnect(configuration, {}, logger)
     await north.start('baseFolder', 'oibusName')
   })
 

--- a/src/service/opcua.service.js
+++ b/src/service/opcua.service.js
@@ -1,13 +1,6 @@
 import path from 'node:path'
 import fs from 'node:fs/promises'
-
-const mkdir = async (folderPath) => {
-  try {
-    await fs.stat(folderPath)
-  } catch (error) {
-    await fs.mkdir(folderPath, { recursive: true })
-  }
-}
+import { createFolder } from './utils.js'
 
 const MAX_NUMBER_OF_NODE_TO_LOG = 10
 
@@ -17,17 +10,17 @@ const MAX_NUMBER_OF_NODE_TO_LOG = 10
  */
 const initOpcuaCertificateFolders = async (certFolder) => {
   const rootFolder = `${certFolder}/opcua`
-  await mkdir(path.join(rootFolder, 'own'))
-  await mkdir(path.join(rootFolder, 'own/certs'))
-  await mkdir(path.join(rootFolder, 'own/private'))
-  await mkdir(path.join(rootFolder, 'rejected'))
-  await mkdir(path.join(rootFolder, 'trusted'))
-  await mkdir(path.join(rootFolder, 'trusted/certs'))
-  await mkdir(path.join(rootFolder, 'trusted/crl'))
+  await createFolder(path.join(rootFolder, 'own'))
+  await createFolder(path.join(rootFolder, 'own/certs'))
+  await createFolder(path.join(rootFolder, 'own/private'))
+  await createFolder(path.join(rootFolder, 'rejected'))
+  await createFolder(path.join(rootFolder, 'trusted'))
+  await createFolder(path.join(rootFolder, 'trusted/certs'))
+  await createFolder(path.join(rootFolder, 'trusted/crl'))
 
-  await mkdir(path.join(rootFolder, 'issuers'))
-  await mkdir(path.join(rootFolder, 'issuers/certs')) // contains Trusted CA certificates
-  await mkdir(path.join(rootFolder, 'issuers/crl')) // contains CRL of revoked CA certificates
+  await createFolder(path.join(rootFolder, 'issuers'))
+  await createFolder(path.join(rootFolder, 'issuers/certs')) // contains Trusted CA certificates
+  await createFolder(path.join(rootFolder, 'issuers/crl')) // contains CRL of revoked CA certificates
 
   await fs.copyFile(`${certFolder}/privateKey.pem`, `${rootFolder}/own/private/private_key.pem`)
   await fs.copyFile(`${certFolder}/cert.pem`, `${rootFolder}/own/certs/client_certificate.pem`)

--- a/src/service/opcua.service.spec.js
+++ b/src/service/opcua.service.spec.js
@@ -1,7 +1,10 @@
 import fs from 'node:fs/promises'
 import path from 'node:path'
+import { createFolder } from './utils.js'
 
 import { initOpcuaCertificateFolders } from './opcua.service.js'
+
+jest.mock('./utils')
 
 describe('opcua service', () => {
   it('should copy certificates', async () => {
@@ -10,9 +13,8 @@ describe('opcua service', () => {
     })
     jest.spyOn(path, 'join').mockImplementationOnce(() => 'stubFolder')
     fs.copyFile = jest.fn()
-    fs.mkdir = jest.fn()
 
     await initOpcuaCertificateFolders('certFolder')
-    expect(fs.mkdir).toHaveBeenCalledTimes(10)
+    expect(createFolder).toHaveBeenCalledTimes(10)
   })
 })

--- a/src/service/proxy.service.js
+++ b/src/service/proxy.service.js
@@ -1,0 +1,36 @@
+import { createProxyAgent } from './http-request-static-functions.js'
+
+/**
+ * This service manage proxies for use in north or south connectors
+ */
+export default class ProxyService {
+  /**
+   * Constructor for ProxyService class
+   * @param {Object[]} proxies - The proxy list
+   * @param {EncryptionService} encryptionService - The encryption service
+   * @return {void}
+   */
+  constructor(proxies, encryptionService) {
+    this.proxies = proxies
+    this.encryptionService = encryptionService
+  }
+
+  /**
+   * Get proxy by name
+   * @param {String} proxyName - The name of the proxy
+   * @return {Promise<Object>} - The proxy
+   */
+  async getProxy(proxyName) {
+    const foundProxy = this.proxies.find(({ name }) => name === proxyName)
+    if (foundProxy) {
+      return createProxyAgent(
+        foundProxy.protocol,
+        foundProxy.host,
+        foundProxy.port,
+        foundProxy.username,
+        await this.encryptionService.decryptText(foundProxy.password || ''),
+      )
+    }
+    return null
+  }
+}

--- a/src/service/proxy.service.spec.js
+++ b/src/service/proxy.service.spec.js
@@ -1,0 +1,38 @@
+import EncryptionService from './encryption.service.js'
+import ProxyService from './proxy.service.js'
+import * as httpRequestStaticFunctions from './http-request-static-functions.js'
+
+const proxies = [
+  {
+    name: 'proxy1',
+    protocol: 'http',
+    host: 'localhost',
+    port: 8080,
+    username: 'user',
+    password: 'pass1',
+  },
+  {
+    name: 'proxy2',
+    protocol: 'https',
+    host: 'localhost',
+    port: 8080,
+    username: 'user',
+    password: 'pass2',
+  },
+]
+jest.mock('./http-request-static-functions')
+jest.mock('./encryption.service', () => ({ getInstance: () => ({ decryptText: jest.fn((password) => password) }) }))
+
+describe('proxy service', () => {
+  it('should get correct proxy agent', async () => {
+    httpRequestStaticFunctions.createProxyAgent.mockImplementation(() => ({ proxyAgent: 'a field' }))
+    const encryptionService = EncryptionService.getInstance()
+    const proxyService = new ProxyService(proxies, encryptionService)
+
+    expect(await proxyService.getProxy('proxy0')).toBeNull()
+    expect(encryptionService.decryptText).not.toHaveBeenCalled()
+
+    expect(await proxyService.getProxy('proxy1')).toEqual({ proxyAgent: 'a field' })
+    expect(encryptionService.decryptText).toHaveBeenCalledWith('pass1')
+  })
+})

--- a/src/south/south-ads/south-ads.js
+++ b/src/south/south-ads/south-ads.js
@@ -13,6 +13,7 @@ export default class SouthADS extends SouthConnector {
    * Constructor for SouthADS
    * @constructor
    * @param {Object} configuration - The South connector configuration
+   * @param {ProxyService} proxyService - The proxy service
    * @param {Function} engineAddValuesCallback - The Engine add values callback
    * @param {Function} engineAddFilesCallback - The Engine add file callback
    * @param {Object} logger - The Pino child logger to use
@@ -20,12 +21,14 @@ export default class SouthADS extends SouthConnector {
    */
   constructor(
     configuration,
+    proxyService,
     engineAddValuesCallback,
     engineAddFilesCallback,
     logger,
   ) {
     super(
       configuration,
+      proxyService,
       engineAddValuesCallback,
       engineAddFilesCallback,
       logger,

--- a/src/south/south-ads/south-ads.spec.js
+++ b/src/south/south-ads/south-ads.spec.js
@@ -782,7 +782,7 @@ describe('South ADS', () => {
         },
       ],
     }
-    south = new ADS(configuration, addValues, addFiles, logger)
+    south = new ADS(configuration, {}, addValues, addFiles, logger)
     await south.start('baseFolder', 'oibusName')
   })
 

--- a/src/south/south-connector.js
+++ b/src/south/south-connector.js
@@ -34,6 +34,7 @@ export default class SouthConnector {
    * Constructor for SouthConnector
    * @constructor
    * @param {Object} configuration - The South connector configuration
+   * @param {ProxyService} proxyService - The proxy service
    * @param {Function} engineAddValuesCallback - The Engine add values callback
    * @param {Function} engineAddFilesCallback - The Engine add file callback
    * @param {Object} logger - The Pino child logger to use
@@ -42,6 +43,7 @@ export default class SouthConnector {
    */
   constructor(
     configuration,
+    proxyService,
     engineAddValuesCallback,
     engineAddFilesCallback,
     logger,
@@ -62,6 +64,7 @@ export default class SouthConnector {
     this.scanGroups = configuration.settings.scanGroups
 
     this.encryptionService = EncryptionService.getInstance()
+    this.proxyService = proxyService
     this.logger = logger
 
     this.numberOfRetrievedFiles = 0

--- a/src/south/south-connector.spec.js
+++ b/src/south/south-connector.spec.js
@@ -51,7 +51,7 @@ describe('SouthConnector', () => {
     jest.useFakeTimers().setSystemTime(new Date(nowDateString))
 
     configuration = { id: 'id', name: 'south', type: 'test', settings: {} }
-    south = new SouthConnector(configuration, addValues, addFiles, logger, manifest)
+    south = new SouthConnector(configuration, {}, addValues, addFiles, logger, manifest)
     await south.start('baseFolder', 'oibusName')
   })
 

--- a/src/south/south-folder-scanner/south-folder-scanner.js
+++ b/src/south/south-folder-scanner/south-folder-scanner.js
@@ -15,6 +15,7 @@ export default class SouthFolderScanner extends SouthConnector {
    * Constructor for SouthFolderScanner
    * @constructor
    * @param {Object} configuration - The South connector configuration
+   * @param {ProxyService} proxyService - The proxy service
    * @param {Function} engineAddValuesCallback - The Engine add values callback
    * @param {Function} engineAddFilesCallback - The Engine add file callback
    * @param {Object} logger - The Pino child logger to use
@@ -22,12 +23,14 @@ export default class SouthFolderScanner extends SouthConnector {
    */
   constructor(
     configuration,
+    proxyService,
     engineAddValuesCallback,
     engineAddFilesCallback,
     logger,
   ) {
     super(
       configuration,
+      proxyService,
       engineAddValuesCallback,
       engineAddFilesCallback,
       logger,

--- a/src/south/south-folder-scanner/south-folder-scanner.spec.js
+++ b/src/south/south-folder-scanner/south-folder-scanner.spec.js
@@ -56,7 +56,7 @@ describe('SouthFolderScanner', () => {
       points: [],
       scanMode: 'every10Second',
     }
-    south = new FolderScanner(configuration, addValues, addFiles, logger)
+    south = new FolderScanner(configuration, {}, addValues, addFiles, logger)
     await south.start('baseFolder', 'oibusName')
     databaseService.getConfig.mockClear()
   })

--- a/src/south/south-modbus/south-modbus.js
+++ b/src/south/south-modbus/south-modbus.js
@@ -16,6 +16,7 @@ export default class SouthModbus extends SouthConnector {
    * Constructor for SouthModbus
    * @constructor
    * @param {Object} configuration - The South connector configuration
+   * @param {ProxyService} proxyService - The proxy service
    * @param {Function} engineAddValuesCallback - The Engine add values callback
    * @param {Function} engineAddFilesCallback - The Engine add file callback
    * @param {Object} logger - The Pino child logger to use
@@ -23,12 +24,14 @@ export default class SouthModbus extends SouthConnector {
    */
   constructor(
     configuration,
+    proxyService,
     engineAddValuesCallback,
     engineAddFilesCallback,
     logger,
   ) {
     super(
       configuration,
+      proxyService,
       engineAddValuesCallback,
       engineAddFilesCallback,
       logger,

--- a/src/south/south-modbus/south-modbus.spec.js
+++ b/src/south/south-modbus/south-modbus.spec.js
@@ -116,7 +116,7 @@ describe('SouthModbus', () => {
         },
       ],
     }
-    south = new Modbus(configuration, addValues, addFiles, logger)
+    south = new Modbus(configuration, {}, addValues, addFiles, logger)
     await south.start('baseFolder', 'oibusName')
   })
 

--- a/src/south/south-mqtt/south-mqtt.js
+++ b/src/south/south-mqtt/south-mqtt.js
@@ -15,6 +15,7 @@ export default class SouthMQTT extends SouthConnector {
    * Constructor for SouthMQTT
    * @constructor
    * @param {Object} configuration - The South connector configuration
+   * @param {ProxyService} proxyService - The proxy service
    * @param {Function} engineAddValuesCallback - The Engine add values callback
    * @param {Function} engineAddFilesCallback - The Engine add file callback
    * @param {Object} logger - The Pino child logger to use
@@ -22,12 +23,14 @@ export default class SouthMQTT extends SouthConnector {
    */
   constructor(
     configuration,
+    proxyService,
     engineAddValuesCallback,
     engineAddFilesCallback,
     logger,
   ) {
     super(
       configuration,
+      proxyService,
       engineAddValuesCallback,
       engineAddFilesCallback,
       logger,
@@ -86,11 +89,10 @@ export default class SouthMQTT extends SouthConnector {
    * Initialize services (logger, certificate, status data) at startup
    * @param {String} baseFolder - The base cache folder
    * @param {String} oibusName - The OIBus name
-   * @param {Object} defaultLogParameters - The default logs parameters
    * @returns {Promise<void>} - The result promise
    */
-  async start(baseFolder, oibusName, defaultLogParameters) {
-    await super.start(baseFolder, oibusName, defaultLogParameters)
+  async start(baseFolder, oibusName) {
+    await super.start(baseFolder, oibusName)
     this.clientId = `${oibusName}-${this.id}`
 
     if (!this.timezone || !DateTime.local().setZone(this.timezone).isValid) {

--- a/src/south/south-mqtt/south-mqtt.spec.js
+++ b/src/south/south-mqtt/south-mqtt.spec.js
@@ -88,7 +88,7 @@ describe('SouthMQTT', () => {
         },
       ],
     }
-    south = new MQTT(configuration, addValues, addFiles, logger)
+    south = new MQTT(configuration, {}, addValues, addFiles, logger)
     await south.start('baseFolder', 'oibusName')
   })
 
@@ -114,7 +114,7 @@ describe('SouthMQTT', () => {
         timestampTimezone: 'invalid',
       },
     }
-    const mqttInvalidSouth = new MQTT(testMqttConfig, addValues, addFiles, logger)
+    const mqttInvalidSouth = new MQTT(testMqttConfig, {}, addValues, addFiles, logger)
     await mqttInvalidSouth.start('baseFolder', 'oibusName')
 
     expect(mqttInvalidSouth.url).toEqual(testMqttConfig.settings.url)
@@ -197,7 +197,7 @@ describe('SouthMQTT', () => {
       },
     }
 
-    const mqttSouthWithFiles = new MQTT(testMqttConfigWithFiles, addValues, addFiles, logger)
+    const mqttSouthWithFiles = new MQTT(testMqttConfigWithFiles, {}, addValues, addFiles, logger)
     await mqttSouthWithFiles.start('baseFolder', 'oibusName')
     mqttSouthWithFiles.certificate = CertificateService
     await mqttSouthWithFiles.connect()

--- a/src/south/south-opchda/south-opchda.js
+++ b/src/south/south-opchda/south-opchda.js
@@ -20,6 +20,7 @@ export default class SouthOPCHDA extends SouthConnector {
    * Constructor for SouthOPCHDA
    * @constructor
    * @param {Object} configuration - The South connector configuration
+   * @param {ProxyService} proxyService - The proxy service
    * @param {Function} engineAddValuesCallback - The Engine add values callback
    * @param {Function} engineAddFilesCallback - The Engine add file callback
    * @param {Object} logger - The Pino child logger to use
@@ -27,12 +28,14 @@ export default class SouthOPCHDA extends SouthConnector {
    */
   constructor(
     configuration,
+    proxyService,
     engineAddValuesCallback,
     engineAddFilesCallback,
     logger,
   ) {
     super(
       configuration,
+      proxyService,
       engineAddValuesCallback,
       engineAddFilesCallback,
       logger,

--- a/src/south/south-opchda/south-opchda.spec.js
+++ b/src/south/south-opchda/south-opchda.spec.js
@@ -91,7 +91,7 @@ describe('South OPCHDA', () => {
         scanMode: 'every10Second',
       }],
     }
-    south = new OPCHDA(configuration, addValues, addFiles, logger)
+    south = new OPCHDA(configuration, {}, addValues, addFiles, logger)
     await south.start('baseFolder', 'oibusName')
   })
 

--- a/src/south/south-opcua-da/south-opcua-da.js
+++ b/src/south/south-opcua-da/south-opcua-da.js
@@ -20,6 +20,7 @@ export default class SouthOPCUADA extends SouthConnector {
    * Constructor for SouthOPCUADA
    * @constructor
    * @param {Object} configuration - The South connector configuration
+   * @param {ProxyService} proxyService - The proxy service
    * @param {Function} engineAddValuesCallback - The Engine add values callback
    * @param {Function} engineAddFilesCallback - The Engine add file callback
    * @param {Object} logger - The Pino child logger to use
@@ -27,12 +28,14 @@ export default class SouthOPCUADA extends SouthConnector {
    */
   constructor(
     configuration,
+    proxyService,
     engineAddValuesCallback,
     engineAddFilesCallback,
     logger,
   ) {
     super(
       configuration,
+      proxyService,
       engineAddValuesCallback,
       engineAddFilesCallback,
       logger,
@@ -82,11 +85,10 @@ export default class SouthOPCUADA extends SouthConnector {
    * Initialize services (logger, certificate, status data) at startup
    * @param {String} baseFolder - The base cache folder
    * @param {String} oibusName - The OIBus name
-   * @param {Object} defaultLogParameters - The default logs parameters
    * @returns {Promise<void>} - The result promise
    */
-  async start(baseFolder, oibusName, defaultLogParameters) {
-    await super.start(baseFolder, oibusName, defaultLogParameters)
+  async start(baseFolder, oibusName) {
+    await super.start(baseFolder, oibusName)
     this.clientName = this.id
 
     await initOpcuaCertificateFolders(this.encryptionService.certsFolder)

--- a/src/south/south-opcua-da/south-opcua-da.spec.js
+++ b/src/south/south-opcua-da/south-opcua-da.spec.js
@@ -69,7 +69,7 @@ describe('SouthOPCUADA', () => {
         scanMode: 'every10Second',
       }],
     }
-    south = new OPCUA_DA(configuration, addValues, addFiles, logger)
+    south = new OPCUA_DA(configuration, {}, addValues, addFiles, logger)
     await south.start('baseFolder', 'oibusName')
   })
 
@@ -194,7 +194,7 @@ describe('SouthOPCUADA', () => {
       }],
     }
 
-    const opcuaSouthTest = new OPCUA_DA(testOpcuaConfig, addValues, addFiles, logger)
+    const opcuaSouthTest = new OPCUA_DA(testOpcuaConfig, {}, addValues, addFiles, logger)
     await opcuaSouthTest.start('baseFolder', 'oibusName')
     await opcuaSouthTest.connect()
     opcuaSouthTest.connected = true

--- a/src/south/south-opcua-ha/south-opcua-ha.js
+++ b/src/south/south-opcua-ha/south-opcua-ha.js
@@ -26,6 +26,7 @@ export default class SouthOPCUAHA extends SouthConnector {
    * Constructor for SouthOPCUAHA
    * @constructor
    * @param {Object} configuration - The South connector configuration
+   * @param {ProxyService} proxyService - The proxy service
    * @param {Function} engineAddValuesCallback - The Engine add values callback
    * @param {Function} engineAddFilesCallback - The Engine add file callback
    * @param {Object} logger - The Pino child logger to use
@@ -33,12 +34,14 @@ export default class SouthOPCUAHA extends SouthConnector {
    */
   constructor(
     configuration,
+    proxyService,
     engineAddValuesCallback,
     engineAddFilesCallback,
     logger,
   ) {
     super(
       configuration,
+      proxyService,
       engineAddValuesCallback,
       engineAddFilesCallback,
       logger,

--- a/src/south/south-opcua-ha/south-opcua-ha.spec.js
+++ b/src/south/south-opcua-ha/south-opcua-ha.spec.js
@@ -91,7 +91,7 @@ describe('SouthOPCUAHA', () => {
         scanMode: 'every10Second',
       }],
     }
-    south = new OPCUA_HA(configuration, addValues, addFiles, logger)
+    south = new OPCUA_HA(configuration, {}, addValues, addFiles, logger)
   })
 
   it('should be properly initialized', async () => {

--- a/src/south/south-rest/south-rest.js
+++ b/src/south/south-rest/south-rest.js
@@ -21,6 +21,7 @@ export default class SouthRest extends SouthConnector {
    * Constructor for SouthRest
    * @constructor
    * @param {Object} configuration - The South connector configuration
+   * @param {ProxyService} proxyService - The proxy service
    * @param {Function} engineAddValuesCallback - The Engine add values callback
    * @param {Function} engineAddFilesCallback - The Engine add file callback
    * @param {Object} logger - The Pino child logger to use
@@ -28,12 +29,14 @@ export default class SouthRest extends SouthConnector {
    */
   constructor(
     configuration,
+    proxyService,
     engineAddValuesCallback,
     engineAddFilesCallback,
     logger,
   ) {
     super(
       configuration,
+      proxyService,
       engineAddValuesCallback,
       engineAddFilesCallback,
       logger,

--- a/src/south/south-rest/south-rest.spec.js
+++ b/src/south/south-rest/south-rest.spec.js
@@ -111,7 +111,7 @@ describe('SouthRest', () => {
       },
       scanMode: 'every10Seconds',
     }
-    south = new RestApi(configuration, addValues, addFiles, logger)
+    south = new RestApi(configuration, {}, addValues, addFiles, logger)
   })
 
   it('should create RestApi connector and connect', async () => {

--- a/src/south/south-sql/south-sql.js
+++ b/src/south/south-sql/south-sql.js
@@ -30,6 +30,7 @@ export default class SouthSQL extends SouthConnector {
    * Constructor for SouthSQL
    * @constructor
    * @param {Object} configuration - The South connector configuration
+   * @param {ProxyService} proxyService - The proxy service
    * @param {Function} engineAddValuesCallback - The Engine add values callback
    * @param {Function} engineAddFilesCallback - The Engine add file callback
    * @param {Object} logger - The Pino child logger to use
@@ -37,12 +38,14 @@ export default class SouthSQL extends SouthConnector {
    */
   constructor(
     configuration,
+    proxyService,
     engineAddValuesCallback,
     engineAddFilesCallback,
     logger,
   ) {
     super(
       configuration,
+      proxyService,
       engineAddValuesCallback,
       engineAddFilesCallback,
       logger,
@@ -98,11 +101,10 @@ export default class SouthSQL extends SouthConnector {
    * Initialize services (logger, certificate, status data) at startup
    * @param {String} baseFolder - The base cache folder
    * @param {String} oibusName - The OIBus name
-   * @param {Object} defaultLogParameters - The default logs parameters
    * @returns {Promise<void>} - The result promise
    */
-  async start(baseFolder, oibusName, defaultLogParameters) {
-    await super.start(baseFolder, oibusName, defaultLogParameters)
+  async start(baseFolder, oibusName) {
+    await super.start(baseFolder, oibusName)
     try {
       // eslint-disable-next-line global-require,import/no-unresolved,import/no-extraneous-dependencies
       oracledb = require('oracledb')

--- a/src/south/south-sql/south-sql.spec.js
+++ b/src/south/south-sql/south-sql.spec.js
@@ -100,7 +100,7 @@ describe('SouthSQL', () => {
       scanMode: 'every10Second',
       points: [],
     }
-    south = new SQL(settings, addValues, addFiles, logger)
+    south = new SQL(settings, {}, addValues, addFiles, logger)
   })
 
   it('should properly connect and set lastCompletedAt from database', async () => {
@@ -129,7 +129,7 @@ describe('SouthSQL', () => {
 
     const tempConfig = { ...settings }
     tempConfig.startTime = '2020-02-02 02:02:02'
-    const tempSqlSouth = new SQL(tempConfig, addValues, addFiles, logger)
+    const tempSqlSouth = new SQL(tempConfig, {}, addValues, addFiles, logger)
     await tempSqlSouth.start('baseFolder', 'oibusName')
     await tempSqlSouth.connect()
 
@@ -145,7 +145,7 @@ describe('SouthSQL', () => {
         databasePath: undefined,
       },
     }
-    const badSqlSouth = new SQL(badConfig, addValues, addFiles, logger)
+    const badSqlSouth = new SQL(badConfig, {}, addValues, addFiles, logger)
     await badSqlSouth.start('baseFolder', 'oibusName')
 
     expect(badSqlSouth.logger.error).toHaveBeenCalledWith('Invalid timezone supplied: "undefined".')

--- a/src/south/south-sql/south-sql.test.js
+++ b/src/south/south-sql/south-sql.test.js
@@ -55,7 +55,7 @@ describe('MySQL Integration test', () => {
   })
 
   it('should retrieve some values in the MySQL database', async () => {
-    const south = new SQL(configuration, addValues, addFiles, logger)
+    const south = new SQL(configuration, {}, addValues, addFiles, logger)
 
     await south.start('baseFolder', 'oibusName')
     await south.connect()
@@ -105,7 +105,7 @@ describe('PostgreSQL Integration test', () => {
   })
 
   it('should retrieve some values in the PostgreSQL database', async () => {
-    const south = new SQL(configuration, addValues, addFiles, logger)
+    const south = new SQL(configuration, {}, addValues, addFiles, logger)
 
     await south.start('baseFolder', 'oibusName')
     await south.connect()
@@ -161,7 +161,7 @@ describe('MSSQL Integration test', () => {
   })
 
   it('should retrieve some values in the MSSQL database', async () => {
-    const south = new SQL(configuration, addValues, addFiles, logger)
+    const south = new SQL(configuration, {}, addValues, addFiles, logger)
 
     await south.start('baseFolder', 'oibusName')
     await south.connect()


### PR DESCRIPTION
Fix issue #2065 

Proxy service is now available from south connector too, since it can be used for retrieving data from REST API.