### PR TITLE
fix(backend): Fix folder creation for North/South Connectors and HistoryQuery

### DIFF
--- a/backend/src/engine/data-stream-engine.spec.ts
+++ b/backend/src/engine/data-stream-engine.spec.ts
@@ -53,16 +53,15 @@ describe('DataStreamEngine', () => {
   });
 
   it('it should start and stop', async () => {
-    (createFolder as jest.Mock)
-      .mockImplementationOnce(() => Promise.resolve())
-      .mockImplementationOnce(() => {
-        throw new Error('North error');
-      })
-      .mockImplementationOnce(() => Promise.resolve())
-      .mockImplementationOnce(() => {
-        throw new Error('South error');
-      });
+    (mockedNorth2.start as jest.Mock).mockImplementationOnce(() => {
+      throw new Error('North error');
+    });
+    (mockedSouth2.start as jest.Mock).mockImplementationOnce(() => {
+      throw new Error('South error');
+    });
 
+    mockedNorth2['settings']['enabled'] = true;
+    mockedSouth2['settings']['enabled'] = true;
     await engine.start([mockedNorth1, mockedNorth2], [mockedSouth1, mockedSouth2]);
 
     expect(engine.logger).toBeDefined();

--- a/backend/src/engine/data-stream-engine.ts
+++ b/backend/src/engine/data-stream-engine.ts
@@ -1,7 +1,7 @@
 import pino from 'pino';
 import NorthConnector from '../north/north-connector';
 import SouthConnector from '../south/south-connector';
-import { createFolder, filesExists } from '../service/utils';
+import { filesExists } from '../service/utils';
 import path from 'node:path';
 import fs from 'node:fs/promises';
 import { Instant } from '../../../shared/model/types';
@@ -155,8 +155,6 @@ export default class DataStreamEngine {
   }
 
   async createSouth<S extends SouthSettings, I extends SouthItemSettings>(south: SouthConnector<S, I>): Promise<void> {
-    const baseFolder = path.resolve(this.cacheFolder, `south-${south.settings.id}`);
-    await createFolder(baseFolder);
     this.southConnectors.set(south.settings.id, south);
     this.southConnectorMetrics.set(south.settings.id, new SouthConnectorMetricsService(south, this.southConnectorMetricsRepository));
   }
@@ -182,9 +180,6 @@ export default class DataStreamEngine {
   }
 
   async createNorth<N extends NorthSettings>(north: NorthConnector<N>): Promise<void> {
-    const baseFolder = path.resolve(this.cacheFolder, `north-${north.settings.id}`);
-    await createFolder(baseFolder);
-
     this.northConnectors.set(north.settings.id, north);
     this.northConnectorMetrics.set(north.settings.id, new NorthConnectorMetricsService(north, this.northConnectorMetricsRepository));
   }

--- a/backend/src/engine/history-query-engine.ts
+++ b/backend/src/engine/history-query-engine.ts
@@ -2,7 +2,7 @@ import pino from 'pino';
 import HistoryQuery from './history-query';
 import path from 'node:path';
 import fs from 'node:fs/promises';
-import { createFolder, filesExists } from '../service/utils';
+import { filesExists } from '../service/utils';
 import { HistoryQueryEntity } from '../model/histor-query.model';
 import { SouthItemSettings, SouthSettings } from '../../../shared/model/south-settings.model';
 import { NorthSettings } from '../../../shared/model/north-settings.model';
@@ -58,8 +58,6 @@ export default class HistoryQueryEngine {
   }
 
   async createHistoryQuery(historyQuery: HistoryQuery): Promise<void> {
-    const baseFolder = path.resolve(this.cacheFolder, `history-${historyQuery.settings.id}`);
-    await createFolder(baseFolder);
     this.historyQueryMetrics.set(
       historyQuery.settings.id,
       new HistoryQueryMetricsService(historyQuery, this.historyQueryMetricsRepository)

--- a/backend/src/engine/history-query.ts
+++ b/backend/src/engine/history-query.ts
@@ -50,7 +50,7 @@ export default class HistoryQuery {
     };
     const southFolder = path.resolve(this.baseFolder, 'south');
     await createFolder(southFolder);
-    this.south = this.southService.runSouth(southConfiguration, this.addContent.bind(this), southFolder, this.logger);
+    this.south = this.southService.runSouth(southConfiguration, this.addContent.bind(this), this.logger, southFolder);
     const northConfiguration: NorthConnectorEntity<NorthSettings> = {
       id: this.historyConfiguration.id,
       name: this.historyConfiguration.name,
@@ -63,7 +63,7 @@ export default class HistoryQuery {
     };
     const northFolder = path.resolve(this.baseFolder, 'north');
     await createFolder(northFolder);
-    this.north = this.northService.runNorth(northConfiguration, northFolder, this.logger);
+    this.north = this.northService.runNorth(northConfiguration, this.logger, northFolder);
 
     if (this.historyConfiguration.status !== 'RUNNING') {
       this.logger.trace(`History Query "${this.historyConfiguration.name}" not enabled`);

--- a/backend/src/service/north.service.spec.ts
+++ b/backend/src/service/north.service.spec.ts
@@ -73,7 +73,7 @@ describe('north service', () => {
   });
 
   it('should create North connector', () => {
-    const connector = service.runNorth(testData.north.list[0], 'myBaseFolder', logger);
+    const connector = service.runNorth(testData.north.list[0], logger, 'myBaseFolder');
     expect(connector).toBeDefined();
   });
 
@@ -88,8 +88,8 @@ describe('north service', () => {
           description: 'my test connector',
           type: 'another'
         } as NorthConnectorEntity<NorthSettings>,
-        'myBaseFolder',
-        logger
+        logger,
+        'myBaseFolder'
       );
     } catch (err) {
       error = err;

--- a/backend/src/service/oibus.service.ts
+++ b/backend/src/service/oibus.service.ts
@@ -76,7 +76,6 @@ export default class OIBusService {
       this.northService.findAll().map(element => {
         return this.northService.runNorth(
           this.northService.findById(element.id)!,
-          this.dataStreamEngine.baseFolder,
           this.dataStreamEngine.logger.child({ scopeType: 'north', scopeId: element.id, scopeName: element.name })
         );
       }),
@@ -84,21 +83,13 @@ export default class OIBusService {
         return this.southService.runSouth(
           this.southService.findById(element.id)!,
           this.dataStreamEngine.addContent.bind(this.dataStreamEngine),
-          this.dataStreamEngine.baseFolder,
           this.dataStreamEngine.logger.child({ scopeType: 'south', scopeId: element.id, scopeName: element.name })
         );
       })
     );
     await this.historyQueryEngine.start(
       this.historyQueryService.findAll().map(element => {
-        return new HistoryQuery(
-          this.historyQueryService.findById(element.id)!,
-          this.southService,
-          this.northService,
-          this.historyQueryRepository,
-          this.historyQueryEngine.baseFolder,
-          this.historyQueryEngine.logger.child({ scopeType: 'history-query', scopeId: element.id, scopeName: element.name })
-        );
+        return this.historyQueryService.runHistoryQuery(element);
       })
     );
 

--- a/backend/src/service/south.service.spec.ts
+++ b/backend/src/service/south.service.spec.ts
@@ -83,7 +83,7 @@ describe('south service', () => {
   });
 
   it('should create South connector', () => {
-    const connector = service.runSouth(testData.south.list[0], jest.fn(), 'myBaseFolder', logger);
+    const connector = service.runSouth(testData.south.list[0], jest.fn(), logger, 'myBaseFolder');
     expect(connector).toBeDefined();
   });
 
@@ -99,8 +99,8 @@ describe('south service', () => {
           type: 'another'
         } as SouthConnectorEntity<SouthSettings, SouthItemSettings>,
         jest.fn(),
-        'myBaseFolder',
-        logger
+        logger,
+        'myBaseFolder'
       );
     } catch (err) {
       error = err;

--- a/backend/src/tests/__mocks__/service/history-query-service.mock.ts
+++ b/backend/src/tests/__mocks__/service/history-query-service.mock.ts
@@ -2,6 +2,7 @@
  * Create a mock object for History Query Service
  */
 export default jest.fn().mockImplementation(() => ({
+  runHistoryQuery: jest.fn(),
   testNorth: jest.fn(),
   testSouth: jest.fn(),
   testSouthItem: jest.fn(),


### PR DESCRIPTION
Fixes issues regarding to folder creation

Note: I've added an additional `runHistoryQuery` method, which is kind of not needed in the way `runSouth` and `runNorth` are, but this way the creation and the way folders are managed are the same for every type of entity.