### PR TITLE
chore: use styleUrl instead of styleUrls

### DIFF
--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -11,7 +11,7 @@ import { NavigationService } from './shared/navigation.service';
 @Component({
   selector: 'oib-root',
   templateUrl: './app.component.html',
-  styleUrls: ['./app.component.scss'],
+  styleUrl: './app.component.scss',
   standalone: true,
   imports: [RouterOutlet, NavbarComponent, NotificationComponent, DefaultValidationErrorsComponent]
 })

--- a/frontend/src/app/auth/login/login.component.ts
+++ b/frontend/src/app/auth/login/login.component.ts
@@ -14,7 +14,7 @@ import { WindowService } from '../../shared/window.service';
 @Component({
   selector: 'oib-login',
   templateUrl: './login.component.html',
-  styleUrls: ['./login.component.scss'],
+  styleUrl: './login.component.scss',
   imports: [...formDirectives, TranslateModule, NgbCollapse],
   standalone: true
 })

--- a/frontend/src/app/engine/edit-certificate-modal/edit-certificate-modal.component.ts
+++ b/frontend/src/app/engine/edit-certificate-modal/edit-certificate-modal.component.ts
@@ -12,7 +12,7 @@ import { NgIf } from '@angular/common';
 @Component({
   selector: 'oib-edit-certificate-modal',
   templateUrl: './edit-certificate-modal.component.html',
-  styleUrls: ['./edit-certificate-modal.component.scss'],
+  styleUrl: './edit-certificate-modal.component.scss',
   imports: [...formDirectives, TranslateModule, SaveButtonComponent, NgIf],
   standalone: true
 })

--- a/frontend/src/app/engine/edit-external-source-modal/edit-external-source-modal.component.ts
+++ b/frontend/src/app/engine/edit-external-source-modal/edit-external-source-modal.component.ts
@@ -11,7 +11,7 @@ import { formDirectives } from '../../shared/form-directives';
 @Component({
   selector: 'oib-edit-external-source-modal',
   templateUrl: './edit-external-source-modal.component.html',
-  styleUrls: ['./edit-external-source-modal.component.scss'],
+  styleUrl: './edit-external-source-modal.component.scss',
   imports: [...formDirectives, TranslateModule, SaveButtonComponent],
   standalone: true
 })

--- a/frontend/src/app/engine/edit-ip-filter-modal/edit-ip-filter-modal.component.ts
+++ b/frontend/src/app/engine/edit-ip-filter-modal/edit-ip-filter-modal.component.ts
@@ -11,7 +11,7 @@ import { formDirectives } from '../../shared/form-directives';
 @Component({
   selector: 'oib-edit-ip-filter-modal',
   templateUrl: './edit-ip-filter-modal.component.html',
-  styleUrls: ['./edit-ip-filter-modal.component.scss'],
+  styleUrl: './edit-ip-filter-modal.component.scss',
   imports: [...formDirectives, TranslateModule, SaveButtonComponent],
   standalone: true
 })

--- a/frontend/src/app/engine/edit-scan-mode-modal/edit-scan-mode-modal.component.ts
+++ b/frontend/src/app/engine/edit-scan-mode-modal/edit-scan-mode-modal.component.ts
@@ -11,7 +11,7 @@ import { formDirectives } from '../../shared/form-directives';
 @Component({
   selector: 'oib-edit-scan-mode-modal',
   templateUrl: './edit-scan-mode-modal.component.html',
-  styleUrls: ['./edit-scan-mode-modal.component.scss'],
+  styleUrl: './edit-scan-mode-modal.component.scss',
   imports: [...formDirectives, TranslateModule, SaveButtonComponent],
   standalone: true
 })

--- a/frontend/src/app/history-query/create-history-query-modal/create-history-query-modal.component.ts
+++ b/frontend/src/app/history-query/create-history-query-modal/create-history-query-modal.component.ts
@@ -14,7 +14,7 @@ import { ObservableState, SaveButtonComponent } from '../../shared/save-button/s
 @Component({
   selector: 'oib-create-history-query-modal',
   templateUrl: './create-history-query-modal.component.html',
-  styleUrls: ['./create-history-query-modal.component.scss'],
+  styleUrl: './create-history-query-modal.component.scss',
   imports: [...formDirectives, TranslateModule, NgForOf, NgIf, SaveButtonComponent],
   standalone: true
 })

