### PR TITLE
fix(north): do not log an error when metadata folder does not exists …

### DIFF
--- a/backend/src/service/cache/cleanup.service.spec.ts
+++ b/backend/src/service/cache/cleanup.service.spec.ts
@@ -360,7 +360,7 @@ describe('CacheService', () => {
     });
     const result = await service['readCacheMetadataFiles']('folder');
     expect(result).toEqual([]);
-    expect(logger.error).toHaveBeenCalledWith(`Could not read cache metadata files from folder "folder": read error`);
+    expect(logger.debug).toHaveBeenCalledWith(`Could not read cache metadata files from folder "folder": read error`);
   });
 
   it('should read cache metadata files', async () => {

--- a/backend/src/service/cache/cleanup.service.ts
+++ b/backend/src/service/cache/cleanup.service.ts
@@ -186,7 +186,7 @@ export default class CleanupService {
     try {
       filenames = await fs.readdir(path.join(folderPath, METADATA_SUB_FOLDER));
     } catch (error: unknown) {
-      this.logger.error(`Could not read cache metadata files from folder "${folderPath}": ${(error as Error).message}`);
+      this.logger.debug(`Could not read cache metadata files from folder "${folderPath}": ${(error as Error).message}`);
       return [];
     }
 


### PR DESCRIPTION
…because north has not been started yet