### PR TITLE
fix(backend): Fix validation of optional items from csv

### DIFF
--- a/backend/src/web-server/controllers/validators/joi.validator.ts
+++ b/backend/src/web-server/controllers/validators/joi.validator.ts
@@ -196,7 +196,7 @@ export default class JoiValidator {
       schema = schema.when(condition.field, {
         is: Joi.any().valid(...condition.values),
         then: schema.required(),
-        otherwise: schema.optional()
+        otherwise: schema.allow('').optional()
       });
     }
     return schema;


### PR DESCRIPTION
Closes: #3080 

Note:
The issue occurred because `.optional()` does not treat empty strings as unset: https://github.com/hapijs/joi/issues/482