### PR TITLE
chore: remove useDefineForClassFields

### DIFF
--- a/frontend/src/app/auth/login/login.component.ts
+++ b/frontend/src/app/auth/login/login.component.ts
@@ -1,6 +1,6 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { Router } from '@angular/router';
-import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { FormGroup, NonNullableFormBuilder, Validators } from '@angular/forms';
 import { RequestedUrlService } from '../authentication.guard';
 import { NgbCollapse } from '@ng-bootstrap/ng-bootstrap';
 import { formDirectives } from '../../shared/form-directives';
@@ -20,13 +20,12 @@ import { WindowService } from '../../shared/window.service';
 })
 export class LoginComponent {
   loginError = false;
-  form: FormGroup = this.fb.group({
+  form: FormGroup = inject(NonNullableFormBuilder).group({
     login: ['', Validators.required],
     password: ['', Validators.required]
   });
 
   constructor(
-    private fb: FormBuilder,
     private currentUserService: CurrentUserService,
     private router: Router,
     private requestedUrlService: RequestedUrlService,

--- a/frontend/src/app/engine/edit-certificate-modal/edit-certificate-modal.component.ts
+++ b/frontend/src/app/engine/edit-certificate-modal/edit-certificate-modal.component.ts
@@ -1,6 +1,6 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
-import { FormBuilder, Validators } from '@angular/forms';
+import { NonNullableFormBuilder, Validators } from '@angular/forms';
 import { Observable, switchMap } from 'rxjs';
 import { ObservableState, SaveButtonComponent } from '../../shared/save-button/save-button.component';
 import { TranslateModule } from '@ngx-translate/core';
@@ -19,11 +19,11 @@ export class EditCertificateModalComponent {
   mode: 'create' | 'edit' = 'create';
   state = new ObservableState();
   certificate: CertificateDTO | null = null;
-  form = this.fb.group({
+  form = inject(NonNullableFormBuilder).group({
     name: ['', Validators.required],
     description: '',
     regenerateCertificate: true,
-    certificateOptions: this.fb.group({
+    certificateOptions: inject(NonNullableFormBuilder).group({
       commonName: ['', Validators.required],
       countryName: ['', Validators.required],
       stateOrProvinceName: ['', Validators.required],
@@ -36,7 +36,6 @@ export class EditCertificateModalComponent {
 
   constructor(
     private modal: NgbActiveModal,
-    private fb: FormBuilder,
     private certificateService: CertificateService
   ) {
     this.form.controls.regenerateCertificate.valueChanges.subscribe(next => {

--- a/frontend/src/app/engine/edit-engine/edit-engine.component.ts
+++ b/frontend/src/app/engine/edit-engine/edit-engine.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, inject, OnInit } from '@angular/core';
 import { TranslateModule } from '@ngx-translate/core';
 import { NonNullableFormBuilder, Validators } from '@angular/forms';
 import { Router, RouterLink } from '@angular/router';
@@ -21,6 +21,7 @@ import { BackNavigationDirective } from '../../shared/back-navigation.directives
 export class EditEngineComponent implements OnInit {
   readonly logLevels = LOG_LEVELS;
 
+  private fb = inject(NonNullableFormBuilder);
   engineForm = this.fb.group({
     name: ['', Validators.required],
     port: [null as number | null, Validators.required],
@@ -56,7 +57,6 @@ export class EditEngineComponent implements OnInit {
   state = new ObservableState();
 
   constructor(
-    private fb: NonNullableFormBuilder,
     private notificationService: NotificationService,
     private engineService: EngineService,
     private router: Router

--- a/frontend/src/app/engine/edit-ip-filter-modal/edit-ip-filter-modal.component.ts
+++ b/frontend/src/app/engine/edit-ip-filter-modal/edit-ip-filter-modal.component.ts
@@ -1,6 +1,6 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
-import { FormBuilder, Validators } from '@angular/forms';
+import { NonNullableFormBuilder, Validators } from '@angular/forms';
 import { Observable, switchMap } from 'rxjs';
 import { ObservableState, SaveButtonComponent } from '../../shared/save-button/save-button.component';
 import { TranslateModule } from '@ngx-translate/core';
@@ -19,14 +19,13 @@ export class EditIpFilterModalComponent {
   mode: 'create' | 'edit' = 'create';
   state = new ObservableState();
   ipFilter: IpFilterDTO | null = null;
-  form = this.fb.group({
+  form = inject(NonNullableFormBuilder).group({
     address: ['', Validators.required],
     description: ''
   });
 
   constructor(
     private modal: NgbActiveModal,
-    private fb: FormBuilder,
     private ipFilterService: IpFilterService
   ) {}
 

--- a/frontend/src/app/engine/edit-scan-mode-modal/edit-scan-mode-modal.component.ts
+++ b/frontend/src/app/engine/edit-scan-mode-modal/edit-scan-mode-modal.component.ts
@@ -1,6 +1,6 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
-import { AbstractControl, FormBuilder, ValidationErrors, Validators } from '@angular/forms';
+import { AbstractControl, NonNullableFormBuilder, ValidationErrors, Validators } from '@angular/forms';
 import { firstValueFrom, Observable, switchMap } from 'rxjs';
 import { ObservableState, SaveButtonComponent } from '../../shared/save-button/save-button.component';
 import { TranslateModule } from '@ngx-translate/core';
@@ -21,7 +21,7 @@ export class EditScanModeModalComponent {
   mode: 'create' | 'edit' = 'create';
   state = new ObservableState();
   scanMode: ScanModeDTO | null = null;
-  form = this.fb.group({
+  form = inject(NonNullableFormBuilder).group({
     name: ['', Validators.required],
     description: '',
     cron: ['', Validators.required, this.cronValidator()]
@@ -30,7 +30,6 @@ export class EditScanModeModalComponent {
 
   constructor(
     private modal: NgbActiveModal,
-    private fb: FormBuilder,
     private scanModeService: ScanModeService
   ) {}
 

--- a/frontend/src/app/engine/oia-module/oia-module.component.ts
+++ b/frontend/src/app/engine/oia-module/oia-module.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy, OnInit } from '@angular/core';
+import { Component, inject, OnDestroy, OnInit } from '@angular/core';
 import { TranslateModule } from '@ngx-translate/core';
 
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
@@ -60,7 +60,8 @@ export class OiaModuleComponent implements OnInit, OnDestroy {
   // subscription to reload the page periodically
   subscription = new Subscription();
   registrationSubscription = new Subscription();
-  readonly searchForm = this.fb.group({
+  route = inject(ActivatedRoute);
+  readonly searchForm = inject(NonNullableFormBuilder).group({
     types: this.route.snapshot.queryParamMap.getAll('types'),
     status: this.route.snapshot.queryParamMap.getAll('status')
   });
@@ -71,10 +72,8 @@ export class OiaModuleComponent implements OnInit, OnDestroy {
     private notificationService: NotificationService,
     private confirmationService: ConfirmationService,
     private modalService: ModalService,
-    private route: ActivatedRoute,
     private router: Router,
-    private pageLoader: PageLoader,
-    private fb: NonNullableFormBuilder
+    private pageLoader: PageLoader
   ) {}
 
   ngOnInit(): void {

--- a/frontend/src/app/engine/oia-module/register-oibus-modal/register-oibus-modal.component.ts
+++ b/frontend/src/app/engine/oia-module/register-oibus-modal/register-oibus-modal.component.ts
@@ -1,6 +1,6 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
-import { FormBuilder, Validators } from '@angular/forms';
+import { NonNullableFormBuilder, Validators } from '@angular/forms';
 import { ObservableState, SaveButtonComponent } from '../../../shared/save-button/save-button.component';
 import { TranslateModule } from '@ngx-translate/core';
 import { formDirectives } from '../../../shared/form-directives';
@@ -16,7 +16,7 @@ import { LOG_LEVELS, RegistrationSettingsCommandDTO, RegistrationSettingsDTO } f
 })
 export class RegisterOibusModalComponent {
   state = new ObservableState();
-  form = this.fb.group({
+  form = inject(NonNullableFormBuilder).group({
     host: ['', Validators.required],
     useProxy: [false as boolean, Validators.required],
     proxyUrl: '',
@@ -27,7 +27,6 @@ export class RegisterOibusModalComponent {
 
   constructor(
     private modal: NgbActiveModal,
-    private fb: FormBuilder,
     private oibusService: EngineService
   ) {}
 

--- a/frontend/src/app/history-query/create-history-query-modal/create-history-query-modal.component.ts
+++ b/frontend/src/app/history-query/create-history-query-modal/create-history-query-modal.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, inject, OnInit } from '@angular/core';
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
 import { TranslateModule } from '@ngx-translate/core';
 import { formDirectives } from '../../shared/form-directives';
@@ -25,19 +25,19 @@ export class CreateHistoryQueryModalComponent implements OnInit {
   southList: Array<SouthConnectorDTO> = [];
   state = new ObservableState();
 
-  createForm = this.fb.group({
-    fromExistingSouth: this.fb.control(true),
-    fromExistingNorth: this.fb.control(true),
-    southType: this.fb.control(null as string | null, Validators.required),
-    northType: this.fb.control(null as string | null, Validators.required),
-    southId: this.fb.control(null as string | null, Validators.required),
-    northId: this.fb.control(null as string | null, Validators.required)
+  createForm = inject(NonNullableFormBuilder).group({
+    fromExistingSouth: true,
+    fromExistingNorth: true,
+    southType: [null as string | null, Validators.required],
+    northType: [null as string | null, Validators.required],
+    southId: [null as string | null, Validators.required],
+    northId: [null as string | null, Validators.required]
   });
+
   constructor(
     private modal: NgbActiveModal,
     private northConnectorService: NorthConnectorService,
-    private southConnectorService: SouthConnectorService,
-    private fb: NonNullableFormBuilder
+    private southConnectorService: SouthConnectorService
   ) {
     this.createForm.controls.southType.disable();
     this.createForm.controls.northType.disable();

--- a/frontend/src/app/history-query/history-query-items/history-query-items.component.ts
+++ b/frontend/src/app/history-query/history-query-items/history-query-items.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { Component, EventEmitter, inject, Input, OnInit, Output } from '@angular/core';
 import { TranslateModule } from '@ngx-translate/core';
 import { ConfirmationService } from '../../shared/confirmation.service';
 import { NotificationService } from '../../shared/notification.service';
@@ -53,7 +53,10 @@ export class HistoryQueryItemsComponent implements OnInit {
   @Input() historyQuery: HistoryQueryDTO | null = null;
   @Input({ required: true }) southManifest!: SouthConnectorManifest;
   @Input() initItems: Array<SouthConnectorItemDTO> = [];
-  @Output() readonly inMemoryItems = new EventEmitter<{ items: Array<SouthConnectorItemDTO>; itemIdsToDelete: Array<string> }>();
+  @Output() readonly inMemoryItems = new EventEmitter<{
+    items: Array<SouthConnectorItemDTO>;
+    itemIdsToDelete: Array<string>;
+  }>();
   @Input() inMemory = false;
 
   allItems: Array<SouthConnectorItemDTO> = [];
@@ -62,14 +65,13 @@ export class HistoryQueryItemsComponent implements OnInit {
   displayedItems: Page<SouthConnectorItemDTO> = emptyPage();
   displaySettings: Array<OibFormControl> = [];
 
-  searchControl = this.fb.control(null as string | null);
+  searchControl = inject(NonNullableFormBuilder).control(null as string | null);
 
   constructor(
     private confirmationService: ConfirmationService,
     private notificationService: NotificationService,
     private modalService: ModalService,
-    private historyQueryService: HistoryQueryService,
-    private fb: NonNullableFormBuilder
+    private historyQueryService: HistoryQueryService
   ) {}
 
   ngOnInit() {

--- a/frontend/src/app/history-query/history-query-list.component.ts
+++ b/frontend/src/app/history-query/history-query-list.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, inject, OnInit } from '@angular/core';
 import { TranslateModule } from '@ngx-translate/core';
 import { AsyncPipe, NgClass } from '@angular/common';
 import { debounceTime, distinctUntilChanged, switchMap, tap } from 'rxjs';
@@ -48,7 +48,7 @@ export class HistoryQueryListComponent implements OnInit {
   displayedHistoryQueries: Page<HistoryQueryDTO> = emptyPage();
   states = new Map<string, ObservableState>();
 
-  searchForm = this.fb.group({
+  searchForm = inject(NonNullableFormBuilder).group({
     name: [null as string | null]
   });
 
@@ -65,8 +65,7 @@ export class HistoryQueryListComponent implements OnInit {
     private notificationService: NotificationService,
     private modalService: ModalService,
     private historyQueryService: HistoryQueryService,
-    private router: Router,
-    private fb: NonNullableFormBuilder
+    private router: Router
   ) {}
 
   ngOnInit() {

--- a/frontend/src/app/logs/logs.component.ts
+++ b/frontend/src/app/logs/logs.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy, OnInit } from '@angular/core';
+import { Component, inject, OnDestroy, OnInit } from '@angular/core';
 import { TranslateModule } from '@ngx-translate/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { PageLoader } from '../shared/page-loader.service';
@@ -60,7 +60,7 @@ import { LegendComponent } from '../shared/legend/legend.component';
   providers: [PageLoader]
 })
 export class LogsComponent implements OnInit, OnDestroy {
-  readonly searchForm = this.fb.group(
+  readonly searchForm = inject(NonNullableFormBuilder).group(
     {
       messageContent: null as string | null,
       start: null as Instant | null,
@@ -106,7 +106,6 @@ export class LogsComponent implements OnInit, OnDestroy {
     private route: ActivatedRoute,
     private router: Router,
     private pageLoader: PageLoader,
-    private fb: NonNullableFormBuilder,
     private logService: LogService
   ) {
     this.searchParams = this.toSearchParams(this.route);

--- a/frontend/src/app/north/create-north-subscription-modal/create-north-subscription-modal.component.ts
+++ b/frontend/src/app/north/create-north-subscription-modal/create-north-subscription-modal.component.ts
@@ -1,6 +1,6 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
-import { FormBuilder, Validators } from '@angular/forms';
+import { NonNullableFormBuilder, Validators } from '@angular/forms';
 import { ObservableState, SaveButtonComponent } from '../../shared/save-button/save-button.component';
 import { TranslateModule } from '@ngx-translate/core';
 import { formDirectives } from '../../shared/form-directives';
@@ -18,14 +18,11 @@ import { OIBusSubscription } from '../../../../../shared/model/subscription.mode
 export class CreateNorthSubscriptionModalComponent {
   state = new ObservableState();
   southConnectors: Array<SouthConnectorDTO> = [];
-  form = this.fb.group({
+  form = inject(NonNullableFormBuilder).group({
     southConnector: [null as SouthConnectorDTO | null, Validators.required]
   });
 
-  constructor(
-    private modal: NgbActiveModal,
-    private fb: FormBuilder
-  ) {}
+  constructor(private modal: NgbActiveModal) {}
 
   /**
    * Prepares the component for creation.

--- a/frontend/src/app/north/north-list.component.ts
+++ b/frontend/src/app/north/north-list.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, inject, OnInit } from '@angular/core';
 import { TranslateModule } from '@ngx-translate/core';
 import { debounceTime, distinctUntilChanged, switchMap, tap } from 'rxjs';
 import { ConfirmationService } from '../shared/confirmation.service';
@@ -43,7 +43,7 @@ export class NorthListComponent implements OnInit {
   displayedNorths: Page<NorthConnectorDTO> = emptyPage();
   states = new Map<string, ObservableState>();
 
-  searchForm = this.fb.group({
+  searchForm = inject(NonNullableFormBuilder).group({
     name: [null as string | null]
   });
 
@@ -56,8 +56,7 @@ export class NorthListComponent implements OnInit {
     private confirmationService: ConfirmationService,
     private notificationService: NotificationService,
     private modalService: ModalService,
-    private northConnectorService: NorthConnectorService,
-    private fb: NonNullableFormBuilder
+    private northConnectorService: NorthConnectorService
   ) {}
 
   ngOnInit() {

--- a/frontend/src/app/shared/datetimepicker/datetimepicker.component.ts
+++ b/frontend/src/app/shared/datetimepicker/datetimepicker.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewInit, Component, ContentChild, ElementRef, forwardRef, Input, OnInit, TemplateRef } from '@angular/core';
+import { AfterViewInit, Component, ContentChild, ElementRef, forwardRef, inject, Input, OnInit, TemplateRef } from '@angular/core';
 import { ControlValueAccessor, NG_VALIDATORS, NG_VALUE_ACCESSOR, NonNullableFormBuilder, Validator } from '@angular/forms';
 import { combineLatest } from 'rxjs';
 import { DateTime } from 'luxon';
@@ -67,16 +67,13 @@ export class DatetimepickerComponent implements OnInit, AfterViewInit, ControlVa
   @Input()
   timeZone = 'Europe/Paris';
 
-  dateCtrl = this.fb.control(null as LocalDate | null);
-  timeCtrl = this.fb.control(null as LocalTime | null);
+  dateCtrl = inject(NonNullableFormBuilder).control(null as LocalDate | null);
+  timeCtrl = inject(NonNullableFormBuilder).control(null as LocalTime | null);
 
   private onChange: (value: any) => void = () => {};
   private onTouched: () => void = () => {};
 
-  constructor(
-    private fb: NonNullableFormBuilder,
-    private element: ElementRef<HTMLElement>
-  ) {}
+  constructor(private element: ElementRef<HTMLElement>) {}
 
   registerOnChange(fn: any): void {
     this.onChange = fn;

--- a/frontend/src/app/shared/form/oib-scan-mode/oib-scan-mode.component.ts
+++ b/frontend/src/app/shared/form/oib-scan-mode/oib-scan-mode.component.ts
@@ -1,4 +1,4 @@
-import { Component, forwardRef, Input } from '@angular/core';
+import { Component, forwardRef, inject, Input } from '@angular/core';
 import { formDirectives } from '../../form-directives';
 
 import { ControlValueAccessor, NG_VALUE_ACCESSOR, NonNullableFormBuilder } from '@angular/forms';
@@ -19,12 +19,12 @@ export class OibScanModeComponent implements ControlValueAccessor {
   @Input() scanModes: Array<ScanModeDTO> = [];
   @Input() acceptSubscription = false;
   @Input() subscriptionOnly = false;
-  scanModeInputCtrl = this.fb.control(null as string | null);
+  scanModeInputCtrl = inject(NonNullableFormBuilder).control(null as string | null);
   disabled = false;
   onChange: (value: string) => void = () => {};
   onTouched = () => {};
 
-  constructor(private fb: NonNullableFormBuilder) {
+  constructor() {
     this.scanModeInputCtrl.valueChanges.subscribe(newValue => {
       this.onChange(newValue!);
     });

--- a/frontend/src/app/shared/multi-select/multi-select.component.spec.ts
+++ b/frontend/src/app/shared/multi-select/multi-select.component.spec.ts
@@ -1,8 +1,8 @@
 import { fakeAsync, TestBed, tick } from '@angular/core/testing';
 
 import { MultiSelectComponent } from './multi-select.component';
-import { Component } from '@angular/core';
-import { FormBuilder } from '@angular/forms';
+import { Component, inject } from '@angular/core';
+import { NonNullableFormBuilder } from '@angular/forms';
 import { ComponentTester, TestButton } from 'ngx-speculoos';
 import { MultiSelectOptionDirective } from './multi-select-option.directive';
 import { noAnimation } from '../test-utils';
@@ -45,7 +45,7 @@ class TestComponent {
     }
   ];
 
-  form = this.fb.group({
+  form = inject(NonNullableFormBuilder).group({
     users: [[] as Array<number | User>]
   });
   placeholder = '';
@@ -53,8 +53,6 @@ class TestComponent {
   changeEvent: Array<number> = [];
 
   byId = byIdComparisonFn;
-
-  constructor(private fb: FormBuilder) {}
 }
 
 class TestComponentTester extends ComponentTester<TestComponent> {

--- a/frontend/src/app/shared/save-button/save-button.component.spec.ts
+++ b/frontend/src/app/shared/save-button/save-button.component.spec.ts
@@ -1,9 +1,9 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { ObservableState, SaveButtonComponent } from './save-button.component';
 import { ComponentTester } from 'ngx-speculoos';
 import { fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { delay, of } from 'rxjs';
-import { FormBuilder, ReactiveFormsModule } from '@angular/forms';
+import { NonNullableFormBuilder, ReactiveFormsModule } from '@angular/forms';
 import { provideI18nTesting } from '../../../i18n/mock-i18n';
 
 @Component({
@@ -18,9 +18,9 @@ import { provideI18nTesting } from '../../../i18n/mock-i18n';
 class TestComponent {
   state = new ObservableState();
   save$ = of(null).pipe(delay(500), this.state.pendingUntilFinalization());
-  form = this.fb.group({ name: '' });
+  form = inject(NonNullableFormBuilder).group({ name: '' });
 
-  constructor(private fb: FormBuilder) {}
+  constructor() {}
 
   save() {
     this.save$.subscribe();

--- a/frontend/src/app/south/south-items/south-items.component.ts
+++ b/frontend/src/app/south/south-items/south-items.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { Component, EventEmitter, inject, Input, OnInit, Output } from '@angular/core';
 import { TranslateModule } from '@ngx-translate/core';
 import { SouthConnectorService } from '../../services/south-connector.service';
 import { ConfirmationService } from '../../shared/confirmation.service';
@@ -58,7 +58,10 @@ export class SouthItemsComponent implements OnInit {
   @Input() inMemory = false;
   @Input() maxInstantPerItem: boolean | null = null;
 
-  @Output() readonly inMemoryItems = new EventEmitter<{ items: Array<SouthConnectorItemDTO>; itemIdsToDelete: Array<string> }>();
+  @Output() readonly inMemoryItems = new EventEmitter<{
+    items: Array<SouthConnectorItemDTO>;
+    itemIdsToDelete: Array<string>;
+  }>();
 
   allItems: Array<SouthConnectorItemDTO> = [];
   itemIdsToDelete: Array<string> = [];
@@ -66,15 +69,14 @@ export class SouthItemsComponent implements OnInit {
   displayedItems: Page<SouthConnectorItemDTO> = emptyPage();
   displaySettings: Array<OibFormControl> = [];
 
-  searchControl = this.fb.control(null as string | null);
+  searchControl = inject(NonNullableFormBuilder).control(null as string | null);
 
   constructor(
     private confirmationService: ConfirmationService,
     private notificationService: NotificationService,
     private modalService: ModalService,
     private southConnectorService: SouthConnectorService,
-    private pipeProviderService: PipeProviderService,
-    private fb: NonNullableFormBuilder
+    private pipeProviderService: PipeProviderService
   ) {}
 
   ngOnInit() {

--- a/frontend/src/app/south/south-list.component.ts
+++ b/frontend/src/app/south/south-list.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, inject, OnInit } from '@angular/core';
 import { TranslateModule } from '@ngx-translate/core';
 import { SouthConnectorDTO } from '../../../../shared/model/south-connector.model';
 import { SouthConnectorService } from '../services/south-connector.service';
@@ -45,7 +45,7 @@ export class SouthListComponent implements OnInit {
   displayedSouths: Page<SouthConnectorDTO> = emptyPage();
   states = new Map<string, ObservableState>();
 
-  searchForm = this.fb.group({
+  searchForm = inject(NonNullableFormBuilder).group({
     name: [null as string | null]
   });
 
@@ -58,8 +58,7 @@ export class SouthListComponent implements OnInit {
     private confirmationService: ConfirmationService,
     private notificationService: NotificationService,
     private modalService: ModalService,
-    private southConnectorService: SouthConnectorService,
-    private fb: NonNullableFormBuilder
+    private southConnectorService: SouthConnectorService
   ) {}
 
   ngOnInit() {

--- a/frontend/src/app/user-settings/change-password-modal/change-password-modal.component.ts
+++ b/frontend/src/app/user-settings/change-password-modal/change-password-modal.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { NgbActiveModal, NgbCollapse } from '@ng-bootstrap/ng-bootstrap';
 import { AbstractControl, NonNullableFormBuilder, ValidationErrors, Validators } from '@angular/forms';
 import { NotificationService } from '../../shared/notification.service';
@@ -29,9 +29,9 @@ function samePasswordValidator(newPasswordForm: AbstractControl): ValidationErro
   standalone: true
 })
 export class ChangePasswordModalComponent {
-  form = this.fb.group({
+  form = inject(NonNullableFormBuilder).group({
     currentPassword: ['', Validators.required],
-    newPasswordForm: this.fb.group(
+    newPasswordForm: inject(NonNullableFormBuilder).group(
       {
         newPassword: ['', Validators.required],
         newPasswordConfirmation: ['', Validators.required]
@@ -42,7 +42,6 @@ export class ChangePasswordModalComponent {
   error = false;
 
   constructor(
-    private fb: NonNullableFormBuilder,
     private modal: NgbActiveModal,
     private notificationService: NotificationService,
     private userSettingsService: UserSettingsService

--- a/frontend/src/app/user-settings/edit-user-settings/edit-user-settings.component.ts
+++ b/frontend/src/app/user-settings/edit-user-settings/edit-user-settings.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { NonNullableFormBuilder, Validators } from '@angular/forms';
 import { Language, LANGUAGES, Timezone } from '../../../../../shared/model/types';
 import { Observable, of, switchMap, tap, timer } from 'rxjs';
@@ -23,6 +23,7 @@ declare namespace Intl {
 
   function supportedValuesOf(input: Key): string[];
 }
+
 @Component({
   selector: 'oib-edit-user-settings',
   templateUrl: './edit-user-settings.component.html',
@@ -31,7 +32,7 @@ declare namespace Intl {
   standalone: true
 })
 export class EditUserSettingsComponent {
-  form = this.fb.group({
+  form = inject(NonNullableFormBuilder).group({
     firstName: ['', [Validators.maxLength(50)]],
     lastName: ['', [Validators.maxLength(50)]],
     timezone: ['' as Timezone, Validators.required]
@@ -48,7 +49,6 @@ export class EditUserSettingsComponent {
   );
 
   constructor(
-    private fb: NonNullableFormBuilder,
     private modalService: ModalService,
     private userSettingsService: UserSettingsService,
     private notificationService: NotificationService,

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -18,7 +18,6 @@
     "importHelpers": true,
     "target": "ES2022",
     "module": "ES2022",
-    "useDefineForClassFields": false,
     "types": [
       "@angular/localize"
     ],


### PR DESCRIPTION
CLI v18.1 will no longer generates projects that use `useDefineForClassFields` so let's try to keep our codebase similar to the new defaults.