--- a/frontend/src/app/history-query/history-query-detail/history-metrics/history-metrics.component.ts
+++ b/frontend/src/app/history-query/history-query-detail/history-metrics/history-metrics.component.ts
@@ -12,7 +12,7 @@ import { SouthConnectorManifest } from '../../../../../../shared/model/south-con
 @Component({
   selector: 'oib-history-metrics',
   templateUrl: './history-metrics.component.html',
-  styleUrls: ['./history-metrics.component.scss'],
+  styleUrl: './history-metrics.component.scss',
   imports: [TranslateModule, NgIf, DatetimePipe, DurationPipe, BoxComponent, BoxTitleDirective, JsonPipe],
   standalone: true
 })

--- a/frontend/src/app/history-query/history-query-detail/history-query-detail.component.ts
+++ b/frontend/src/app/history-query/history-query-detail/history-query-detail.component.ts
@@ -59,7 +59,7 @@ import { TestConnectionResultModalComponent } from '../../shared/test-connection
     ClipboardModule
   ],
   templateUrl: './history-query-detail.component.html',
-  styleUrls: ['./history-query-detail.component.scss'],
+  styleUrl: './history-query-detail.component.scss',
   providers: [PageLoader]
 })
 export class HistoryQueryDetailComponent implements OnInit, OnDestroy {

--- a/frontend/src/app/logs/logs.component.ts
+++ b/frontend/src/app/logs/logs.component.ts
@@ -58,7 +58,7 @@ import { LegendComponent } from '../shared/legend/legend.component';
     LegendComponent
   ],
   templateUrl: './logs.component.html',
