### PR TITLE
fix(styles): fix padding bug

### DIFF
--- a/frontend/src/app/shared/box/box.component.scss
+++ b/frontend/src/app/shared/box/box.component.scss
@@ -8,6 +8,7 @@
 
 .oib-box-content.has-table,
 .oib-box-content.has-empty-div,
-.oib-box-content.has-alert-warning {
+.oib-box-content.has-alert-warning,
+.oib-box-content.has-grey-container {
   padding: 0; /* Remove padding for table, empty div, and alert-warning */
 }

--- a/frontend/src/app/shared/box/box.component.ts
+++ b/frontend/src/app/shared/box/box.component.ts
@@ -53,7 +53,7 @@ export class BoxComponent implements AfterContentInit {
     if (contentElement) {
       const tableElement = contentElement.querySelector('table');
       const alertWarningElement = contentElement.querySelector('.alert-warning');
-      const emptyDivElements = contentElement.querySelectorAll('div:empty');
+      const emptyDivElements = contentElement.querySelectorAll('div');
 
       contentElement.classList.remove('has-empty-div', 'has-table', 'has-alert-warning'); // Deletes the existing class
 

--- a/frontend/src/app/shared/box/box.component.ts
+++ b/frontend/src/app/shared/box/box.component.ts
@@ -54,6 +54,7 @@ export class BoxComponent implements AfterContentInit {
       const tableElement = contentElement.querySelector('table');
       const alertWarningElement = contentElement.querySelector('.alert-warning');
       const emptyDivElements = contentElement.querySelectorAll('div');
+      const greyContainerElement = contentElement.querySelector('.oib-grey-container');
 
       contentElement.classList.remove('has-empty-div', 'has-table', 'has-alert-warning'); // Deletes the existing class
 
@@ -65,6 +66,9 @@ export class BoxComponent implements AfterContentInit {
       }
       if (alertWarningElement) {
         contentElement.classList.add('has-alert-warning');
+      }
+      if (greyContainerElement) {
+        contentElement.classList.add('has-grey-container');
       }
     }
   }

--- a/frontend/src/app/shared/box/box.component.ts
+++ b/frontend/src/app/shared/box/box.component.ts
@@ -56,7 +56,7 @@ export class BoxComponent implements AfterContentInit {
       const emptyDivElements = contentElement.querySelectorAll('div');
       const greyContainerElement = contentElement.querySelector('.oib-grey-container');
 
-      contentElement.classList.remove('has-empty-div', 'has-table', 'has-alert-warning'); // Deletes the existing class
+      contentElement.classList.remove('has-empty-div', 'has-table', 'has-alert-warning', 'has-grey-container'); // Deletes the existing class
 
       if (tableElement) {
         contentElement.classList.add('has-table');


### PR DESCRIPTION
change :
const emptyDivElements = contentElement.querySelectorAll('div:empty');
for :
const emptyDivElements = contentElement.querySelectorAll('div');

Thanks to this change, the for loop no longer searches for empty divs, but for divs with a length of 0.
Add new class and new const in oib-box.
Now the for loop detects the oib-grey-container class and removes the padding according to its position in oib-box.

I think all the bugs about oib-box and its padding have disappeared.