### PR TITLE
chore: enable renovate minimum release age for npm

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,6 +1,7 @@
 {
   "extends": [
     "config:base",
+    "security:minimumReleaseAgeNpm",
     ":semanticCommitTypeAll(chore)"
   ],
   "baseBranches": ["main"],


### PR DESCRIPTION
Enable Renovate's npm minimum release age preset to avoid lockfile updates breaking when pnpm enforces supply-chain release-age policies.