### PR TITLE
feat(cache): add a max size limit

### DIFF
--- a/src/frontend/north/__snapshots__/configure-north.spec.jsx.snap
+++ b/src/frontend/north/__snapshots__/configure-north.spec.jsx.snap
@@ -248,6 +248,9 @@ exports[`ConfigureNorth check ConfigureNorth 1`] = `
               </p>
               <ul>
                 <li>
+                  Max Size: The maximum size (in MBytes) this connector cache can reach before discarding any new values or files from South connectors.
+                </li>
+                <li>
                   sendInterval: the cache will try to group a maximum of values in a buffer and to send them in a single transaction. However, if the sendInterval (in ms) is reached, the transaction will be sent even if the buffer is not full.
                 </li>
                 <li>
@@ -261,6 +264,42 @@ exports[`ConfigureNorth check ConfigureNorth 1`] = `
                 </li>
               </ul>
             </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="row"
+      >
+        <div
+          class="col-md-3"
+        >
+          <div
+            class="mb-3"
+          >
+            <label
+              class="form-label"
+              for="north.0.caching.maxSize"
+            >
+              Max cache size (in MB)
+            </label>
+            <input
+              aria-invalid="false"
+              class="oi-form-input form-control"
+              id="north.0.caching.maxSize"
+              name="north.0.caching.maxSize"
+              type="integer"
+              value=""
+            />
+            <div
+              class="invalid-feedback"
+            />
+            <small
+              class="form-text text-muted"
+            >
+              <div>
+                Size for this North connector only. Set to 0 for no limit
+              </div>
+            </small>
           </div>
         </div>
       </div>
@@ -895,6 +934,9 @@ exports[`ConfigureNorth check update 1`] = `
               </p>
               <ul>
                 <li>
+                  Max Size: The maximum size (in MBytes) this connector cache can reach before discarding any new values or files from South connectors.
+                </li>
+                <li>
                   sendInterval: the cache will try to group a maximum of values in a buffer and to send them in a single transaction. However, if the sendInterval (in ms) is reached, the transaction will be sent even if the buffer is not full.
                 </li>
                 <li>
@@ -908,6 +950,42 @@ exports[`ConfigureNorth check update 1`] = `
                 </li>
               </ul>
             </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="row"
+      >
+        <div
+          class="col-md-3"
+        >
+          <div
+            class="mb-3"
+          >
+            <label
+              class="form-label"
+              for="north.0.caching.maxSize"
+            >
+              Max cache size (in MB)
+            </label>
+            <input
+              aria-invalid="false"
+              class="oi-form-input form-control"
+              id="north.0.caching.maxSize"
+              name="north.0.caching.maxSize"
+              type="integer"
+              value=""
+            />
+            <div
+              class="invalid-feedback"
+            />
+            <small
+              class="form-text text-muted"
+            >
+              <div>
+                Size for this North connector only. Set to 0 for no limit
+              </div>
+            </small>
           </div>
         </div>
       </div>

--- a/src/frontend/north/form/__snapshots__/north-form.spec.jsx.snap
+++ b/src/frontend/north/form/__snapshots__/north-form.spec.jsx.snap
@@ -248,6 +248,9 @@ exports[`NorthForm check NorthForm with North connector: TestConsole 1`] = `
               </p>
               <ul>
                 <li>
+                  Max Size: The maximum size (in MBytes) this connector cache can reach before discarding any new values or files from South connectors.
+                </li>
+                <li>
                   sendInterval: the cache will try to group a maximum of values in a buffer and to send them in a single transaction. However, if the sendInterval (in ms) is reached, the transaction will be sent even if the buffer is not full.
                 </li>
                 <li>
@@ -261,6 +264,42 @@ exports[`NorthForm check NorthForm with North connector: TestConsole 1`] = `
                 </li>
               </ul>
             </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="row"
