### PR TITLE
Sort by Types or Names South / North / History queries #4284

### DIFF
--- a/frontend/src/app/history-query/history-query-list.component.html
+++ b/frontend/src/app/history-query/history-query-list.component.html
@@ -51,8 +51,26 @@
           <thead>
             <tr>
               <th style="width: 3rem"></th>
-              <th translate="history-query.name"></th>
-              <th translate="history-query.interval" style="width: 22rem"></th>
+              <th>
+                <button
+                  type="button"
+                  style="background: none; border: none; font-weight: bold; color: inherit"
+                  (click)="toggleSort('name')"
+                >
+                  <span translate="history-query.name" class="me-2"></span>
+                  <span class="fa {{ getSortIcon('name') }}"></span>
+                </button>
+              </th>
+              <th style="width: 22rem">
+                <button
+                  type="button"
+                  style="background: none; border: none; font-weight: bold; color: inherit"
+                  (click)="toggleSort('interval')"
+                >
+                  <span translate="history-query.interval" class="me-2"></span>
+                  <span class="fa {{ getSortIcon('interval') }}"></span>
+                </button>
+              </th>
               <th translate="history-query.description"></th>
               <th></th>
             </tr>

--- a/frontend/src/app/north/north-list.component.html
+++ b/frontend/src/app/north/north-list.component.html
@@ -49,8 +49,26 @@
           <thead>
             <tr>
               <th style="width: 3rem"></th>
-              <th translate="north.name"></th>
-              <th translate="north.type" style="width: 9rem"></th>
+              <th>
+                <button
+                  type="button"
+                  style="background: none; border: none; font-weight: bold; color: inherit"
+                  (click)="toggleSort('name')"
+                >
+                  <span translate="north.name" class="me-2"></span>
+                  <span class="fa {{ getSortIcon('name') }}"></span>
+                </button>
+              </th>
+              <th style="width: 9rem">
+                <button
+                  type="button"
+                  style="background: none; border: none; font-weight: bold; color: inherit"
+                  (click)="toggleSort('type')"
+                >
+                  <span translate="north.type" class="me-2"></span>
+                  <span class="fa {{ getSortIcon('type') }}"></span>
+                </button>
+              </th>
               <th translate="north.description"></th>
               <th></th>
             </tr>

--- a/frontend/src/app/south/south-list.component.html
+++ b/frontend/src/app/south/south-list.component.html
@@ -49,8 +49,26 @@
           <thead>
             <tr>
               <th style="width: 3rem"></th>
-              <th translate="south.name"></th>
-              <th translate="south.type" style="width: 9rem"></th>
+              <th>
+                <button
+                  type="button"
+                  style="background: none; border: none; font-weight: bold; color: inherit"
+                  (click)="toggleSort('name')"
+                >
+                  <span translate="south.name" class="me-2"></span>
+                  <span class="fa {{ getSortIcon('name') }}"></span>
+                </button>
+              </th>
+              <th style="width: 9rem">
+                <button
+                  type="button"
+                  style="background: none; border: none; font-weight: bold; color: inherit"
+                  (click)="toggleSort('type')"
+                >
+                  <span translate="south.type" class="me-2"></span>
+                  <span class="fa {{ getSortIcon('type') }}"></span>
+                </button>
+              </th>
               <th translate="south.description"></th>
               <th></th>
             </tr>


### PR DESCRIPTION
UI before the changes:
<img width="1399" height="392" alt="image" src="https://github.com/user-attachments/assets/5027e2b8-42b5-45e8-a4df-6a16ae69e2fa" />

UI after the changes:
<img width="1400" height="421" alt="image" src="https://github.com/user-attachments/assets/1daa6b2a-2d9b-4c05-a123-49565def6142" />
<img width="1397" height="403" alt="image" src="https://github.com/user-attachments/assets/3072b6f4-78b5-4591-89db-d4c470f908f1" />
<img width="1399" height="407" alt="image" src="https://github.com/user-attachments/assets/54a58408-492f-480c-806d-725e8dca07f9" />


Closes #4284 