### PR TITLE
fix(ads): stop testConnection/testItem from mutating the live client

### DIFF
--- a/backend/src/south/south-ads/south-ads.spec.ts
+++ b/backend/src/south/south-ads/south-ads.spec.ts
@@ -589,7 +589,10 @@ describe('South ADS', () => {
       mock.fn(async () => undefined)
     );
     const result = await south.testConnection();
-    assert.strictEqual(disconnectMock.mock.calls.length, 1);
+    // testConnection() must never touch the connector's own disconnect()/this.client
+    assert.strictEqual(disconnectMock.mock.calls.length, 0);
+    assert.strictEqual((south as unknown as Record<string, unknown>)['client'], null);
+    assert.strictEqual(disconnect.mock.calls.length, 1); // the local test client was closed instead
     assert.deepStrictEqual(result, {
       items: [
         { key: 'Device name', value: 'TestDevice' },
@@ -600,7 +603,7 @@ describe('South ADS', () => {
     });
   });
 
-  it('should disconnect even when testConnection device info fetch fails', async () => {
+  it('should close the local test client even when testConnection device info fetch fails', async () => {
     readDeviceInfo.mock.mockImplementation(() => {
       throw new Error('readDeviceInfo failed');
     });
@@ -610,7 +613,37 @@ describe('South ADS', () => {
       mock.fn(async () => undefined)
     );
     await assert.rejects(south.testConnection(), new Error('readDeviceInfo failed'));
-    assert.strictEqual(disconnectMock.mock.calls.length, 1);
+    assert.strictEqual(disconnectMock.mock.calls.length, 0);
+    assert.strictEqual((south as unknown as Record<string, unknown>)['client'], null);
+    assert.strictEqual(disconnect.mock.calls.length, 1);
+  });
+
+  it('should reuse the live client in testConnection without touching this.client or reconnectTimeout', async () => {
+    await south.start();
+    await south.connect();
+    connect.mock.resetCalls();
+    const liveClient = (south as unknown as Record<string, unknown>)['client'];
+    assert.ok(liveClient !== null);
+
+    (south as unknown as Record<string, unknown>)['reconnectTimeout'] = 'sentinel';
+
+    const result = await south.testConnection();
+
+    // No new Client was created — the live one was reused
+    assert.strictEqual(connect.mock.calls.length, 0);
+    // this.client must be untouched: same reference, still set, never nulled or disconnected
+    assert.strictEqual((south as unknown as Record<string, unknown>)['client'], liveClient);
+    assert.strictEqual(disconnect.mock.calls.length, 0);
+    // this.reconnectTimeout must be untouched
+    assert.strictEqual((south as unknown as Record<string, unknown>)['reconnectTimeout'], 'sentinel');
+    assert.deepStrictEqual(result, {
+      items: [
+        { key: 'Device name', value: 'TestDevice' },
+        { key: 'Firmware version', value: '3.1.4000' },
+        { key: 'ADS state', value: 'Run' },
+        { key: 'Device state', value: '0' }
+      ]
+    });
   });
 
   it('should read symbol', async () => {
@@ -698,13 +731,10 @@ describe('South ADS', () => {
   });
 
   it('should test item and succeed', async () => {
-    const connectMock = mock.method(
-      south,
-      'connect',
-      mock.fn(async () => {
-        mock.timers.tick(15);
-      })
-    );
+    connect.mock.mockImplementationOnce(async () => {
+      mock.timers.tick(15);
+      return { targetAmsNetId: 'targetAmsNetId', localAmsNetId: 'localAmsNetId', localAdsPort: 'localAdsPort' };
+    });
     const disconnectMock = mock.method(
       south,
       'disconnect',
@@ -723,30 +753,66 @@ describe('South ADS', () => {
         return [mockedResult];
       })
     );
-    await south.start();
+    // Note: no south.start()/south.connect() here — this.client must stay null so testItem()
+    // exercises the "no live client" path and creates its own local client.
     const result = await south.testItem(configuration.items[0], testData.south.itemTestingSettings);
-    assert.strictEqual(disconnectMock.mock.calls.length, 1);
+    // testItem() must never touch the connector's own connect()/disconnect()/this.client
+    assert.strictEqual(disconnectMock.mock.calls.length, 0);
+    assert.strictEqual((south as unknown as Record<string, unknown>)['client'], null);
+    assert.strictEqual(disconnect.mock.calls.length, 1); // the local test client was closed instead
     assert.deepStrictEqual(result, {
       result: { type: 'time-values', content: [mockedResult] },
       connectionDuration: 15,
       queryDuration: 25
     });
-    assert.ok(connectMock.mock.calls.length >= 1);
+  });
+
+  it('should reuse the live client in testItem without touching this.client or reconnectTimeout', async () => {
+    await south.start();
+    await south.connect();
+    connect.mock.resetCalls();
+    const liveClient = (south as unknown as Record<string, unknown>)['client'];
+    assert.ok(liveClient !== null);
+
+    (south as unknown as Record<string, unknown>)['reconnectTimeout'] = 'sentinel';
+
+    const mockedResult = {
+      pointId: 'pointId',
+      timestamp: '2024-06-10T14:00:00.000Z',
+      data: { value: 42 }
+    };
+    const readAdsSymbolMock = mock.method(
+      south,
+      'readAdsSymbol',
+      mock.fn(async () => [mockedResult])
+    );
+
+    const result = await south.testItem(configuration.items[0], testData.south.itemTestingSettings);
+
+    // No new Client was created and connected — the live one was reused
+    assert.strictEqual(connect.mock.calls.length, 0);
+    // this.client must be untouched: same reference, still set, never nulled or disconnected
+    assert.strictEqual((south as unknown as Record<string, unknown>)['client'], liveClient);
+    assert.strictEqual(disconnect.mock.calls.length, 0);
+    // this.reconnectTimeout must be untouched
+    assert.strictEqual((south as unknown as Record<string, unknown>)['reconnectTimeout'], 'sentinel');
+    // readAdsSymbol was handed the reused live client, not a fresh one
+    assert.strictEqual(readAdsSymbolMock.mock.calls[0].arguments[2], liveClient);
+    assert.deepStrictEqual(result.result, { type: 'time-values', content: [mockedResult] });
+    assert.strictEqual(result.connectionDuration, 0);
   });
 
   it('should test item and throw an error', async () => {
-    mock.method(
-      south,
-      'connect',
-      mock.fn(async () => {
-        throw new Error('undefined');
-      })
-    );
+    connect.mock.mockImplementationOnce(() => {
+      throw new Error('undefined');
+    });
 
     await assert.rejects(
       south.testItem(configuration.items[0], testData.south.itemTestingSettings),
       new Error('Unable to connect. undefined')
     );
+    // Failure must not have left the connector's own this.client set or touched
+    assert.strictEqual((south as unknown as Record<string, unknown>)['client'], null);
   });
 
   it('should use readRawMulti when items are found in the PLC symbol table', async () => {

--- a/backend/src/south/south-ads/south-ads.ts
+++ b/backend/src/south/south-ads/south-ads.ts
@@ -270,8 +270,12 @@ export default class SouthADS extends SouthConnector<SouthADSSettings, SouthADSI
     return contentResult.length > 0 ? contentResult[contentResult.length - 1] : null;
   }
 
-  async readAdsSymbol(item: SouthConnectorItemEntity<SouthADSItemSettings>, timestamp: Instant): Promise<Array<OIBusTimeValue>> {
-    const result = await this.client!.readValue(item.settings.address);
+  async readAdsSymbol(
+    item: SouthConnectorItemEntity<SouthADSItemSettings>,
+    timestamp: Instant,
+    client: Client = this.client!
+  ): Promise<Array<OIBusTimeValue>> {
+    const result = await client.readValue(item.settings.address);
 
     return this.parseValues(
       `${this.connector.settings.plcName}${item.name}`,
@@ -287,14 +291,24 @@ export default class SouthADS extends SouthConnector<SouthADSSettings, SouthADSI
     item: SouthConnectorItemEntity<SouthADSItemSettings>,
     _testingSettings: SouthConnectorItemTestingSettings
   ): Promise<SouthConnectorItemQueryResult> {
+    // Reuse the already-connected live client when this instance is live and connected, instead of
+    // opening a second one on top of it. This.client (the connector's persistent connection) must
+    // never be mutated or closed from here — some ADS/TwinCAT routers also cap concurrent client
+    // connections, so reusing avoids exceeding that cap while the connector is running.
+    const reusingLiveClient = this.client !== null;
+    let client: Client | undefined = this.client ?? undefined;
+    let connectionDuration = 0;
     try {
-      const connectStart = DateTime.now().toMillis();
-      await this.connect();
-      const connectionDuration = DateTime.now().toMillis() - connectStart;
+      if (!client) {
+        const options = this.createConnectionOptions();
+        client = new Client(options);
+        const connectStart = DateTime.now().toMillis();
+        await client.connect();
+        connectionDuration = DateTime.now().toMillis() - connectStart;
+      }
       const queryStart = DateTime.now().toMillis();
-      const dataValues: Array<OIBusTimeValue> = await this.readAdsSymbol(item, DateTime.now().toUTC().toISO()!);
+      const dataValues: Array<OIBusTimeValue> = await this.readAdsSymbol(item, DateTime.now().toUTC().toISO()!, client);
       const queryDuration = DateTime.now().toMillis() - queryStart;
-      await this.disconnect();
       return {
         result: {
           type: 'time-values',
@@ -305,6 +319,10 @@ export default class SouthADS extends SouthConnector<SouthADSSettings, SouthADSI
       };
     } catch (error: unknown) {
       throw new Error(`Unable to connect. ${(error as Error).message}`);
+    } finally {
+      if (client && !reusingLiveClient) {
+        await this.closeLocalAdsClient(client);
+      }
     }
   }
 
@@ -361,11 +379,19 @@ export default class SouthADS extends SouthConnector<SouthADSSettings, SouthADSI
   }
 
   override async testConnection(): Promise<OIBusConnectionTestResult> {
-    const options = this.createConnectionOptions();
-    this.client = new Client(options);
-    await this.client.connect();
+    // Reuse the already-connected live client when this instance is live and connected, instead of
+    // opening a second one on top of it. This.client (the connector's persistent connection) must
+    // never be mutated or closed from here — some ADS/TwinCAT routers also cap concurrent client
+    // connections, so reusing avoids exceeding that cap while the connector is running.
+    const reusingLiveClient = this.client !== null;
+    let client: Client | undefined = this.client ?? undefined;
     try {
-      const [deviceInfo, state] = await Promise.all([this.client.readDeviceInfo(), this.client.readState()]);
+      if (!client) {
+        const options = this.createConnectionOptions();
+        client = new Client(options);
+        await client.connect();
+      }
+      const [deviceInfo, state] = await Promise.all([client.readDeviceInfo(), client.readState()]);
       return {
         items: [
           { key: 'Device name', value: deviceInfo.deviceName },
@@ -375,7 +401,23 @@ export default class SouthADS extends SouthConnector<SouthADSSettings, SouthADSI
         ]
       };
     } finally {
-      await this.disconnect();
+      if (client && !reusingLiveClient) {
+        await this.closeLocalAdsClient(client);
+      }
+    }
+  }
+
+  /**
+   * Close a local ADS client created for testConnection()/testItem(). This is separate from
+   * disconnectAdsClient()/disconnect() which operate on the connector's persistent this.client —
+   * it must never touch this.client or this.reconnectTimeout.
+   */
+  private async closeLocalAdsClient(client: Client): Promise<void> {
+    if (!client.connection.connected) return;
+    try {
+      await client.disconnect();
+    } catch (error) {
+      this.logger.error(`ADS test client disconnect error. ${error}`);
     }
   }
 


### PR DESCRIPTION
testConnection() and testItem() both created a new Client and assigned it to this.client (the connector's persistent connection), then called this.disconnect() at the end. If the connector was already connected when a user tested from the UI, this silently overwrote and orphaned the live client (leaked TCP connection), then disconnect() nulled this.client and cleared this.reconnectTimeout with nothing scheduled to bring it back — worse than a normal disconnect.

Both methods now use a local client instead of touching this.client:
- if the connector already has a live this.client, reuse it (mirrors south-opcua's reusingLiveSession pattern — some ADS/TwinCAT routers cap concurrent client connections too)
- otherwise create and connect a local Client, and close only that local client in a finally block (mirrors south-modbus's finally { socket.destroy(); })

Neither method calls this.connect()/this.disconnect() anymore, so this.client and this.reconnectTimeout are never touched by a test call.

readAdsSymbol() now accepts an optional client argument so testItem() can pass through whichever client (reused or local) it ended up using.

Added/updated unit tests covering: local client creation and cleanup when no live connection exists, live client reuse without touching this.client/this.reconnectTimeout, and the error path leaving this.client untouched.