### PR TITLE
Improve History Query south progress monitoring for multi-item connectors #4829

### DIFF
--- a/backend/shared/model/engine.model.ts
+++ b/backend/shared/model/engine.model.ts
@@ -1552,7 +1552,92 @@ export interface HistoryQueryMetrics {
      * @example 2
      */
     numberOfIntervals: number;
+
+    /**
+     * The name of the item currently being queried. Only set for connectors that query items one
+     * at a time (SOUTH_SINGLE_ITEMS).
+     * @example "item1"
+     */
+    itemName?: string;
+
+    /**
+     * The 1-based index of the item currently being queried, among the run's enabled items. Only
+     * set for connectors that query items one at a time (SOUTH_SINGLE_ITEMS).
+     * @example 3
+     */
+    currentItemNumber?: number;
+
+    /**
+     * The total number of enabled items in the run. Only set for connectors that query items one
+     * at a time (SOUTH_SINGLE_ITEMS).
+     * @example 10
+     */
+    numberOfItems?: number;
+
+    /**
+     * The progress of the current item's own interval list as a fraction [0, 1], scoped to that
+     * item only (not ratcheted, unlike `intervalProgress`). Only set for connectors that query
+     * items one at a time (SOUTH_SINGLE_ITEMS).
+     * @example 0.25
+     */
+    itemIntervalProgress?: number;
+
+    /**
+     * The 1-based index of the current lead's own interval, within its own interval list (raw, not
+     * ratcheted) — same source data as `itemIntervalProgress`, surfaced raw for display. Only set
+     * for connectors that query items one at a time (SOUTH_SINGLE_ITEMS).
+     * @example 12
+     */
+    itemIntervalNumber?: number;
+
+    /**
+     * The total number of intervals in the current lead's own interval list (raw, not ratcheted).
+     * Only set for connectors that query items one at a time (SOUTH_SINGLE_ITEMS).
+     * @example 34
+     */
+    itemNumberOfIntervals?: number;
+
+    /**
+     * The runtime status of every item in the run. Only set for connectors that query items one at
+     * a time (SOUTH_SINGLE_ITEMS).
+     */
+    itemsStatus?: Array<HistoryQueryItemStatus>;
   };
+}
+
+/**
+ * Runtime status of a single item within a history query run, for progress-monitoring UIs.
+ */
+export interface HistoryQueryItemStatus {
+  /**
+   * The item ID.
+   * @example "e4f7e3f0-1234-4567-8901-abcdef123456"
+   */
+  itemId: string;
+
+  /**
+   * The item name.
+   * @example "item1"
+   */
+  itemName: string;
+
+  /**
+   * The item's runtime status within the run.
+   * @example "running"
+   */
+  status: 'pending' | 'running' | 'done';
+
+  /**
+   * The timestamp of the last value retrieved for this item.
+   * @example "2023-01-01T00:00:00Z"
+   */
+  lastValueTimestamp: Instant | null;
+
+  /**
+   * The number of records (values or files) retrieved for this item so far.
+   * @example 42
+   */
+  recordsCount: number;
 }
 
 /**

--- a/backend/shared/model/history-query.model.ts
+++ b/backend/shared/model/history-query.model.ts
@@ -132,6 +132,23 @@ export interface HistoryQueryLightDTO extends BaseEntity {
    * @example "aws-s3"
    */
   northType: OIBusNorthType;