+      >
+        <div
+          class="col-md-3"
+        >
+          <div
+            class="mb-3"
+          >
+            <label
+              class="form-label"
+              for="north.0.caching.maxSize"
+            >
+              Max cache size (in MB)
+            </label>
+            <input
+              aria-invalid="false"
+              class="oi-form-input form-control"
+              id="north.0.caching.maxSize"
+              name="north.0.caching.maxSize"
+              type="integer"
+              value=""
+            />
+            <div
+              class="invalid-feedback"
+            />
+            <small
+              class="form-text text-muted"
+            >
+              <div>
+                Size for this North connector only. Set to 0 for no limit
+              </div>
+            </small>
           </div>
         </div>
       </div>
@@ -836,6 +875,9 @@ exports[`NorthForm check NorthForm with empty North connector 1`] = `
               </p>
               <ul>
                 <li>
+                  Max Size: The maximum size (in MBytes) this connector cache can reach before discarding any new values or files from South connectors.
+                </li>
+                <li>
                   sendInterval: the cache will try to group a maximum of values in a buffer and to send them in a single transaction. However, if the sendInterval (in ms) is reached, the transaction will be sent even if the buffer is not full.
                 </li>
                 <li>
@@ -849,6 +891,42 @@ exports[`NorthForm check NorthForm with empty North connector 1`] = `
                 </li>
               </ul>
             </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="row"
+      >
+        <div
+          class="col-md-3"
+        >
+          <div
+            class="mb-3"
+          >
+            <label
+              class="form-label"
+              for="north.0.caching.maxSize"
+            >
+              Max cache size (in MB)
+            </label>
+            <input
+              aria-invalid="false"
+              class="oi-form-input form-control"
+              id="north.0.caching.maxSize"
+              name="north.0.caching.maxSize"
+              type="integer"
+              value=""
+            />
+            <div
+              class="invalid-feedback"
+            />
+            <small
+              class="form-text text-muted"
+            >
+              <div>
+                Size for this North connector only. Set to 0 for no limit
+              </div>
+            </small>
           </div>
         </div>
       </div>

