### PR TITLE
fix(backend,frontend): Fix history query metrics

### DIFF
--- a/backend/src/engine/history-query.ts
+++ b/backend/src/engine/history-query.ts
@@ -189,8 +189,8 @@ export default class HistoryQuery {
     }
     if (this.south) {
       this.south.connectedEvent.removeAllListeners();
-      this.south.metricsEvent.removeAllListeners();
       await this.south.stop(false);
+      this.south.metricsEvent.removeAllListeners();
     }
     if (this.north) {
       await this.north.stop(false);

--- a/backend/src/south/south-connector.ts
+++ b/backend/src/south/south-connector.ts
@@ -399,8 +399,12 @@ export default abstract class SouthConnector<T extends SouthSettings, I extends 
         // requests. For example only one hour if maxReadInterval is 3600 (in s)
         const startTimeFromCache = DateTime.fromISO(southCache.maxInstant).minus({ milliseconds: overlap }).toUTC().toISO()!;
         const intervals = generateIntervals(startTimeFromCache, endTime, throttling.maxReadInterval);
+        let numberOfIntervalsDone = 0;
+        if (startTime !== startTimeFromCache) {
+          numberOfIntervalsDone = generateIntervals(startTime, startTimeFromCache, throttling.maxReadInterval).length;
+        }
         this.logIntervals(intervals);
-        await this.queryIntervals(intervals, [item], southCache, startTimeFromCache, throttling.readDelay);
+        await this.queryIntervals(intervals, [item], southCache, startTimeFromCache, throttling.readDelay, numberOfIntervalsDone);
         if (index !== itemsToRead.length - 1) {
           await delay(throttling.readDelay);
         }
@@ -411,9 +415,13 @@ export default abstract class SouthConnector<T extends SouthSettings, I extends 
       // maxReadInterval will divide a huge request (for example 1 year of data) into smaller
       // requests. For example only one hour if maxReadInterval is 3600 (in s)
       const intervals = generateIntervals(startTimeFromCache, endTime, throttling.maxReadInterval);
+      let numberOfIntervalsDone = 0;
+      if (startTime !== startTimeFromCache) {
+        numberOfIntervalsDone = generateIntervals(startTime, startTimeFromCache, throttling.maxReadInterval).length;
+      }
       this.logIntervals(intervals);
 
-      await this.queryIntervals(intervals, itemsToRead, southCache, startTimeFromCache, throttling.readDelay);
+      await this.queryIntervals(intervals, itemsToRead, southCache, startTime, throttling.readDelay, numberOfIntervalsDone);
     }
     this.metricsEvent.emit('history-query-stop', {
       running: false
@@ -425,12 +433,13 @@ export default abstract class SouthConnector<T extends SouthSettings, I extends 
     intervals: Array<Interval>,
     items: Array<SouthConnectorItemEntity<I>>,
     southCache: SouthCache,
-    startTimeFromCache: Instant,
-    readDelay: number
+    startTime: Instant,
+    readDelay: number,
+    numberOfIntervalsDone: number
   ) {
     this.metricsEvent.emit('history-query-start', {
       running: true,
-      intervalProgress: this.calculateIntervalProgress(intervals, 0, startTimeFromCache)
+      intervalProgress: this.calculateIntervalProgress(intervals, 0, startTime)
     });
 
     for (const [index, interval] of intervals.entries()) {
@@ -450,11 +459,11 @@ export default abstract class SouthConnector<T extends SouthSettings, I extends 
 
       this.metricsEvent.emit('history-query-interval', {
         running: true,
-        intervalProgress: this.calculateIntervalProgress(intervals, index, startTimeFromCache),
+        intervalProgress: this.calculateIntervalProgress(intervals, index, startTime),
         currentIntervalStart: interval.start,
         currentIntervalEnd: interval.end,
-        currentIntervalNumber: index + 1,
-        numberOfIntervals: intervals.length
+        currentIntervalNumber: numberOfIntervalsDone + index + 1,
+        numberOfIntervals: numberOfIntervalsDone + intervals.length
       });
 
       if (this.stopping) {

--- a/backend/src/tests/utils/test-data.ts
+++ b/backend/src/tests/utils/test-data.ts
@@ -56,7 +56,7 @@ const constants = {
     DATE_2: '2020-03-20T00:00:00.000Z',
     DATE_3: '2020-03-25T00:00:00.000Z'
   }
-};
+} as const;
 
 const ipFilterCommandDTO: IPFilterCommandDTO = {
   address: '1.1.1.1',

--- a/frontend/src/app/history-query/history-query-detail/history-query-detail.component.ts
+++ b/frontend/src/app/history-query/history-query-detail/history-query-detail.component.ts
@@ -168,6 +168,10 @@ export class HistoryQueryDetailComponent implements OnInit, OnDestroy {
       if (event && event.data) {
         this.historyMetrics = JSON.parse(event.data);
         this.cd.detectChanges();
+
+        if (this.historyQuery && this.historyQueryFinishedByMetrics) {
+          this.historyQuery.status = 'FINISHED';
+        }
       }
     });
   }
@@ -233,5 +237,17 @@ export class HistoryQueryDetailComponent implements OnInit, OnDestroy {
     const modalRef = this.modalService.open(TestConnectionResultModalComponent);
     const component: TestConnectionResultModalComponent = modalRef.componentInstance;
     component.runHistoryQueryTest(type, command, this.historyQuery!.id);
+  }
+
+  get historyQueryFinishedByMetrics() {
+    if (!this.historyMetrics || this.historyMetrics.historyMetrics.intervalProgress !== 1) {
+      return false;
+    }
+
+    const valueProgress = this.historyMetrics.north.numberOfValuesSent / this.historyMetrics.south.numberOfValuesRetrieved;
+    const fileProgress = this.historyMetrics.north.numberOfFilesSent / this.historyMetrics.south.numberOfFilesRetrieved;
+
+    const percentage = valueProgress > 0 ? valueProgress : fileProgress;
+    return percentage === 1;
   }
 }


### PR DESCRIPTION
- fixes south metrics so it keeps track of the progress of the full interval
- fixes issues caused by metrics event order
- adds frontend functionality to restart history query after finish

Fixes: #3512 