+
+  /**
+   * The 1-based index of the item currently being queried, among the run's enabled items. Only
+   * set while the history query is actively running on a connector that queries items one at a
+   * time (SOUTH_SINGLE_ITEMS).
+   *
+   * @example 3
+   */
+  currentItemNumber?: number;
+
+  /**
+   * The total number of enabled items in the run. Only set while the history query is actively
+   * running on a connector that queries items one at a time (SOUTH_SINGLE_ITEMS).
+   *
+   * @example 10
+   */
+  numberOfItems?: number;
 }
 
 export interface HistoryQueryCommonDTO {

--- a/backend/src/engine/history-query.spec.ts
+++ b/backend/src/engine/history-query.spec.ts
@@ -336,6 +336,9 @@ describe('HistoryQuery enabled', () => {
     });
     assert.ok(emitMock.mock.calls.some(c => c.arguments[0] === 'south-history-query-interval'));
 
+    mockedSouth1Mock.metricsEvent.emit('history-query-item-start', { itemName: 'item1', currentItemNumber: 1, numberOfItems: 2 });
+    assert.ok(emitMock.mock.calls.some(c => c.arguments[0] === 'south-history-query-item'));
+
     // 'south-history-query-start'/'south-history-query-stop' are emitted directly by HistoryQuery
     // itself (not forwarded from a south metricsEvent) around the historyQueryHandler run.
     mockedSouth1Mock.connectedEvent.emit('connected');
@@ -378,7 +381,9 @@ describe('HistoryQuery enabled', () => {
       currentIntervalStart: '2020-03-15T00:00:00.000Z',
       currentIntervalEnd: '2020-03-15T00:30:00.000Z',
       currentIntervalNumber: 0,
-      numberOfIntervals: 4
+      numberOfIntervals: 4,
+      itemIntervalNumber: undefined,
+      itemNumberOfIntervals: undefined
     });
 
     // Exactly covers the first two slots: 2 of 4 done, 50% progress.
@@ -394,7 +399,9 @@ describe('HistoryQuery enabled', () => {
       currentIntervalStart: '2020-03-15T00:00:00.000Z',
       currentIntervalEnd: '2020-03-15T02:00:00.000Z',
       currentIntervalNumber: 2,
-      numberOfIntervals: 4
+      numberOfIntervals: 4,
+      itemIntervalNumber: undefined,
+      itemNumberOfIntervals: undefined
     });
 
     // Covers the whole range: 4 of 4 done, 100% progress.
@@ -410,10 +417,181 @@ describe('HistoryQuery enabled', () => {
       currentIntervalStart: '2020-03-15T03:00:00.000Z',
       currentIntervalEnd: '2020-03-15T04:00:00.000Z',
       currentIntervalNumber: 4,
-      numberOfIntervals: 4
+      numberOfIntervals: 4,
+      itemIntervalNumber: undefined,
+      itemNumberOfIntervals: undefined
     });
 
     await progressHistoryQuery.stop();
+  });
+
+  it('should never let intervalProgress regress when a later item reports an earlier currentIntervalEnd (sawtooth regression)', async () => {
+    // Same fixed, whole-range interval breakdown as the previous test.
+    const fixedIntervals = [
+      { start: '2020-03-15T00:00:00.000Z', end: '2020-03-15T01:00:00.000Z' },
+      { start: '2020-03-15T01:00:00.000Z', end: '2020-03-15T02:00:00.000Z' },
+      { start: '2020-03-15T02:00:00.000Z', end: '2020-03-15T03:00:00.000Z' },
+      { start: '2020-03-15T03:00:00.000Z', end: '2020-03-15T04:00:00.000Z' }
+    ];
+    utilsExports.generateIntervals = mock.fn(() => fixedIntervals);
+    const progressHistoryQuery = new HistoryQuery(testData.historyQueries.list[0], mockedNorth1, mockedSouth1);
+    const emitMock = mock.method(progressHistoryQuery.metricsEvent, 'emit');
+    mockedSouth1Mock.historyQueryHandler = mock.fn(async () => undefined);
+
+    await progressHistoryQuery.start();
+
+    // First item's own window reaches the end of the third fixed slot: 3 of 4 done, 75% progress.
+    mockedSouth1Mock.metricsEvent.emit('history-query-interval', {
+      currentIntervalStart: '2020-03-15T02:00:00.000Z',
+      currentIntervalEnd: '2020-03-15T03:00:00.000Z',
+      itemName: 'item1',
+      currentItemNumber: 1,
+      numberOfItems: 2
+    });
+    let call = emitMock.mock.calls.find(c => c.arguments[0] === 'south-history-query-interval')!;
+    assert.deepStrictEqual(call.arguments[1], {
+      running: true,
+      intervalProgress: 0.75,
+      currentIntervalStart: '2020-03-15T02:00:00.000Z',
+      currentIntervalEnd: '2020-03-15T03:00:00.000Z',
+      currentIntervalNumber: 3,
+      numberOfIntervals: 4,
+      itemName: 'item1',
+      currentItemNumber: 1,
+      numberOfItems: 2,
+      itemIntervalNumber: undefined,
+      itemNumberOfIntervals: undefined
+    });
+    const firstIntervalProgress = (call.arguments[1] as { intervalProgress: number }).intervalProgress;
+    const firstCurrentIntervalNumber = (call.arguments[1] as { currentIntervalNumber: number }).currentIntervalNumber;
+
+    // The run moves on to a second item, whose own window starts (and ends) well before where the
+    // first item left off — without the ratchet this would make the overall progress drop back down.
+    emitMock.mock.resetCalls();
+    mockedSouth1Mock.metricsEvent.emit('history-query-interval', {
+      currentIntervalStart: '2020-03-15T00:00:00.000Z',
+      currentIntervalEnd: '2020-03-15T00:30:00.000Z',
+      itemName: 'item2',
+      currentItemNumber: 2,
+      numberOfItems: 2
+    });
+    call = emitMock.mock.calls.find(c => c.arguments[0] === 'south-history-query-interval')!;
+    const secondPayload = call.arguments[1] as { intervalProgress: number; currentIntervalNumber: number };
+
+    // The overall (ratcheted) progress must not decrease...
+    assert.ok(secondPayload.intervalProgress >= firstIntervalProgress);
+    assert.ok(secondPayload.currentIntervalNumber >= firstCurrentIntervalNumber);
+    assert.strictEqual(secondPayload.intervalProgress, firstIntervalProgress);
+    assert.strictEqual(secondPayload.currentIntervalNumber, firstCurrentIntervalNumber);
+    // ...even though this event's own currentIntervalEnd genuinely regressed.
+    assert.deepStrictEqual(call.arguments[1], {
+      running: true,
+      intervalProgress: 0.75,
+      currentIntervalStart: '2020-03-15T00:00:00.000Z',
+      currentIntervalEnd: '2020-03-15T00:30:00.000Z',
+      currentIntervalNumber: 3,
+      numberOfIntervals: 4,
+      itemName: 'item2',
+      currentItemNumber: 2,
+      numberOfItems: 2,
+      itemIntervalNumber: undefined,
+      itemNumberOfIntervals: undefined
+    });
+
+    await progressHistoryQuery.stop();
+  });
+
+  it('should seed maxIntervalEndReached and itemsStatus from the south connector cache snapshot on start (restart resume)', async () => {
+    mockedSouth1Mock.getHistoryQuerySnapshot = mock.fn(() => ({
+      items: [
+        { itemId: 'historyQueryItem1', itemName: 'item1', trackedInstant: '2020-03-17T00:00:00.000Z', queryTime: null, value: null },
+        {
+          itemId: 'historyQueryItem2',
+          itemName: 'item2',
+          trackedInstant: testData.historyQueries.list[0].queryTimeRange.endTime,
+          queryTime: null,
+          value: null
+        }
+      ]
+    }));
+    mockedSouth1Mock.historyQueryHandler = mock.fn(async () => undefined);
+
+    await historyQuery.start();
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const internal = historyQuery as any;
+    // The higher of the two seeded trackedInstants (item2's, which equals the configured end time).
+    assert.strictEqual(internal.maxIntervalEndReached, testData.historyQueries.list[0].queryTimeRange.endTime);
+    assert.deepStrictEqual(Array.from(internal.itemsStatus.values()), [
+      {
+        itemId: 'historyQueryItem1',
+        itemName: 'item1',
+        status: 'pending',
+        lastValueTimestamp: '2020-03-17T00:00:00.000Z',
+        recordsCount: 0
+      },
+      {
+        itemId: 'historyQueryItem2',
+        itemName: 'item2',
+        status: 'done',
+        lastValueTimestamp: testData.historyQueries.list[0].queryTimeRange.endTime,
+        recordsCount: 0
+      }
+    ]);
+  });
+
+  it('should relay history-query-item-start to south-history-query-item, marking items running/done and updating recordsCount', async () => {
+    mockedSouth1Mock.getHistoryQuerySnapshot = mock.fn(() => ({
+      items: [
+        { itemId: 'historyQueryItem1', itemName: 'item1', trackedInstant: null, queryTime: null, value: null },
+        { itemId: 'historyQueryItem2', itemName: 'item2', trackedInstant: null, queryTime: null, value: null }
+      ]
+    }));
+    mockedSouth1Mock.historyQueryHandler = mock.fn(async () => undefined);
+    const emitMock = mock.method(historyQuery.metricsEvent, 'emit');
+
+    await historyQuery.start();
+
+    mockedSouth1Mock.metricsEvent.emit('history-query-item-start', { itemName: 'item1', currentItemNumber: 1, numberOfItems: 2 });
+    let call = emitMock.mock.calls.find(c => c.arguments[0] === 'south-history-query-item')!;
+    assert.deepStrictEqual(call.arguments[1], {
+      itemName: 'item1',
+      currentItemNumber: 1,
+      numberOfItems: 2,
+      itemsStatus: [
+        { itemId: 'historyQueryItem1', itemName: 'item1', status: 'running', lastValueTimestamp: null, recordsCount: 0 },
+        { itemId: 'historyQueryItem2', itemName: 'item2', status: 'pending', lastValueTimestamp: null, recordsCount: 0 }
+      ]
+    });
+
+    // Values retrieved while item1 is running are attributed to item1.
+    mockedSouth1Mock.metricsEvent.emit('add-values', {
+      numberOfValuesRetrieved: 3,
+      lastValueRetrieved: { pointId: 'point1', timestamp: '2020-03-16T00:00:00.000Z', data: {} }
+    });
+
+    // The run moves on to item2: item1 is marked done, item2 becomes running.
+    emitMock.mock.resetCalls();
+    mockedSouth1Mock.metricsEvent.emit('history-query-item-start', { itemName: 'item2', currentItemNumber: 2, numberOfItems: 2 });
+    call = emitMock.mock.calls.find(c => c.arguments[0] === 'south-history-query-item')!;
+    assert.deepStrictEqual(call.arguments[1], {
+      itemName: 'item2',
+      currentItemNumber: 2,
+      numberOfItems: 2,
+      itemsStatus: [
+        { itemId: 'historyQueryItem1', itemName: 'item1', status: 'done', lastValueTimestamp: '2020-03-16T00:00:00.000Z', recordsCount: 3 },
+        { itemId: 'historyQueryItem2', itemName: 'item2', status: 'running', lastValueTimestamp: null, recordsCount: 0 }
+      ]
+    });
+
+    // A retrieved file while item2 is running increments its recordsCount without touching item1.
+    mockedSouth1Mock.metricsEvent.emit('add-file', { lastFileRetrieved: 'file1.csv' });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const internal = historyQuery as any;
+    assert.deepStrictEqual(Array.from(internal.itemsStatus.values()), [
+      { itemId: 'historyQueryItem1', itemName: 'item1', status: 'done', lastValueTimestamp: '2020-03-16T00:00:00.000Z', recordsCount: 3 },
+      { itemId: 'historyQueryItem2', itemName: 'item2', status: 'running', lastValueTimestamp: null, recordsCount: 1 }
+    ]);
   });
 
   it('should get north cache sizes', async () => {

--- a/backend/src/engine/history-query.ts
+++ b/backend/src/engine/history-query.ts
@@ -10,9 +10,11 @@ import {
   CacheSearchResult,
   DataFolderType,
   FileCacheContent,
+  HistoryQueryItemStatus,
   OIBusTimeValue
 } from '../../shared/model/engine.model';
 import { HistoryQueryEntity } from '../model/histor-query.model';
+import { SouthConnectorItemEntity } from '../model/south-connector.model';
 import { EventEmitter } from 'node:events';
 import { Instant } from '../model/types';
 import { ScanMode } from '../model/scan-mode.model';
@@ -23,6 +25,13 @@ import { loggerService } from '../service/logger/logger.service';
 import { Interval } from '../../shared/model/types';
 
 const FINISH_INTERVAL = 5000;
+
+// Per-item runtime status is tracked across a history query run, for progress-monitoring UIs, using
+// the canonical `HistoryQueryItemStatus` shape from `../../shared/model/engine.model` (shared with
+// the frontend). It's seeded at `start()` from the south connector's persisted cache snapshot
+// (`getHistoryQuerySnapshot`) so a resumed run reflects the correct starting point instead of
+// looking like it starts from scratch, then kept live via the `history-query-item-start` /
+// `add-values` / `add-file` / `south-history-query-stop` events.
 
 /** Events published by a History Query's {@link HistoryQuery.metricsEvent} (relayed from its north/south). */
 export interface HistoryMetricsEvents {
@@ -37,13 +46,35 @@ export interface HistoryMetricsEvents {
   'south-history-query-start': { running: boolean };
   'south-history-query-interval': {
     running: boolean;
+    // Ratcheted progress against the whole, fixed configured time range — never regresses, even
+    // when a multi-item connector moves on to an item whose own window starts well before where
+    // the previous item left off.
     intervalProgress: number;
     currentIntervalStart: Instant;
     currentIntervalEnd: Instant;
     currentIntervalNumber: number;
     numberOfIntervals: number;
+    // Item identity, only set for SOUTH_SINGLE_ITEMS connectors (items queried one at a time).
+    itemName?: string;
+    currentItemNumber?: number;
+    numberOfItems?: number;
+    // Progress scoped to the CURRENT item's own interval list (raw, not ratcheted) — resets to
+    // (close to) 0 for every new item, unlike `intervalProgress`.
+    itemIntervalProgress?: number;
+    // Raw pass-through of the current lead's own interval index/total (not ratcheted), for display
+    // purposes (e.g. "12 / 34"). Same source data as `itemIntervalProgress`, just surfaced raw.
+    itemIntervalNumber?: number;
+    itemNumberOfIntervals?: number;
   };
   'south-history-query-stop': { running: boolean };
+  // Emitted once per item (SOUTH_SINGLE_ITEMS connectors only), when the run moves to a new item —
+  // carries the full up-to-date itemsStatus array so the UI never needs to reconstruct it itself.
+  'south-history-query-item': {
+    itemName: string;
+    currentItemNumber: number;
+    numberOfItems: number;
+    itemsStatus: Array<HistoryQueryItemStatus>;
+  };
   'south-add-values': { numberOfValuesRetrieved: number; lastValueRetrieved: OIBusTimeValue | null };
   'south-add-file': { lastFileRetrieved: string };
 }
@@ -53,6 +84,13 @@ export default class HistoryQuery {
   private stopping = false;
   private logger!: ILogger;
   private intervals: Array<Interval> = [];
+  // Ratcheted high-water mark of `currentIntervalEnd` seen so far. Never allowed to regress — see
+  // `computeCurrentProgress`. Seeded at `start()` from the persisted south cache so a resumed run
+  // doesn't visually restart from zero.
+  private maxIntervalEndReached: Instant | null = null;
+  // Per-item runtime status, keyed by itemId. Seeded at `start()`, then kept live via item-start /
+  // add-values / add-file / stop events.
+  private itemsStatus: Map<string, HistoryQueryItemStatus> = new Map<string, HistoryQueryItemStatus>();
 
   public metricsEvent: TypedEventEmitter<HistoryMetricsEvents> = new TypedEventEmitter<HistoryMetricsEvents>();
   public finishEvent: EventEmitter = new EventEmitter();
@@ -105,38 +143,26 @@ export default class HistoryQuery {
     });
     await this.north.start();
 
+    const southItems = this.buildSouthItems();
+    this.seedItemsStatus(southItems);
+
     this.south.connectedEvent.on('connected', () => {
       this.metricsEvent.emit('south-history-query-start', { running: true });
       this.south!.historyQueryHandler(
-        this.historyConfiguration.items
-          .filter(item => item.enabled)
-          .map(item => ({
-            ...item,
-            group: null,
-            syncWithGroup: false,
-            scanMode: {
-              id: 'history',
-              name: 'history',
-              description: '',
-              type: 'cron',
-              cron: '',
-              interval: null,
-              activationWindow: null,
-              createdBy: '',
-              updatedBy: '',
-              createdAt: '',
-              updatedAt: ''
-            },
-            maxReadInterval: this.historyConfiguration.queryTimeRange.maxReadInterval,
-            readDelay: this.historyConfiguration.queryTimeRange.readDelay,
-            startTimeOffset: null,
-            endTimeOffset: null,
-            recoveryStrategy: null
-          })),
+        southItems,
         this.historyConfiguration.queryTimeRange.startTime,
         this.historyConfiguration.queryTimeRange.endTime
       )
         .then(() => {
+          // The run completed normally: whichever item was still marked 'running' is done. If we're
+          // in the middle of stopping, leave it as 'running' so a resumed run picks it back up.
+          if (!this.stopping) {
+            for (const status of this.itemsStatus.values()) {
+              if (status.status === 'running') {
+                status.status = 'done';
+              }
+            }
+          }
           this.metricsEvent.emit('south-history-query-stop', { running: false });
         })
         .catch(async error => {
@@ -161,16 +187,122 @@ export default class HistoryQuery {
     this.south.metricsEvent.on('run-end', (data: { lastRunDuration: number }) => {
       this.metricsEvent.emit('south-run-end', data);
     });
-    this.south.metricsEvent.on('history-query-interval', (data: { currentIntervalStart: Instant; currentIntervalEnd: Instant }) => {
-      this.metricsEvent.emit('south-history-query-interval', this.computeCurrentProgress(data));
-    });
+    this.south.metricsEvent.on(
+      'history-query-interval',
+      (data: {
+        currentIntervalStart: Instant;
+        currentIntervalEnd: Instant;
+        currentIntervalNumber?: number;
+        numberOfIntervals?: number;
+        itemName?: string;
+        currentItemNumber?: number;
+        numberOfItems?: number;
+      }) => {
+        this.metricsEvent.emit('south-history-query-interval', this.computeCurrentProgress(data));
+      }
+    );
+    this.south.metricsEvent.on(
+      'history-query-item-start',
+      (data: { itemName: string; currentItemNumber: number; numberOfItems: number }) => {
+        for (const status of this.itemsStatus.values()) {
+          if (status.status === 'running') {
+            status.status = 'done';
+          }
+        }
+        const currentStatus = Array.from(this.itemsStatus.values()).find(status => status.itemName === data.itemName);
+        if (currentStatus) {
+          currentStatus.status = 'running';
+        }
+        this.metricsEvent.emit('south-history-query-item', {
+          itemName: data.itemName,
+          currentItemNumber: data.currentItemNumber,
+          numberOfItems: data.numberOfItems,
+          itemsStatus: Array.from(this.itemsStatus.values())
+        });
+      }
+    );
     this.south.metricsEvent.on('add-values', (data: { numberOfValuesRetrieved: number; lastValueRetrieved: OIBusTimeValue | null }) => {
+      this.updateRunningItemStatus(data.numberOfValuesRetrieved, data.lastValueRetrieved?.timestamp ?? null);
       this.metricsEvent.emit('south-add-values', data);
     });
     this.south.metricsEvent.on('add-file', (data: { lastFileRetrieved: string }) => {
+      this.updateRunningItemStatus(1, null);
       this.metricsEvent.emit('south-add-file', data);
     });
     await this.south.start();
+  }
+
+  /**
+   * Build the SouthConnectorItemEntity-shaped item list `historyQueryHandler` / `getHistoryQuerySnapshot`
+   * expect, from the history query's own configured items — adding the synthetic 'history' scan mode
+   * and the query-time-range-derived interval settings every history query item shares.
+   */
+  private buildSouthItems(): Array<SouthConnectorItemEntity<SouthItemSettings>> {
+    return this.historyConfiguration.items
+      .filter(item => item.enabled)
+      .map(item => ({
+        ...item,
+        group: null,
+        syncWithGroup: false,
+        scanMode: {
+          id: 'history',
+          name: 'history',
+          description: '',
+          type: 'cron',
+          cron: '',
+          interval: null,
+          activationWindow: null,
+          createdBy: '',
+          updatedBy: '',
+          createdAt: '',
+          updatedAt: ''
+        },
+        maxReadInterval: this.historyConfiguration.queryTimeRange.maxReadInterval,
+        readDelay: this.historyConfiguration.queryTimeRange.readDelay,
+        startTimeOffset: null,
+        endTimeOffset: null,
+        recoveryStrategy: null
+      }));
+  }
+
+  /**
+   * Seed `maxIntervalEndReached` and `itemsStatus` from the south connector's persisted cache
+   * snapshot, so a resumed run reflects the correct starting point (progress bar, per-item status)
+   * instead of visually restarting from zero.
+   */
+  private seedItemsStatus(items: Array<SouthConnectorItemEntity<SouthItemSettings>>): void {
+    const snapshot = this.south.getHistoryQuerySnapshot(items);
+    this.maxIntervalEndReached = snapshot.items.reduce<Instant | null>((max, item) => {
+      if (!item.trackedInstant) return max;
+      return !max || item.trackedInstant > max ? item.trackedInstant : max;
+    }, null);
+    this.itemsStatus = new Map(
+      snapshot.items.map(item => [
+        item.itemId,
+        {
+          itemId: item.itemId,
+          itemName: item.itemName,
+          status: (item.trackedInstant && item.trackedInstant >= this.historyConfiguration.queryTimeRange.endTime
+            ? 'done'
+            : 'pending') as HistoryQueryItemStatus['status'],
+          lastValueTimestamp: item.trackedInstant,
+          recordsCount: 0
+        }
+      ])
+    );
+  }
+
+  /** Update whichever item is currently marked `'running'` with newly retrieved records. No-op if no item is running (e.g. batched connectors, which never emit `history-query-item-start`). */
+  private updateRunningItemStatus(recordsDelta: number, lastValueTimestamp: Instant | null): void {
+    for (const status of this.itemsStatus.values()) {
+      if (status.status === 'running') {
+        status.recordsCount += recordsDelta;
+        if (lastValueTimestamp) {
+          status.lastValueTimestamp = lastValueTimestamp;
+        }
+        break;
+      }
+    }
   }
 
   async stop(): Promise<void> {
@@ -277,28 +409,48 @@ export default class HistoryQuery {
     await this.north.updateCacheContent(updateCommand);
   }
 
-  private computeCurrentProgress(data: { currentIntervalStart: Instant; currentIntervalEnd: Instant }): {
-    running: boolean;
-    intervalProgress: number;
+  private computeCurrentProgress(data: {
     currentIntervalStart: Instant;
     currentIntervalEnd: Instant;
-    currentIntervalNumber: number;
-    numberOfIntervals: number;
-  } {
+    currentIntervalNumber?: number;
+    numberOfIntervals?: number;
+    itemName?: string;
+    currentItemNumber?: number;
+    numberOfItems?: number;
+  }): HistoryMetricsEvents['south-history-query-interval'] {
     // this.intervals is the full, fixed breakdown of the history query's configured time range
     // (oldest to newest), computed once in the constructor. It's independent of the south
     // connector's own per-run sub-intervals (which vary with recovery strategy and cache state),
-    // so counting how many of its slots are fully covered by currentIntervalEnd gives a stable
-    // overall progress measure across restarts.
+    // so counting how many of its slots are fully covered by the ratcheted `maxIntervalEndReached`
+    // gives a stable overall progress measure across restarts.
+    //
+    // The ratchet itself is what fixes the sawtooth bug: a multi-item connector reports its own,
+    // independent `currentIntervalEnd` per item, which is usually much earlier than where the
+    // previous item left off when the run moves on to a new item. Recomputing `currentIntervalNumber`
+    // fresh from that raw value every call (the old behavior) made the overall progress bar visibly
+    // jump backwards on every item transition. Ratcheting the high-water mark forward-only means
+    // `currentIntervalNumber` here only ever advances.
     const numberOfIntervals = this.intervals.length || 1;
-    const currentIntervalNumber = this.intervals.filter(interval => interval.end <= data.currentIntervalEnd).length;
+    if (this.maxIntervalEndReached === null || data.currentIntervalEnd > this.maxIntervalEndReached) {
+      this.maxIntervalEndReached = data.currentIntervalEnd;
+    }
+    const currentIntervalNumber = this.intervals.filter(interval => interval.end <= this.maxIntervalEndReached!).length;
+
     return {
       running: true,
       intervalProgress: currentIntervalNumber / numberOfIntervals,
       currentIntervalStart: data.currentIntervalStart,
       currentIntervalEnd: data.currentIntervalEnd,
       currentIntervalNumber,
-      numberOfIntervals
+      numberOfIntervals,
+      ...(data.itemName !== undefined ? { itemName: data.itemName } : {}),
+      ...(data.currentItemNumber !== undefined ? { currentItemNumber: data.currentItemNumber } : {}),
+      ...(data.numberOfItems !== undefined ? { numberOfItems: data.numberOfItems } : {}),
+      // Scoped to the current item's own raw interval count (NOT ratcheted) so it resets to (near)
+      // 0 for each new item, unlike the ratcheted `intervalProgress` above.
+      ...(data.numberOfIntervals ? { itemIntervalProgress: (data.currentIntervalNumber ?? 0) / data.numberOfIntervals } : {}),
+      itemIntervalNumber: data.currentIntervalNumber,
+      itemNumberOfIntervals: data.numberOfIntervals
     };
   }
 }

--- a/backend/src/repository/metrics/history-query-metrics.repository.spec.ts
+++ b/backend/src/repository/metrics/history-query-metrics.repository.spec.ts
@@ -35,7 +35,18 @@ describe('HistoryQueryMetricsRepository with populated database', () => {
     const result = repository.getMetrics(testData.historyQueries.list[0].id);
     // north current* sizes are no longer persisted (read live by the service) — compare the persisted subset.
     const { currentCacheSize: _c, currentErrorSize: _e, currentArchiveSize: _a, ...north } = testData.historyQueries.metrics.north;
-    assert.deepStrictEqual(result, { ...testData.historyQueries.metrics, north });
+    // per-item fields on historyMetrics are derived live from the running engine, not persisted — compare the persisted subset.
+    const {
+      itemName: _in,
+      currentItemNumber: _cin,
+      numberOfItems: _noi,
+      itemIntervalProgress: _iip,
+      itemIntervalNumber: _iin,
+      itemNumberOfIntervals: _inoi,
+      itemsStatus: _is,
+      ...historyMetrics
+    } = testData.historyQueries.metrics.historyMetrics;
+    assert.deepStrictEqual(result, { ...testData.historyQueries.metrics, north, historyMetrics });
   });
 
   it('should update metrics', () => {

--- a/backend/src/service/history-query.service.spec.ts
+++ b/backend/src/service/history-query.service.spec.ts
@@ -1057,10 +1057,106 @@ describe('History Query service', () => {
       endTime: historyQuery.queryTimeRange.endTime,
       southType: historyQuery.southType,
       northType: historyQuery.northType,
+      currentItemNumber: undefined,
+      numberOfItems: undefined,
       createdBy: getUserInfo(historyQueryLight.createdBy),
       updatedBy: getUserInfo(historyQueryLight.updatedBy),
       createdAt: historyQueryLight.createdAt,
       updatedAt: historyQueryLight.updatedAt
     });
+  });
+
+  it('should include current item progress in light DTO when the history query is currently running', () => {
+    const getUserInfo = (id: string) => ({ id, friendlyName: id });
+    const historyQuery = testData.historyQueries.list[0];
+    const historyQueryLight: HistoryQueryEntityLight = {
+      id: historyQuery.id,
+      name: historyQuery.name,
+      description: historyQuery.description,
+      status: historyQuery.status,
+      startTime: historyQuery.queryTimeRange.startTime,
+      endTime: historyQuery.queryTimeRange.endTime,
+      southType: historyQuery.southType,
+      northType: historyQuery.northType,
+      createdBy: '',
+      updatedBy: '',
+      createdAt: '',
+      updatedAt: ''
+    };
+    const runningMetrics = {
+      ...testData.historyQueries.metrics,
+      historyMetrics: {
+        ...testData.historyQueries.metrics.historyMetrics,
+        running: true,
+        currentItemNumber: 2,
+        numberOfItems: 5
+      }
+    };
+    const getHistoryMetrics = mock.fn((_historyId: string) => runningMetrics);
+
+    const result = toHistoryQueryLightDTO(historyQueryLight, getUserInfo, getHistoryMetrics);
+
+    assert.deepStrictEqual(getHistoryMetrics.mock.calls[0].arguments, [historyQueryLight.id]);
+    assert.strictEqual(result.currentItemNumber, 2);
+    assert.strictEqual(result.numberOfItems, 5);
+  });
+
+  it('should omit current item progress in light DTO when the history query is not currently running', () => {
+    const getUserInfo = (id: string) => ({ id, friendlyName: id });
+    const historyQuery = testData.historyQueries.list[0];
+    const historyQueryLight: HistoryQueryEntityLight = {
+      id: historyQuery.id,
+      name: historyQuery.name,
+      description: historyQuery.description,
+      status: historyQuery.status,
+      startTime: historyQuery.queryTimeRange.startTime,
+      endTime: historyQuery.queryTimeRange.endTime,
+      southType: historyQuery.southType,
+      northType: historyQuery.northType,
+      createdBy: '',
+      updatedBy: '',
+      createdAt: '',
+      updatedAt: ''
+    };
+    const notRunningMetrics = {
+      ...testData.historyQueries.metrics,
+      historyMetrics: {
+        ...testData.historyQueries.metrics.historyMetrics,
+        running: false,
+        currentItemNumber: 2,
+        numberOfItems: 5
+      }
+    };
+    const getHistoryMetrics = mock.fn((_historyId: string) => notRunningMetrics);
+
+    const result = toHistoryQueryLightDTO(historyQueryLight, getUserInfo, getHistoryMetrics);
+
+    assert.strictEqual(result.currentItemNumber, undefined);
+    assert.strictEqual(result.numberOfItems, undefined);
+  });
+
+  it('should omit current item progress in light DTO when the engine has no metrics for the history query', () => {
+    const getUserInfo = (id: string) => ({ id, friendlyName: id });
+    const historyQuery = testData.historyQueries.list[0];
+    const historyQueryLight: HistoryQueryEntityLight = {
+      id: historyQuery.id,
+      name: historyQuery.name,
+      description: historyQuery.description,
+      status: historyQuery.status,
+      startTime: historyQuery.queryTimeRange.startTime,
+      endTime: historyQuery.queryTimeRange.endTime,
+      southType: historyQuery.southType,
+      northType: historyQuery.northType,
+      createdBy: '',
+      updatedBy: '',
+      createdAt: '',
+      updatedAt: ''
+    };
+    const getHistoryMetrics = mock.fn((_historyId: string) => null);
+
+    const result = toHistoryQueryLightDTO(historyQueryLight, getUserInfo, getHistoryMetrics);
+
+    assert.strictEqual(result.currentItemNumber, undefined);
+    assert.strictEqual(result.numberOfItems, undefined);
   });
 });

--- a/backend/src/service/history-query.service.ts
+++ b/backend/src/service/history-query.service.ts
@@ -769,7 +769,15 @@ const copyHistoryQueryItemCommandToHistoryQueryItemEntity = async (
   );
 };
 
-export const toHistoryQueryLightDTO = (historyQuery: HistoryQueryEntityLight, getUserInfo: GetUserInfo): HistoryQueryLightDTO => {
+export const toHistoryQueryLightDTO = (
+  historyQuery: HistoryQueryEntityLight,
+  getUserInfo: GetUserInfo,
+  getHistoryMetrics?: (historyId: string) => HistoryQueryMetrics | null
+): HistoryQueryLightDTO => {
+  // Plain synchronous read of the already-in-memory metrics of the running engine, if any.
+  // No SSE connection or polling is involved here.
+  const metrics = getHistoryMetrics?.(historyQuery.id);
+  const isRunning = metrics?.historyMetrics.running ?? false;
   return {
     id: historyQuery.id,
     name: historyQuery.name,
@@ -779,6 +787,8 @@ export const toHistoryQueryLightDTO = (historyQuery: HistoryQueryEntityLight, ge
     endTime: historyQuery.endTime,
     southType: historyQuery.southType,
     northType: historyQuery.northType,
+    currentItemNumber: isRunning ? metrics!.historyMetrics.currentItemNumber : undefined,
+    numberOfItems: isRunning ? metrics!.historyMetrics.numberOfItems : undefined,
     createdBy: getUserInfo(historyQuery.createdBy),
     updatedBy: getUserInfo(historyQuery.updatedBy),
     createdAt: historyQuery.createdAt,

--- a/backend/src/service/metrics/history-query-metrics.service.spec.ts
+++ b/backend/src/service/metrics/history-query-metrics.service.spec.ts
@@ -86,9 +86,39 @@ describe('HistoryMetricsService', () => {
       currentIntervalStart: testData.constants.dates.DATE_1,
       currentIntervalEnd: testData.constants.dates.DATE_3,
       currentIntervalNumber: 2,
-      numberOfIntervals: 10
+      numberOfIntervals: 10,
+      itemName: 'item1',
+      currentItemNumber: 1,
+      numberOfItems: 3,
+      itemIntervalProgress: 0.5,
+      itemIntervalNumber: 2,
+      itemNumberOfIntervals: 10
+    });
+    const itemsStatus = [
+      {
+        itemId: 'id1',
+        itemName: 'item1',
+        status: 'running' as const,
+        lastValueTimestamp: testData.constants.dates.DATE_1,
+        recordsCount: 5
+      },
+      { itemId: 'id2', itemName: 'item2', status: 'pending' as const, lastValueTimestamp: null, recordsCount: 0 }
+    ];
+    historyQueryMock.metricsEvent.emit('south-history-query-item', {
+      itemName: 'item1',
+      currentItemNumber: 1,
+      numberOfItems: 3,
+      itemsStatus
     });
     historyQueryMock.metricsEvent.emit('south-history-query-stop', { running: false });
+
+    assert.deepStrictEqual(service.metrics.historyMetrics.itemsStatus, itemsStatus);
+    assert.strictEqual(service.metrics.historyMetrics.itemName, 'item1');
+    assert.strictEqual(service.metrics.historyMetrics.currentItemNumber, 1);
+    assert.strictEqual(service.metrics.historyMetrics.numberOfItems, 3);
+    assert.strictEqual(service.metrics.historyMetrics.itemIntervalProgress, 0.5);
+    assert.strictEqual(service.metrics.historyMetrics.itemIntervalNumber, 2);
+    assert.strictEqual(service.metrics.historyMetrics.itemNumberOfIntervals, 10);
 
     // Still no DB write — debounce timer hasn't fired.
     assert.strictEqual(historyQueryMetricsRepository.updateMetrics.mock.calls.length, 0);
@@ -131,7 +161,14 @@ describe('HistoryMetricsService', () => {
           currentIntervalStart: testData.constants.dates.DATE_1,
           currentIntervalEnd: testData.constants.dates.DATE_3,
           currentIntervalNumber: 2,
-          numberOfIntervals: 10
+          numberOfIntervals: 10,
+          itemName: 'item1',
+          currentItemNumber: 1,
+          numberOfItems: 3,
+          itemIntervalProgress: 0.5,
+          itemIntervalNumber: 2,
+          itemNumberOfIntervals: 10,
+          itemsStatus
         }
       }
     ]);
@@ -197,6 +234,7 @@ describe('HistoryMetricsService', () => {
     assert.ok(offEvents.includes('south-run-end'));
     assert.ok(offEvents.includes('south-history-query-start'));
     assert.ok(offEvents.includes('south-history-query-interval'));
+    assert.ok(offEvents.includes('south-history-query-item'));
     assert.ok(offEvents.includes('south-history-query-stop'));
     assert.ok(offEvents.includes('south-add-values'));
     assert.ok(offEvents.includes('south-add-file'));

--- a/backend/src/service/metrics/history-query-metrics.service.ts
+++ b/backend/src/service/metrics/history-query-metrics.service.ts
@@ -1,4 +1,4 @@
-import { CacheMetadata, HistoryQueryMetrics, OIBusTimeValue } from '../../../shared/model/engine.model';
+import { CacheMetadata, HistoryQueryItemStatus, HistoryQueryMetrics, OIBusTimeValue } from '../../../shared/model/engine.model';
 import { PassThrough } from 'node:stream';
 import HistoryQuery from '../../engine/history-query';
 import HistoryQueryMetricsRepository, { PersistedHistoryQueryMetrics } from '../../repository/metrics/history-query-metrics.repository';
@@ -44,7 +44,8 @@ export default class HistoryQueryMetricsService {
       currentIntervalStart: null,
       currentIntervalEnd: null,
       currentIntervalNumber: 0,
-      numberOfIntervals: 0
+      numberOfIntervals: 0,
+      itemsStatus: []
     }
   };
 
@@ -64,6 +65,7 @@ export default class HistoryQueryMetricsService {
     this.historyQuery.metricsEvent.on('south-run-end', this.onSouthRunEnd);
     this.historyQuery.metricsEvent.on('south-history-query-start', this.onSouthHistoryQueryStart);
     this.historyQuery.metricsEvent.on('south-history-query-interval', this.onSouthHistoryQueryInterval);
+    this.historyQuery.metricsEvent.on('south-history-query-item', this.onSouthHistoryQueryItem);
     this.historyQuery.metricsEvent.on('south-history-query-stop', this.onSouthHistoryQueryStop);
     this.historyQuery.metricsEvent.on('south-add-values', this.onSouthAddValues);
     this.historyQuery.metricsEvent.on('south-add-file', this.onSouthAddFile);
@@ -123,6 +125,12 @@ export default class HistoryQueryMetricsService {
     currentIntervalEnd: Instant;
     currentIntervalNumber: number;
     numberOfIntervals: number;
+    itemName?: string;
+    currentItemNumber?: number;
+    numberOfItems?: number;
+    itemIntervalProgress?: number;
+    itemIntervalNumber?: number;
+    itemNumberOfIntervals?: number;
   }) => {
     this._metrics.historyMetrics.running = data.running;
     this._metrics.historyMetrics.intervalProgress = data.intervalProgress;
@@ -130,6 +138,25 @@ export default class HistoryQueryMetricsService {
     this._metrics.historyMetrics.currentIntervalEnd = data.currentIntervalEnd;
     this._metrics.historyMetrics.currentIntervalNumber = data.currentIntervalNumber;
     this._metrics.historyMetrics.numberOfIntervals = data.numberOfIntervals;
+    this._metrics.historyMetrics.itemName = data.itemName;
+    this._metrics.historyMetrics.currentItemNumber = data.currentItemNumber;
+    this._metrics.historyMetrics.numberOfItems = data.numberOfItems;
+    this._metrics.historyMetrics.itemIntervalProgress = data.itemIntervalProgress;
+    this._metrics.historyMetrics.itemIntervalNumber = data.itemIntervalNumber;
+    this._metrics.historyMetrics.itemNumberOfIntervals = data.itemNumberOfIntervals;
+    this.updateMetrics();
+  };
+
+  private onSouthHistoryQueryItem = (data: {
+    itemName: string;
+    currentItemNumber: number;
+    numberOfItems: number;
+    itemsStatus: Array<HistoryQueryItemStatus>;
+  }) => {
+    this._metrics.historyMetrics.itemName = data.itemName;
+    this._metrics.historyMetrics.currentItemNumber = data.currentItemNumber;
+    this._metrics.historyMetrics.numberOfItems = data.numberOfItems;
+    this._metrics.historyMetrics.itemsStatus = data.itemsStatus;
     this.updateMetrics();
   };
 
@@ -206,6 +233,7 @@ export default class HistoryQueryMetricsService {
     this.historyQuery.metricsEvent.off('south-run-end', this.onSouthRunEnd);
     this.historyQuery.metricsEvent.off('south-history-query-start', this.onSouthHistoryQueryStart);
     this.historyQuery.metricsEvent.off('south-history-query-interval', this.onSouthHistoryQueryInterval);
+    this.historyQuery.metricsEvent.off('south-history-query-item', this.onSouthHistoryQueryItem);
     this.historyQuery.metricsEvent.off('south-history-query-stop', this.onSouthHistoryQueryStop);
     this.historyQuery.metricsEvent.off('south-add-values', this.onSouthAddValues);
     this.historyQuery.metricsEvent.off('south-add-file', this.onSouthAddFile);

--- a/backend/src/south/south-connector.spec.ts
+++ b/backend/src/south/south-connector.spec.ts
@@ -303,6 +303,50 @@ describe('SouthConnector', () => {
       assert.strictEqual((southCacheRepository.deleteItemsBySouth as Mock<(...args: Array<unknown>) => unknown>).mock.calls.length, 1);
     });
 
+    it('should build a history query snapshot from persisted cache entries', () => {
+      const items = testData.south.list[0].items as Array<SouthConnectorItemEntity<SouthFolderScannerItemSettings>>;
+      const groupedItem = {
+        ...items[1],
+        syncWithGroup: true,
+        group: { id: 'groupId1', name: 'group 1' }
+      } as unknown as SouthConnectorItemEntity<SouthFolderScannerItemSettings>;
+
+      (southCacheRepository.getItemLastValue as Mock<(...args: Array<unknown>) => unknown>).mock.mockImplementationOnce(() => ({
+        itemId: items[0].id,
+        groupId: null,
+        trackedInstant: '2020-02-02T02:02:02.222Z',
+        queryTime: '2020-02-02T03:02:02.222Z',
+        value: { foo: 'bar' }
+      }));
+      (southCacheRepository.getGroupLastValue as Mock<(...args: Array<unknown>) => unknown>).mock.mockImplementationOnce(() => null);
+
+      const snapshot = south.getHistoryQuerySnapshot([items[0], groupedItem]);
+
+      assert.deepStrictEqual(snapshot, {
+        items: [
+          {
+            itemId: items[0].id,
+            itemName: items[0].name,
+            trackedInstant: '2020-02-02T02:02:02.222Z',
+            queryTime: '2020-02-02T03:02:02.222Z',
+            value: { foo: 'bar' }
+          },
+          {
+            itemId: groupedItem.id,
+            itemName: groupedItem.name,
+            trackedInstant: null,
+            queryTime: null,
+            value: null
+          }
+        ]
+      });
+
+      const getItemCalls = (southCacheRepository.getItemLastValue as Mock<(...args: Array<unknown>) => unknown>).mock.calls;
+      assert.strictEqual(getItemCalls[getItemCalls.length - 1].arguments[1], items[0].id);
+      const getGroupCalls = (southCacheRepository.getGroupLastValue as Mock<(...args: Array<unknown>) => unknown>).mock.calls;
+      assert.strictEqual(getGroupCalls[getGroupCalls.length - 1].arguments[1], 'groupId1');
+    });
+
     it('should properly connect and disconnect without touching any cron state', async () => {
       await south.connect();
       await south.disconnect();
@@ -456,6 +500,11 @@ describe('SouthConnector', () => {
       const historyQueryMock = mock.fn(async () => ({ trackedInstant: '2021-02-02T02:02:02.222Z', value: null }));
       south.historyQuery = historyQueryMock;
 
+      const itemStartListener = mock.fn();
+      const intervalListener = mock.fn();
+      south.metricsEvent.on('history-query-item-start', itemStartListener);
+      south.metricsEvent.on('history-query-interval', intervalListener);
+
       const items = testData.south.list[1].items as Array<SouthConnectorItemEntity<SouthMSSQLItemSettings>>;
       await south.historyQueryHandler(items, '2020-02-02T02:02:02.222Z', '2021-02-02T02:02:02.222Z');
 
@@ -465,6 +514,40 @@ describe('SouthConnector', () => {
       assert.strictEqual(historyQueryMock.mock.calls.length, 2);
       assert.deepStrictEqual(historyQueryMock.mock.calls[0].arguments[0], [items[0]]);
       assert.deepStrictEqual(historyQueryMock.mock.calls[1].arguments[0], [items[1]]);
+
+      // history-query-item-start is emitted once per item, before it is queried
+      assert.strictEqual(itemStartListener.mock.calls.length, 2);
+      assert.deepStrictEqual(itemStartListener.mock.calls[0].arguments[0], {
+        itemName: items[0].name,
+        currentItemNumber: 1,
+        numberOfItems: 2
+      });
+      assert.deepStrictEqual(itemStartListener.mock.calls[1].arguments[0], {
+        itemName: items[1].name,
+        currentItemNumber: 2,
+        numberOfItems: 2
+      });
+
+      // history-query-interval carries the item context and interval position/count
+      assert.strictEqual(intervalListener.mock.calls.length, 2);
+      assert.deepStrictEqual(intervalListener.mock.calls[0].arguments[0], {
+        currentIntervalStart: interval.start,
+        currentIntervalEnd: interval.end,
+        currentIntervalNumber: 1,
+        numberOfIntervals: 1,
+        itemName: items[0].name,
+        currentItemNumber: 1,
+        numberOfItems: 2
+      });
+      assert.deepStrictEqual(intervalListener.mock.calls[1].arguments[0], {
+        currentIntervalStart: interval.start,
+        currentIntervalEnd: interval.end,
+        currentIntervalNumber: 1,
+        numberOfIntervals: 1,
+        itemName: items[1].name,
+        currentItemNumber: 2,
+        numberOfItems: 2
+      });
     });
 
     it('should use independent cache entries per item for single-item connectors', async () => {
@@ -835,6 +918,10 @@ describe('SouthConnector', () => {
             }, 1000);
           })
       );
+
+      const intervalListener = mock.fn();
+      south.metricsEvent.on('history-query-interval', intervalListener);
+
       south.historyQueryHandler(
         testData.south.list[2].items as Array<SouthConnectorItemEntity<SouthOPCUAItemSettings>>,
         '2020-02-02T02:02:02.222Z',
@@ -854,6 +941,15 @@ describe('SouthConnector', () => {
         )
       );
       assert.strictEqual(historyQueryMock.mock.calls.length, 1);
+
+      // This is a batched (non-single-items) connector, so no item context is attached
+      assert.strictEqual(intervalListener.mock.calls.length, 1);
+      assert.deepStrictEqual(intervalListener.mock.calls[0].arguments[0], {
+        currentIntervalStart: intervals[0].start,
+        currentIntervalEnd: intervals[0].end,
+        currentIntervalNumber: 1,
+        numberOfIntervals: intervals.length
+      });
     });
 
     it('should use group historian settings when syncWithGroup is true', async () => {

--- a/backend/src/south/south-connector.ts
+++ b/backend/src/south/south-connector.ts
@@ -30,7 +30,19 @@ export interface SouthMetricsEvents {
   'history-query-interval': {
     currentIntervalStart: Instant;
     currentIntervalEnd: Instant;
+    // 1-based index of this interval within the current lead/item's own generated interval list.
+    currentIntervalNumber: number;
+    // Total number of intervals generated for the current lead/item.
+    numberOfIntervals: number;
+    // Only set for SOUTH_SINGLE_ITEMS connectors, where items are queried one at a time.
+    currentItemName?: string;
+    currentItemNumber?: number;
+    numberOfItems?: number;
   };
+  // Emitted once per item, before it is queried, for SOUTH_SINGLE_ITEMS connectors — needed because
+  // an item whose window is already caught up may emit zero `history-query-interval` events, so the
+  // UI would otherwise have no boundary event to show progress moving to the next item.
+  'history-query-item-start': { itemName: string; currentItemNumber: number; numberOfItems: number };
   // `any-content` (opaque payloads) has no time value, hence the `| null`.
   'add-values': { numberOfValuesRetrieved: number; lastValueRetrieved: OIBusTimeValue | null };
   'add-file': { lastFileRetrieved: string };
@@ -542,14 +554,18 @@ export default abstract class SouthConnector<T extends SouthSettings, I extends 
       if (SOUTH_SINGLE_ITEMS.includes(this.connector.type)) {
         // Each item is queried independently so that each has its own cache entry and trackedInstant.
         // This mirrors how groupItemsByGroup() sends singleton arrays during normal scan flow.
-        for (const item of itemsToRead) {
-          await this.runHistoryQueryForLead(item, [item], null, startTime, endTime);
+        const numberOfItems = itemsToRead.length;
+        for (let i = 0; i < itemsToRead.length; i++) {
+          const item = itemsToRead[i];
+          const itemContext = { itemName: item.name, currentItemNumber: i + 1, numberOfItems };
+          this.metricsEvent.emit('history-query-item-start', itemContext);
+          await this.runHistoryQueryForLead(item, [item], null, startTime, endTime, itemContext);
           if (this.stopping) break;
         }
       } else {
         const lead = itemsToRead[0];
         const groupId = lead.group && lead.syncWithGroup ? lead.group.id : null;
-        await this.runHistoryQueryForLead(lead, itemsToRead, groupId, startTime, endTime);
+        await this.runHistoryQueryForLead(lead, itemsToRead, groupId, startTime, endTime, null);
       }
     } finally {
       // Guaranteed even if runHistoryQueryForLead throws, so a failed history query can't leave
@@ -570,7 +586,8 @@ export default abstract class SouthConnector<T extends SouthSettings, I extends 
     items: Array<SouthConnectorItemEntity<I>>,
     groupId: string | null,
     startTime: Instant,
-    endTime: Instant
+    endTime: Instant,
+    itemContext: { itemName: string; currentItemNumber: number; numberOfItems: number } | null
   ): Promise<void> {
     // A non-null groupId means this is a batched, synced group (the only caller that passes one —
     // see historyQueryHandler): the cache is shared by the whole group, keyed by group_id alone, so
@@ -605,7 +622,7 @@ export default abstract class SouthConnector<T extends SouthSettings, I extends 
     const { effectiveStartTime, effectiveEndTime } = queryWindow;
     const intervals = generateIntervals(effectiveStartTime, effectiveEndTime, maxReadInterval, recoveryStrategy);
     this.logIntervals(intervals);
-    await this.queryIntervals(intervals, items, southCache, readDelay, recoveryStrategy);
+    await this.queryIntervals(intervals, items, southCache, readDelay, recoveryStrategy, itemContext);
   }
 
   private async queryIntervals(
@@ -613,7 +630,8 @@ export default abstract class SouthConnector<T extends SouthSettings, I extends 
     items: Array<SouthConnectorItemEntity<I>>,
     southCache: SouthCacheEntry,
     readDelay: number,
-    strategy: SouthHistoryRecoveryStrategy
+    strategy: SouthHistoryRecoveryStrategy,
+    itemContext: { itemName: string; currentItemNumber: number; numberOfItems: number } | null
   ) {
     // For 'newest' strategy, track the max trackedInstant seen across all intervals. Intervals are
     // queried newest-first (see generateIntervals), so this is expected to resolve on the first
@@ -624,7 +642,13 @@ export default abstract class SouthConnector<T extends SouthSettings, I extends 
       const queryTime = DateTime.now().toUTC().toISO()!;
       const interval = intervals[index];
 
-      this.metricsEvent.emit('history-query-interval', { currentIntervalStart: interval.start, currentIntervalEnd: interval.end });
+      this.metricsEvent.emit('history-query-interval', {
+        currentIntervalStart: interval.start,
+        currentIntervalEnd: interval.end,
+        currentIntervalNumber: index + 1,
+        numberOfIntervals: intervals.length,
+        ...(itemContext ?? {})
+      });
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-expect-error
       const lastValue: { trackedInstant: Instant; value: unknown } | null = await this.historyQuery(items, interval.start, interval.end);
@@ -825,6 +849,32 @@ export default abstract class SouthConnector<T extends SouthSettings, I extends 
   resetCache(): Promise<void> {
     this.southCacheRepository.deleteItemsBySouth(this.connector.id);
     return Promise.resolve();
+  }
+
+  /**
+   * Snapshot the persisted history-query cache state for `items`, for progress-monitoring UIs.
+   * Mirrors the lookup `south.service.ts#getItemLastValue` uses: when an item is synced with its
+   * group, the cache entry is shared across the whole group (saved once under the group's lead
+   * item), so it's looked up by group id; otherwise it's looked up by the item's own id.
+   */
+  getHistoryQuerySnapshot(items: Array<SouthConnectorItemEntity<I>>): {
+    items: Array<{ itemId: string; itemName: string; trackedInstant: Instant | null; queryTime: Instant | null; value: unknown | null }>;
+  } {
+    return {
+      items: items.map(item => {
+        const cacheEntry =
+          item.syncWithGroup && item.group
+            ? this.southCacheRepository.getGroupLastValue(this.connector.id, item.group.id)
+            : this.southCacheRepository.getItemLastValue(this.connector.id, item.id);
+        return {
+          itemId: item.id,
+          itemName: item.name,
+          trackedInstant: cacheEntry?.trackedInstant ?? null,
+          queryTime: cacheEntry?.queryTime ?? null,
+          value: cacheEntry?.value ?? null
+        };
+      })
+    };
   }
 
   /**

--- a/backend/src/tests/__mocks__/south-connector.mock.ts
+++ b/backend/src/tests/__mocks__/south-connector.mock.ts
@@ -41,6 +41,13 @@ export default class SouthConnectorMock extends SouthConnector<SouthSettings, So
       _testingSettings: SouthConnectorItemTestingSettings
     ): Promise<SouthConnectorItemQueryResult> => ({ result: {} as OIBusContent, connectionDuration: 0, queryDuration: 0 })
   );
+  override getHistoryQuerySnapshot = mock.fn(
+    (
+      _items: Array<SouthConnectorItemEntity<SouthItemSettings>>
+    ): {
+      items: Array<{ itemId: string; itemName: string; trackedInstant: Instant | null; queryTime: Instant | null; value: unknown | null }>;
+    } => ({ items: [] })
+  );
   override connectedEvent = new EventEmitter();
   override metricsEvent = new EventEmitter();
 

--- a/backend/src/tests/utils/test-data.ts
+++ b/backend/src/tests/utils/test-data.ts
@@ -1627,7 +1627,18 @@ const historyQueryMetrics: HistoryQueryMetrics = {
     currentIntervalStart: null,
     currentIntervalEnd: null,
     currentIntervalNumber: 0,
-    numberOfIntervals: 0
+    numberOfIntervals: 0,
+    itemName: 'item1',
+    currentItemNumber: 1,
+    numberOfItems: 3,
+    itemIntervalProgress: 0,
+    itemIntervalNumber: 0,
+    itemNumberOfIntervals: 0,
+    itemsStatus: [
+      { itemId: 'historyQueryItem1', itemName: 'item1', status: 'running', lastValueTimestamp: null, recordsCount: 0 },
+      { itemId: 'historyQueryItem2', itemName: 'item2', status: 'pending', lastValueTimestamp: null, recordsCount: 0 },
+      { itemId: 'historyQueryItem3', itemName: 'item3', status: 'pending', lastValueTimestamp: null, recordsCount: 0 }
+    ]
   }
 };
 

--- a/backend/src/web-server/controllers/history-query.controller.ts
+++ b/backend/src/web-server/controllers/history-query.controller.ts
@@ -98,7 +98,13 @@ export class HistoryQueryController extends Controller {
   list(@Request() request: CustomExpressRequest): Array<HistoryQueryLightDTO> {
     const historyQueryService = request.services.historyQueryService as HistoryQueryService;
     const historyQueries = historyQueryService.list();
-    return historyQueries.map(historyQuery => toHistoryQueryLightDTO(historyQuery, id => request.services.userService.getUserInfo(id)));
+    return historyQueries.map(historyQuery =>
+      toHistoryQueryLightDTO(
+        historyQuery,
+        id => request.services.userService.getUserInfo(id),
+        id => historyQueryService.getHistoryMetric(id)
+      )
+    );
   }
 
   /**

--- a/backend/src/web-server/routes.ts
+++ b/backend/src/web-server/routes.ts
@@ -7185,6 +7185,8 @@ const models: TsoaRoute.Models = {
             "endTime": {"dataType":"string","required":true},
             "southType": {"ref":"OIBusSouthType","required":true},
             "northType": {"ref":"OIBusNorthType","required":true},
+            "currentItemNumber": {"dataType":"double"},
+            "numberOfItems": {"dataType":"double"},
         },
         "additionalProperties": false,
     },

--- a/documentation/docs/api/openapi.json
+++ b/documentation/docs/api/openapi.json
@@ -31652,6 +31652,18 @@
 						"$ref": "#/components/schemas/OIBusNorthType",
 						"description": "The type of the North connector used for data storage.",
 						"example": "aws-s3"
+					},
+					"currentItemNumber": {
+						"type": "number",
+						"format": "double",
+						"description": "The 1-based index of the item currently being queried, among the run's enabled items. Only\nset while the history query is actively running on a connector that queries items one at a\ntime (SOUTH_SINGLE_ITEMS).",
+						"example": 3
+					},
+					"numberOfItems": {
+						"type": "number",
+						"format": "double",
+						"description": "The total number of enabled items in the run. Only set while the history query is actively\nrunning on a connector that queries items one at a time (SOUTH_SINGLE_ITEMS).",
+						"example": 10
 					}
 				},
 				"required": [

--- a/frontend/src/app/history-query/history-query-detail/history-metrics/history-metrics.component.html
+++ b/frontend/src/app/history-query/history-query-detail/history-metrics/history-metrics.component.html
@@ -95,25 +95,87 @@
         </tr>
       </thead>
       <tbody>
-        <!-- south interval progressbar -->
-        @if (historyMetrics().historyMetrics.intervalProgress) {
+        <!-- whole-range progress, only for batched connectors (no per-item data) -->
+        @if (!hasItemProgress()) {
+          <!-- south interval progressbar -->
+          @if (historyMetrics().historyMetrics.intervalProgress) {
+            <tr>
+              <td translate="history-query.monitoring.south.data-retrieved"></td>
+              <td>
+                <oib-progressbar [value]="historyMetrics().historyMetrics.intervalProgress" [animated]="southProgressbarAnimated()" />
+              </td>
+            </tr>
+          }
+          <!-- south interval progress -->
+          @if (historyMetrics().historyMetrics.currentIntervalNumber && historyMetrics().historyMetrics.numberOfIntervals) {
+            <tr>
+              <td translate="history-query.monitoring.south.interval-progress"></td>
+              <td>
+                {{ historyMetrics().historyMetrics.currentIntervalNumber }}
+                / {{ historyMetrics().historyMetrics.numberOfIntervals }} : [
+                @if (historyMetrics().historyMetrics.currentIntervalStart; as currentIntervalStart) {
+                  {{ currentIntervalStart | datetime: 'ff' }}
+                }
+                ,
+                @if (historyMetrics().historyMetrics.currentIntervalEnd; as currentIntervalEnd) {
+                  {{ currentIntervalEnd | datetime: 'ff' }}
+                }
+                ]
+              </td>
+            </tr>
+          }
+        }
+        <!-- per-item progress, only for connectors that query items one at a time -->
+        @if (hasItemProgress()) {
           <tr>
-            <td translate="history-query.monitoring.south.data-retrieved"></td>
+            <td translate="history-query.monitoring.south.item-progress"></td>
             <td>
-              <oib-progressbar [value]="historyMetrics().historyMetrics.intervalProgress" [animated]="southProgressbarAnimated()" />
+              <span
+                translate="history-query.monitoring.south.current-item"
+                [translateParams]="{
+                  name: historyMetrics().historyMetrics.itemName,
+                  current: historyMetrics().historyMetrics.currentItemNumber,
+                  total: historyMetrics().historyMetrics.numberOfItems
+                }"
+              ></span>
+              <oib-progressbar
+                [value]="(historyMetrics().historyMetrics.currentItemNumber ?? 0) / (historyMetrics().historyMetrics.numberOfItems ?? 1)"
+                [animated]="itemProgressbarAnimated()"
+              />
+            </td>
+          </tr>
+          <tr>
+            <td translate="history-query.monitoring.south.item-interval-progress"></td>
+            <td>
+              {{ historyMetrics().historyMetrics.itemIntervalNumber }}
+              / {{ historyMetrics().historyMetrics.itemNumberOfIntervals }} : [
+              @if (historyMetrics().historyMetrics.currentIntervalStart; as currentIntervalStart) {
+                {{ currentIntervalStart | datetime: 'ff' }}
+              }
+              ,
+              @if (historyMetrics().historyMetrics.currentIntervalEnd; as currentIntervalEnd) {
+                {{ currentIntervalEnd | datetime: 'ff' }}
+              }
+              ]
+              <oib-progressbar
+                [value]="historyMetrics().historyMetrics.itemIntervalProgress ?? 0"
+                [animated]="itemIntervalProgressbarAnimated()"
+              />
             </td>
           </tr>
         }
-        <!-- south interval progress -->
-        @if (historyMetrics().historyMetrics.currentIntervalNumber && historyMetrics().historyMetrics.numberOfIntervals) {
+        <!-- rate and ETA, only while the query is running -->
+        @if (historyQuery().status === 'RUNNING') {
           <tr>
-            <td translate="history-query.monitoring.south.interval-progress"></td>
-            <td>
-              {{ historyMetrics().historyMetrics.currentIntervalNumber }}
-              / {{ historyMetrics().historyMetrics.numberOfIntervals }} : [{{ historyMetrics().historyMetrics.currentIntervalStart }},
-              {{ historyMetrics().historyMetrics.currentIntervalEnd }}]
-            </td>
+            <td translate="history-query.monitoring.south.values-per-second"></td>
+            <td>{{ southRate() | number: '1.0-2' }}</td>
           </tr>
+          @if (southEta(); as eta) {
+            <tr>
+              <td translate="history-query.monitoring.south.eta"></td>
+              <td>{{ eta * 1000 | duration: 'short' }}</td>
+            </tr>
+          }
         }
         <!-- number of values for point connectors -->
         <tr>
@@ -173,3 +235,35 @@
     </table>
   </div>
 </oib-box>
+
+@if (historyMetrics().historyMetrics.itemsStatus?.length) {
+  <oib-box>
+    <ng-template oibBoxTitle>
+      <span translate="history-query.monitoring.south.items-status.title"></span>
+    </ng-template>
+    <div>
+      <table class="table table-sm table-hover oib-table">
+        <thead class="light">
+          <tr>
+            <th translate="history-query.monitoring.south.items-status.status"></th>
+            <th translate="history-query.monitoring.south.items-status.name"></th>
+            <th translate="history-query.monitoring.south.items-status.last-value"></th>
+            <th translate="history-query.monitoring.south.items-status.records"></th>
+          </tr>
+        </thead>
+        <tbody>
+          @for (itemStatus of historyMetrics().historyMetrics.itemsStatus; track itemStatus.itemId) {
+            <tr class="history-item-status">
+              <td>
+                <span [translate]="'history-query.monitoring.south.items-status.' + itemStatus.status"></span>
+              </td>
+              <td>{{ itemStatus.itemName }}</td>
+              <td>{{ itemStatus.lastValueTimestamp ? (itemStatus.lastValueTimestamp | datetime: 'ff') : '' }}</td>
+              <td>{{ itemStatus.recordsCount }}</td>
+            </tr>
+          }
+        </tbody>
+      </table>
+    </div>
+  </oib-box>
+}

--- a/frontend/src/app/history-query/history-query-detail/history-metrics/history-metrics.component.spec.ts
+++ b/frontend/src/app/history-query/history-query-detail/history-metrics/history-metrics.component.spec.ts
@@ -1,4 +1,5 @@
 import { TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
 import { describe, expect, test } from 'vitest';
 
 import { HistoryMetricsComponent } from './history-metrics.component';
@@ -22,5 +23,33 @@ describe('HistoryMetricsComponent', () => {
     fixture.componentRef.setInput('southManifest', testData.south.manifest as unknown as SouthConnectorManifest);
     fixture.detectChanges();
     expect(fixture.componentInstance).toBeTruthy();
+  });
+
+  test('should display per-item progress and per-item status table', () => {
+    TestBed.configureTestingModule({
+      providers: [provideI18nTesting()]
+    });
+
+    const fixture = TestBed.createComponent(HistoryMetricsComponent);
+    fixture.componentRef.setInput('historyQuery', testData.historyQueries.list[0] as unknown as HistoryQueryDTO);
+    fixture.componentRef.setInput('historyMetrics', testData.historyQueries.metrics as unknown as HistoryQueryMetrics);
+    fixture.componentRef.setInput('northManifest', testData.north.manifest as unknown as NorthConnectorManifest);
+    fixture.componentRef.setInput('southManifest', testData.south.manifest as unknown as SouthConnectorManifest);
+    fixture.detectChanges();
+
+    const compiled: HTMLElement = fixture.nativeElement;
+
+    // item progress bar row shows the current item name and X / N counter
+    const bodyText = compiled.textContent ?? '';
+    expect(bodyText).toContain('item1');
+    expect(bodyText).toContain('1');
+    expect(bodyText).toContain('3');
+
+    // per-item status table renders one row per item in itemsStatus
+    const itemRows = fixture.debugElement.queryAll(By.css('tr.history-item-status'));
+    expect(itemRows.length).toBe(3);
+    expect(itemRows[0].nativeElement.textContent).toContain('item1');
+    expect(itemRows[1].nativeElement.textContent).toContain('item2');
+    expect(itemRows[2].nativeElement.textContent).toContain('item3');
   });
 });

--- a/frontend/src/app/history-query/history-query-detail/history-metrics/history-metrics.component.ts
+++ b/frontend/src/app/history-query/history-query-detail/history-metrics/history-metrics.component.ts
@@ -1,7 +1,7 @@
 import { Component, computed, input, ChangeDetectionStrategy } from '@angular/core';
 import { TranslateDirective } from '@ngx-translate/core';
 import { HistoryQueryMetrics } from '../../../../../../backend/shared/model/engine.model';
-import { JsonPipe } from '@angular/common';
+import { DecimalPipe, JsonPipe } from '@angular/common';
 import { DatetimePipe } from '../../../shared/datetime.pipe';
 import { DurationPipe } from '../../../shared/duration.pipe';
 import { BoxComponent, BoxTitleDirective } from '../../../shared/box/box.component';
@@ -16,7 +16,17 @@ import { FileSizePipe } from '../../../shared/file-size.pipe';
   templateUrl: './history-metrics.component.html',
   styleUrl: './history-metrics.component.scss',
   changeDetection: ChangeDetectionStrategy.Eager,
-  imports: [TranslateDirective, DatetimePipe, DurationPipe, BoxComponent, BoxTitleDirective, JsonPipe, ProgressbarComponent, FileSizePipe]
+  imports: [
+    TranslateDirective,
+    DatetimePipe,
+    DurationPipe,
+    BoxComponent,
+    BoxTitleDirective,
+    JsonPipe,
+    ProgressbarComponent,
+    FileSizePipe,
+    DecimalPipe
+  ]
 })
 export class HistoryMetricsComponent {
   readonly historyQuery = input.required<HistoryQueryDTO>();
@@ -26,6 +36,53 @@ export class HistoryMetricsComponent {
   readonly southProgressbarAnimated = computed(
     () => this.historyQuery().status === 'RUNNING' && this.historyMetrics().historyMetrics.intervalProgress !== 1
   );
+
+  /**
+   * Whether the payload carries per-item progress fields. Only connectors that query items one at a
+   * time (SOUTH_SINGLE_ITEMS, decided backend-side) populate `numberOfItems`, so this is gated purely
+   * on the shape of the payload rather than duplicating the connector-type list on the frontend.
+   */
+  readonly hasItemProgress = computed(() => (this.historyMetrics().historyMetrics.numberOfItems ?? 0) > 0);
+
+  readonly itemProgressbarAnimated = computed(() => {
+    const historyMetrics = this.historyMetrics().historyMetrics;
+    const progress = (historyMetrics.currentItemNumber ?? 0) / (historyMetrics.numberOfItems ?? 1);
+    return this.historyQuery().status === 'RUNNING' && progress !== 1;
+  });
+
+  readonly itemIntervalProgressbarAnimated = computed(
+    () => this.historyQuery().status === 'RUNNING' && this.historyMetrics().historyMetrics.itemIntervalProgress !== 1
+  );
+
+  /**
+   * Values + files retrieved per second since metrics collection started.
+   */
+  readonly southRate = computed(() => {
+    const elapsedSeconds = (Date.now() - Date.parse(this.historyMetrics().metricsStart)) / 1000;
+    if (!elapsedSeconds) {
+      return 0;
+    }
+    const totalRetrieved = this.historyMetrics().south.numberOfValuesRetrieved + this.historyMetrics().south.numberOfFilesRetrieved;
+    return totalRetrieved / elapsedSeconds;
+  });
+
+  /**
+   * Rough ETA in seconds, extrapolated from the ratcheted `intervalProgress` and the elapsed time since
+   * metrics collection started. Since `intervalProgress` is monotonic (never regresses, even across
+   * restarts), extrapolating from elapsed-so-far / progress-so-far stays stable across restarts.
+   */
+  readonly southEta = computed(() => {
+    const historyMetrics = this.historyMetrics().historyMetrics;
+    if (!historyMetrics.running || !historyMetrics.intervalProgress) {
+      return null;
+    }
+    const elapsedSeconds = (Date.now() - Date.parse(this.historyMetrics().metricsStart)) / 1000;
+    if (!elapsedSeconds) {
+      return null;
+    }
+    const remainingFraction = 1 - historyMetrics.intervalProgress;
+    return (elapsedSeconds / historyMetrics.intervalProgress) * remainingFraction;
+  });
 
   get northProgress() {
     return this.historyMetrics().north.contentSentSize / this.historyMetrics().north.contentCachedSize;

--- a/frontend/src/app/history-query/history-query-list.component.html
+++ b/frontend/src/app/history-query/history-query-list.component.html
@@ -114,7 +114,7 @@
         <table class="mt-2 table table-sm table-hover oib-table">
           <thead>
             <tr>
-              <th style="width: 3rem"></th>
+              <th style="width: 6rem"></th>
               <th>
                 <button
                   type="button"
@@ -174,6 +174,15 @@
               <tr>
                 <td>
                   <span [ngbTooltip]="getStatusLabel(query.status) | translate" [class]="getStatusClass(query.status)"></span>
+                  @if (query.numberOfItems) {
+                    <span
+                      class="ms-1 text-muted"
+                      [ngbTooltip]="
+                        'history-query.item-progress' | translate: { current: query.currentItemNumber, total: query.numberOfItems }
+                      "
+                      >({{ query.currentItemNumber }} / {{ query.numberOfItems }})</span
+                    >
+                  }
                 </td>
                 <td>
                   <span [ngbTooltip]="query.name" placement="top-start">{{ query.name }}</span>

--- a/frontend/src/app/history-query/history-query-list.component.spec.ts
+++ b/frontend/src/app/history-query/history-query-list.component.spec.ts
@@ -131,6 +131,29 @@ describe('HistoryQueryListComponent', () => {
     expect(fixture.componentInstance.filteredHistoryQueries.length).toBe(1);
   });
 
+  test('should display the item progress indicator when numberOfItems is set', async () => {
+    const queriesWithProgress = (testData.historyQueries.listLight as unknown as Array<HistoryQueryLightDTO>).map((query, index) =>
+      index === 0 ? { ...query, currentItemNumber: 3, numberOfItems: 10 } : query
+    );
+    historyQueryService.list.mockReturnValue(of(queriesWithProgress));
+
+    const fixture = TestBed.createComponent(HistoryQueryListComponent);
+    fixture.detectChanges();
+
+    const root = page.elementLocator(fixture.nativeElement);
+    const firstRowCells = root.getByCss('tbody tr').nth(0).getByCss('td');
+    await expect.element(firstRowCells.nth(0)).toHaveTextContent('(3 / 10)');
+  });
+
+  test('should not display the item progress indicator when numberOfItems is not set', async () => {
+    const fixture = TestBed.createComponent(HistoryQueryListComponent);
+    fixture.detectChanges();
+
+    const root = page.elementLocator(fixture.nativeElement);
+    const firstRowCells = root.getByCss('tbody tr').nth(0).getByCss('td');
+    await expect.element(firstRowCells.nth(0).getByCss('.text-muted')).not.toBeInTheDocument();
+  });
+
   test('should sort by south type when clicking the column header', () => {
     const fixture = TestBed.createComponent(HistoryQueryListComponent);
     fixture.detectChanges();

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -2912,6 +2912,7 @@
     "south-type": "South type",
     "north-type": "North type",
     "interval": "Interval",
+    "item-progress": "{{ current }}/{{ total }} items",
     "query-time-range": {
       "start": "Start",
       "end": "End",
@@ -3037,7 +3038,22 @@
         "last-run-start": "Last run",
         "last-run-duration": "Last run duration",
         "data-retrieved": "Data retrieved",
-        "interval-progress": "Interval progress"
+        "interval-progress": "Interval progress",
+        "current-item": "Current item: {{ name }} ({{ current }} / {{ total }})",
+        "item-progress": "Items processed",
+        "item-interval-progress": "Current item progress",
+        "values-per-second": "Values/files per second",
+        "eta": "Estimated time remaining",
+        "items-status": {
+          "title": "Items status",
+          "name": "Name",
+          "status": "Status",
+          "last-value": "Last value retrieved",
+          "records": "Records retrieved",
+          "pending": "Pending",
+          "running": "Running",
+          "done": "Done"
+        }
       }
     },
     "tooltips": {


### PR DESCRIPTION
UI after the changes:

<img width="1600" height="1100" alt="01-list" src="https://github.com/user-attachments/assets/f8b832c7-87eb-4e75-9fd8-14f080171158" />
<img width="1400" height="100" alt="01-list-zoomed" src="https://github.com/user-attachments/assets/29ba250c-c027-4ac1-bc0d-5a90a700196f" />
<img width="1600" height="1420" alt="02-detail" src="https://github.com/user-attachments/assets/06b4cecb-6127-4bb8-b7a8-28a93b59bc28" />


Closes #4829 