-  styleUrls: ['./logs.component.scss'],
+  styleUrl: './logs.component.scss',
   providers: [PageLoader]
 })
 export class LogsComponent implements OnInit, OnDestroy {

--- a/frontend/src/app/north/choose-north-connector-type-modal/choose-north-connector-type-modal.component.ts
+++ b/frontend/src/app/north/choose-north-connector-type-modal/choose-north-connector-type-modal.component.ts
@@ -10,7 +10,7 @@ import { NorthConnectorService } from '../../services/north-connector.service';
 @Component({
   selector: 'oib-choose-north-connector-type-modal',
   templateUrl: './choose-north-connector-type-modal.component.html',
-  styleUrls: ['./choose-north-connector-type-modal.component.scss'],
+  styleUrl: './choose-north-connector-type-modal.component.scss',
   imports: [...formDirectives, TranslateModule, NgForOf],
   standalone: true
 })

--- a/frontend/src/app/north/create-north-subscription-modal/create-north-subscription-modal.component.ts
+++ b/frontend/src/app/north/create-north-subscription-modal/create-north-subscription-modal.component.ts
@@ -12,7 +12,7 @@ import { OIBusSubscription } from '../../../../../shared/model/subscription.mode
 @Component({
   selector: 'oib-create-north-subscription-modal',
   templateUrl: './create-north-subscription-modal.component.html',
-  styleUrls: ['./create-north-subscription-modal.component.scss'],
+  styleUrl: './create-north-subscription-modal.component.scss',
   imports: [...formDirectives, TranslateModule, SaveButtonComponent, NgForOf, NgIf],
   standalone: true
 })

--- a/frontend/src/app/north/explore-cache/archive-files/archive-files.component.ts
+++ b/frontend/src/app/north/explore-cache/archive-files/archive-files.component.ts
@@ -16,7 +16,7 @@ import { FileTableComponent, FileTableData } from '../file-table/file-table.comp
 @Component({
   selector: 'oib-archive-files',
   templateUrl: './archive-files.component.html',
-  styleUrls: ['./archive-files.component.scss'],
+  styleUrl: './archive-files.component.scss',
   imports: [
     ...formDirectives,
     TranslateModule,

--- a/frontend/src/app/north/explore-cache/cache-files/cache-files.component.ts
+++ b/frontend/src/app/north/explore-cache/cache-files/cache-files.component.ts
@@ -16,7 +16,7 @@ import { FileTableComponent, FileTableData } from '../file-table/file-table.comp
 @Component({
   selector: 'oib-cache-files',
   templateUrl: './cache-files.component.html',
-  styleUrls: ['./cache-files.component.scss'],
+  styleUrl: './cache-files.component.scss',
   imports: [
     ...formDirectives,
     TranslateModule,

--- a/frontend/src/app/north/explore-cache/error-files/error-files.component.ts
+++ b/frontend/src/app/north/explore-cache/error-files/error-files.component.ts
@@ -16,7 +16,7 @@ import { emptyPage } from '../../../shared/test-utils';
 @Component({
   selector: 'oib-error-files',
   templateUrl: './error-files.component.html',
-  styleUrls: ['./error-files.component.scss'],
+  styleUrl: './error-files.component.scss',
   imports: [
     ...formDirectives,
     TranslateModule,

--- a/frontend/src/app/north/explore-cache/explore-cache.component.ts
+++ b/frontend/src/app/north/explore-cache/explore-cache.component.ts
@@ -18,7 +18,7 @@ import { CacheFilesComponent } from './cache-files/cache-files.component';
 @Component({
   selector: 'oib-explore-cache',
   templateUrl: './explore-cache.component.html',
-  styleUrls: ['./explore-cache.component.scss'],
+  styleUrl: './explore-cache.component.scss',
   imports: [
     ...formDirectives,
     TranslateModule,

--- a/frontend/src/app/north/explore-cache/file-table/file-table.component.ts
+++ b/frontend/src/app/north/explore-cache/file-table/file-table.component.ts
@@ -28,7 +28,7 @@ export type FileTableData = {
 @Component({
   selector: 'oib-file-table',
   templateUrl: './file-table.component.html',
-  styleUrls: ['./file-table.component.scss'],
+  styleUrl: './file-table.component.scss',
   imports: [
     ...formDirectives,
     TranslateModule,

--- a/frontend/src/app/north/north-detail/north-detail.component.ts
+++ b/frontend/src/app/north/north-detail/north-detail.component.ts
@@ -44,7 +44,7 @@ import { EngineService } from '../../services/engine.service';
     ClipboardModule
   ],
   templateUrl: './north-detail.component.html',
-  styleUrls: ['./north-detail.component.scss'],
+  styleUrl: './north-detail.component.scss',
   providers: [PageLoader, BooleanEnumPipe]
 })
 export class NorthDetailComponent implements OnInit, OnDestroy {

--- a/frontend/src/app/north/north-metrics/north-metrics.component.ts
+++ b/frontend/src/app/north/north-metrics/north-metrics.component.ts
@@ -14,7 +14,7 @@ import { Router } from '@angular/router';
 @Component({
   selector: 'oib-north-metrics',
   templateUrl: './north-metrics.component.html',
-  styleUrls: ['./north-metrics.component.scss'],
+  styleUrl: './north-metrics.component.scss',
   imports: [TranslateModule, NgIf, DatetimePipe, DurationPipe, BoxComponent, BoxTitleDirective, JsonPipe, FileSizePipe],
   standalone: true
 })

--- a/frontend/src/app/shared/box/box.component.ts
+++ b/frontend/src/app/shared/box/box.component.ts
@@ -30,7 +30,7 @@ export class BoxTitleDirective {
   selector: 'oib-box',
   standalone: true,
   templateUrl: './box.component.html',
-  styleUrls: ['./box.component.scss'],
+  styleUrl: './box.component.scss',
   imports: [NgbCollapse, NgIf, NgTemplateOutlet, TranslateModule],
   changeDetection: ChangeDetectionStrategy.OnPush
 })

--- a/frontend/src/app/shared/confirmation-modal/confirmation-modal.component.ts
+++ b/frontend/src/app/shared/confirmation-modal/confirmation-modal.component.ts
@@ -4,7 +4,7 @@ import { NgbActiveModal, NgbModalModule } from '@ng-bootstrap/ng-bootstrap';
 @Component({
   selector: 'oib-confirmation-modal',
   templateUrl: './confirmation-modal.component.html',
-  styleUrls: ['./confirmation-modal.component.scss'],
+  styleUrl: './confirmation-modal.component.scss',
   imports: [NgbModalModule],
   standalone: true
 })

--- a/frontend/src/app/shared/datetimepicker/datetimepicker.component.ts
+++ b/frontend/src/app/shared/datetimepicker/datetimepicker.component.ts
@@ -49,7 +49,7 @@ import { formDirectives } from '../form-directives';
 @Component({
   selector: 'oib-datetimepicker',
   templateUrl: './datetimepicker.component.html',
-  styleUrls: ['./datetimepicker.component.scss'],
+  styleUrl: './datetimepicker.component.scss',
   providers: [
     { provide: NG_VALUE_ACCESSOR, useExisting: forwardRef(() => DatetimepickerComponent), multi: true },
     { provide: NG_VALIDATORS, useExisting: forwardRef(() => DatetimepickerComponent), multi: true }

--- a/frontend/src/app/shared/default-validation-errors/default-validation-errors.component.ts
+++ b/frontend/src/app/shared/default-validation-errors/default-validation-errors.component.ts
@@ -6,7 +6,7 @@ import { DecimalPipe } from '@angular/common';
 @Component({
   selector: 'oib-default-validation-errors',
   templateUrl: './default-validation-errors.component.html',
-  styleUrls: ['./default-validation-errors.component.scss'],
+  styleUrl: './default-validation-errors.component.scss',
   imports: [TranslateModule, ValdemortModule, DecimalPipe],
   standalone: true
 })

--- a/frontend/src/app/shared/form/form.component.ts
+++ b/frontend/src/app/shared/form/form.component.ts
@@ -28,7 +28,7 @@ declare namespace Intl {
   standalone: true,
   imports: [...formDirectives, NgIf, NgForOf, OibCodeBlockComponent, NgbTypeahead, TranslateModule, OibArrayComponent],
   templateUrl: './form.component.html',
-  styleUrls: ['./form.component.scss'],
+  styleUrl: './form.component.scss',
   viewProviders: [
     {
       provide: ControlContainer,

--- a/frontend/src/app/shared/form/oib-code-block/oib-code-block-stub.component.ts
+++ b/frontend/src/app/shared/form/oib-code-block/oib-code-block-stub.component.ts
@@ -4,7 +4,7 @@ import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 @Component({
   selector: 'oib-code-block',
   templateUrl: './code-block.component.html',
-  styleUrls: ['./code-block.component.scss'],
+  styleUrl: './code-block.component.scss',
   providers: [
     {
       provide: NG_VALUE_ACCESSOR,

--- a/frontend/src/app/shared/form/oib-code-block/oib-code-block.component.ts
+++ b/frontend/src/app/shared/form/oib-code-block/oib-code-block.component.ts
@@ -11,7 +11,7 @@ import { NgIf } from '@angular/common';
 @Component({
   selector: 'oib-code-block',
   templateUrl: './oib-code-block.component.html',
-  styleUrls: ['./oib-code-block.component.scss'],
+  styleUrl: './oib-code-block.component.scss',
   imports: [...formDirectives, NgIf],
   providers: [
     {

--- a/frontend/src/app/shared/form/oib-form-array/edit-element/edit-element.component.ts
+++ b/frontend/src/app/shared/form/oib-form-array/edit-element/edit-element.component.ts
@@ -10,7 +10,7 @@ import { FormComponent } from '../../form.component';
 @Component({
   selector: 'oib-edit-element',
   templateUrl: './edit-element.component.html',
-  styleUrls: ['./edit-element.component.scss'],
+  styleUrl: './edit-element.component.scss',
   imports: [...formDirectives, NgIf, NgForOf, TranslateModule, forwardRef(() => FormComponent)],
   standalone: true
 })

--- a/frontend/src/app/shared/form/oib-form-array/oib-array.component.ts
+++ b/frontend/src/app/shared/form/oib-form-array/oib-array.component.ts
@@ -10,7 +10,7 @@ import { PipeProviderService } from '../pipe-provider.service';
 @Component({
   selector: 'oib-array',
   templateUrl: './oib-array.component.html',
-  styleUrls: ['./oib-array.component.scss'],
+  styleUrl: './oib-array.component.scss',
   imports: [...formDirectives, NgIf, NgForOf, TranslateModule, EditElementComponent],
   providers: [
     {

--- a/frontend/src/app/shared/form/oib-scan-mode/oib-scan-mode.component.ts
+++ b/frontend/src/app/shared/form/oib-scan-mode/oib-scan-mode.component.ts
@@ -10,7 +10,7 @@ import { TranslateModule } from '@ngx-translate/core';
   standalone: true,
   imports: [...formDirectives, NgIf, NgForOf, TranslateModule],
   templateUrl: './oib-scan-mode.component.html',
-  styleUrls: ['./oib-scan-mode.component.scss'],
+  styleUrl: './oib-scan-mode.component.scss',
   providers: [{ provide: NG_VALUE_ACCESSOR, useExisting: forwardRef(() => OibScanModeComponent), multi: true }]
 })
 export class OibScanModeComponent implements ControlValueAccessor {

--- a/frontend/src/app/shared/legend/legend.component.ts
+++ b/frontend/src/app/shared/legend/legend.component.ts
@@ -5,7 +5,7 @@ import { TranslateModule } from '@ngx-translate/core';
 @Component({
   selector: 'oib-legend',
   templateUrl: './legend.component.html',
-  styleUrls: ['./legend.component.scss'],
+  styleUrl: './legend.component.scss',
   standalone: true,
   imports: [NgClass, NgIf, NgForOf, TranslateModule],
   changeDetection: ChangeDetectionStrategy.OnPush

--- a/frontend/src/app/shared/multi-select/multi-select.component.ts
+++ b/frontend/src/app/shared/multi-select/multi-select.component.ts
@@ -22,7 +22,7 @@ import { NgForOf, NgIf } from '@angular/common';
 @Component({
   selector: 'oib-multi-select',
   templateUrl: './multi-select.component.html',
-  styleUrls: ['./multi-select.component.scss'],
+  styleUrl: './multi-select.component.scss',
   providers: [
     {
       provide: NG_VALUE_ACCESSOR,

--- a/frontend/src/app/shared/notification/notification.component.ts
+++ b/frontend/src/app/shared/notification/notification.component.ts
@@ -14,7 +14,7 @@ interface Action {
 @Component({
   selector: 'oib-notification',
   templateUrl: './notification.component.html',
-  styleUrls: ['./notification.component.scss'],
+  styleUrl: './notification.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [NgIf, NgForOf, NgbToastModule, TranslateModule, AsyncPipe],
   standalone: true

--- a/frontend/src/app/shared/pagination/pagination.component.ts
+++ b/frontend/src/app/shared/pagination/pagination.component.ts
@@ -7,7 +7,7 @@ import { NgIf } from '@angular/common';
 @Component({
   selector: 'oib-pagination',
   templateUrl: './pagination.component.html',
-  styleUrls: ['./pagination.component.scss'],
+  styleUrl: './pagination.component.scss',
   imports: [NgbPaginationModule, NgIf],
   standalone: true
 })

--- a/frontend/src/app/shared/pill/pill.component.ts
+++ b/frontend/src/app/shared/pill/pill.component.ts
@@ -4,7 +4,7 @@ import { NgClass, NgIf } from '@angular/common';
 @Component({
   selector: 'oib-pill',
   templateUrl: './pill.component.html',
-  styleUrls: ['./pill.component.scss'],
+  styleUrl: './pill.component.scss',
   standalone: true,
   imports: [NgClass, NgIf],
   changeDetection: ChangeDetectionStrategy.OnPush

--- a/frontend/src/app/shared/save-button/save-button.component.ts
+++ b/frontend/src/app/shared/save-button/save-button.component.ts
@@ -31,7 +31,7 @@ export class ObservableState {
 @Component({
   selector: 'oib-save-button',
   templateUrl: './save-button.component.html',
-  styleUrls: ['./save-button.component.scss'],
+  styleUrl: './save-button.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [AsyncPipe, NgIf, NgClass, TranslateModule],
   standalone: true

--- a/frontend/src/app/shared/test-connection-result-modal/test-connection-result-modal.component.ts
+++ b/frontend/src/app/shared/test-connection-result-modal/test-connection-result-modal.component.ts
@@ -13,7 +13,7 @@ import { HistoryQueryService } from '../../services/history-query.service';
 @Component({
   selector: 'oib-test-connection-result-modal',
   templateUrl: './test-connection-result-modal.component.html',
-  styleUrls: ['./test-connection-result-modal.component.scss'],
+  styleUrl: './test-connection-result-modal.component.scss',
   imports: [TranslateModule, SaveButtonComponent, NgForOf, NgIf, FormComponent],
   standalone: true
 })

--- a/frontend/src/app/shared/truncated-string/truncated-string.component.ts
+++ b/frontend/src/app/shared/truncated-string/truncated-string.component.ts
@@ -6,7 +6,7 @@ import { NgbPopover } from '@ng-bootstrap/ng-bootstrap';
   selector: 'oib-truncated-string',
   standalone: true,
   templateUrl: './truncated-string.component.html',
-  styleUrls: ['./truncated-string.component.scss'],
+  styleUrl: './truncated-string.component.scss',
   imports: [NgIf, NgbPopover],
   changeDetection: ChangeDetectionStrategy.OnPush
 })

--- a/frontend/src/app/south/choose-south-connector-type-modal/choose-south-connector-type-modal.component.ts
+++ b/frontend/src/app/south/choose-south-connector-type-modal/choose-south-connector-type-modal.component.ts
@@ -10,7 +10,7 @@ import { NgForOf } from '@angular/common';
 @Component({
   selector: 'oib-choose-south-connector-type-modal',
   templateUrl: './choose-south-connector-type-modal.component.html',
-  styleUrls: ['./choose-south-connector-type-modal.component.scss'],
+  styleUrl: './choose-south-connector-type-modal.component.scss',
   imports: [...formDirectives, TranslateModule, NgForOf],
   standalone: true
 })

--- a/frontend/src/app/south/edit-south-item-modal/edit-south-item-modal.component.ts
+++ b/frontend/src/app/south/edit-south-item-modal/edit-south-item-modal.component.ts
@@ -31,7 +31,7 @@ declare namespace Intl {
 @Component({
   selector: 'oib-edit-south-item-modal',
   templateUrl: './edit-south-item-modal.component.html',
-  styleUrls: ['./edit-south-item-modal.component.scss'],
+  styleUrl: './edit-south-item-modal.component.scss',
   imports: [
     ...formDirectives,
     TranslateModule,

--- a/frontend/src/app/south/import-south-items-modal/import-south-items-modal.component.ts
+++ b/frontend/src/app/south/import-south-items-modal/import-south-items-modal.component.ts
@@ -16,7 +16,7 @@ import { PipeProviderService } from '../../shared/form/pipe-provider.service';
 @Component({
   selector: 'oib-import-south-items-modal',
   templateUrl: './import-south-items-modal.component.html',
-  styleUrls: ['./import-south-items-modal.component.scss'],
+  styleUrl: './import-south-items-modal.component.scss',
   imports: [
     ...formDirectives,
     TranslateModule,

--- a/frontend/src/app/south/south-detail/south-detail.component.ts
+++ b/frontend/src/app/south/south-detail/south-detail.component.ts
@@ -43,7 +43,7 @@ import { ClipboardModule } from '@angular/cdk/clipboard';
     ClipboardModule
   ],
   templateUrl: './south-detail.component.html',
-  styleUrls: ['./south-detail.component.scss'],
+  styleUrl: './south-detail.component.scss',
   providers: [PageLoader]
 })
 export class SouthDetailComponent implements OnInit, OnDestroy {

--- a/frontend/src/app/south/south-metrics/south-metrics.component.ts
+++ b/frontend/src/app/south/south-metrics/south-metrics.component.ts
@@ -13,7 +13,7 @@ import { Router } from '@angular/router';
 @Component({
   selector: 'oib-south-metrics',
   templateUrl: './south-metrics.component.html',
-  styleUrls: ['./south-metrics.component.scss'],
+  styleUrl: './south-metrics.component.scss',
   standalone: true,
   imports: [TranslateModule, NgIf, DatetimePipe, DurationPipe, BoxComponent, BoxTitleDirective, JsonPipe]
 })

--- a/frontend/src/app/user-settings/change-password-modal/change-password-modal.component.ts
+++ b/frontend/src/app/user-settings/change-password-modal/change-password-modal.component.ts
@@ -24,7 +24,7 @@ function samePasswordValidator(newPasswordForm: AbstractControl): ValidationErro
 @Component({
   selector: 'oib-change-password-modal',
   templateUrl: './change-password-modal.component.html',
-  styleUrls: ['./change-password-modal.component.scss'],
+  styleUrl: './change-password-modal.component.scss',
   imports: [...formDirectives, TranslateModule, NgbCollapse, NgIf],
   standalone: true
 })

--- a/frontend/src/app/user-settings/edit-user-settings/edit-user-settings.component.ts
+++ b/frontend/src/app/user-settings/edit-user-settings/edit-user-settings.component.ts
@@ -26,7 +26,7 @@ declare namespace Intl {
 @Component({
   selector: 'oib-edit-user-settings',
   templateUrl: './edit-user-settings.component.html',
-  styleUrls: ['./edit-user-settings.component.scss'],
+  styleUrl: './edit-user-settings.component.scss',
   imports: [...formDirectives, TranslateModule, NgIf, NgForOf, NgbTypeahead, SaveButtonComponent],
   standalone: true
 })


### PR DESCRIPTION
In v17, we can now use `styleUrl` when there is only one style file, so I updated the existing components to use it when possible