--- a/src/frontend/north/form/north-form.jsx
+++ b/src/frontend/north/form/north-form.jsx
@@ -112,6 +112,10 @@ const NorthForm = ({ north, northIndex, onChange }) => {
               </p>
               <ul>
                 <li>
+                  Max Size: The maximum size (in MBytes) this connector cache can reach before discarding any new values or files from
+                  South connectors.
+                </li>
+                <li>
                   sendInterval: the cache will try to group a maximum of values
                   in a buffer and to send them in a single transaction. However,
                   if the sendInterval (in ms) is reached, the transaction will
@@ -138,6 +142,19 @@ const NorthForm = ({ north, northIndex, onChange }) => {
               </ul>
             </>
           </OibTitle>
+          <Row>
+            <Col md="3">
+              <OibInteger
+                onChange={onChange}
+                value={north.caching.maxSize}
+                defaultValue={0}
+                valid={validation.caching.maxSize}
+                name={`${prefix}.caching.maxSize`}
+                label="Max cache size (in MB)"
+                help={<div>Size for this North connector only. Set to 0 for no limit</div>}
+              />
+            </Col>
+          </Row>
           <Row>
             <Col md="3">
               <OibInteger

--- a/src/frontend/north/form/north.validation.js
+++ b/src/frontend/north/form/north.validation.js
@@ -2,6 +2,7 @@ const validation = {
   caching: {
     sendInterval: (val) => (val >= 1000 ? null : 'Send interval should be greater or equal to 1000'),
     retryInterval: (val) => (val >= 1000 ? null : 'Retry interval should be greater or equal to 1000'),
+    maxSize: (val) => (val >= 0 ? null : 'Max size should be greater or equal to 0'),
     retryCount: (val) => (val >= 0 ? null : 'Retry count should be greater or equal to 0'),
     groupCount: (val) => (val > 0 ? null : 'Group count should be greater than 0'),
     maxSendCount: (val) => (val > 0 ? null : 'Max group count should be greater than 0'),

--- a/src/migration/migration-rules.js
+++ b/src/migration/migration-rules.js
@@ -1781,10 +1781,16 @@ export default {
   31: async (config, logger) => {
     for (const south of config.south) {
       if (south.type === 'SQL') {
-        logger.info(`Add ODBC settingsSouth connector ${south.name} (${south.id}).`)
+        logger.info(`Add ODBC settings to South connector ${south.name} (${south.id}).`)
         south.settings.selfSigned = false
         south.settings.odbcDriverPath = ''
       }
+    }
+  },
+  32: async (config, logger) => {
+    for (const north of config.north) {
+      logger.info(`Add caching max size settings to North connector ${north.name} (${north.id}).`)
+      north.caching.maxSize = 0
     }
   },
 }

--- a/src/migration/migration.service.js
+++ b/src/migration/migration.service.js
@@ -3,7 +3,7 @@ import path from 'node:path'
 
 import migrationRules from './migration-rules.js'
 
-const REQUIRED_SCHEMA_VERSION = 31
+const REQUIRED_SCHEMA_VERSION = 32
 const DEFAULT_VERSION = 1
 
 /**

--- a/src/service/cache/value-cache.service.spec.js
+++ b/src/service/cache/value-cache.service.spec.js
@@ -5,7 +5,7 @@ import nanoid from 'nanoid'
 
 import ValueCache from './value-cache.service.js'
 
-import { createFolder } from '../utils.js'
+import { createFolder, dirSize } from '../utils.js'
 
 jest.mock('node:fs/promises')
 jest.mock('../utils')
@@ -31,7 +31,8 @@ describe('ValueCache', () => {
   beforeEach(async () => {
     jest.resetAllMocks()
     jest.useFakeTimers().setSystemTime(new Date(nowDateString))
-    settings = { sendInterval: 1000, groupCount: 1000, maxSendCount: 10000, retryCount: 3, retryInterval: 5000 }
+    dirSize.mockReturnValue(5)
+    settings = { sendInterval: 1000, groupCount: 1000, maxSendCount: 10000, retryCount: 3, retryInterval: 5000, maxSize: 10 }
     cache = new ValueCache(
       'northId',
       logger,
@@ -510,7 +511,7 @@ describe('ValueCache', () => {
   it('should retry to send values if it fails', async () => {
     const valuesToSend = [{ key: '1.queue.tmp', values: [{ value: 'myFirstValue' }, { value: 'mySecondValue' }] },
       { key: '2.queue.tmp', values: [{ value: 'myThirdValue' }] }]
-    cache.getValuesToSend = jest.fn().mockImplementationOnce(() => valuesToSend).mockImplementationOnce(() => [])
+    cache.getValuesToSend = jest.fn(() => valuesToSend)
     cache.manageErroredValues = jest.fn()
     cache.northSendValuesCallback = jest.fn()
       .mockImplementationOnce(() => {

--- a/src/service/utils.js
+++ b/src/service/utils.js
@@ -142,9 +142,41 @@ const asyncFilter = async (array, predicate) => {
   return array.filter((item, index) => results[index])
 }
 
+/**
+ *
+ * @param {string} dir - The directory to eval
+ * @returns {Promise<number>} - The size of the directory
+ */
+const dirSize = async (dir) => {
+  const files = await fs.readdir(dir, { withFileTypes: true })
+
+  const paths = files.map(async (file) => {
+    const filePath = path.join(dir, file.name)
+
+    if (file.isDirectory()) {
+      const size = await dirSize(filePath)
+      return size
+    }
+
+    if (file.isFile()) {
+      try {
+        const { size } = await fs.stat(filePath)
+        return size
+      } catch {
+        return 0
+      }
+    }
+
+    return 0
+  })
+
+  return (await Promise.all(paths)).flat(Infinity).reduce((i, size) => i + size, 0)
+}
+
 export {
   getCommandLineArguments,
   delay,
+  dirSize,
   generateIntervals,
   createFolder,
   replaceFilenameWithVariable,


### PR DESCRIPTION
I need to test deeper (unit test and runtime tests) but with a quick local fix and test, here is the logic :
- When starting, file and value caches get the whole cache size (including error folders)
- Every send method finish by retrieving again the whole cache size (including error folders), updating the current size
- When caching, the cache size (as a class variable for value/fileCache) is check : if it exceeds the maxSize settings, the values/files will be discarded