### PR TITLE
fix(mqtt): stop testItem from disconnecting the connector's live client

### DIFF
--- a/backend/src/south/south-mqtt/south-mqtt.spec.ts
+++ b/backend/src/south/south-mqtt/south-mqtt.spec.ts
@@ -652,11 +652,13 @@ describe('SouthMQTT', () => {
     assert.deepStrictEqual(mqttStream.unsubscribeAsync.mock.calls[0].arguments, [configuration.items[0].settings.topic]);
     assert.strictEqual(mqttStream.end.mock.calls.length, 1);
     assert.deepStrictEqual(mqttStream.end.mock.calls[0].arguments, [true]);
-    assert.strictEqual(disconnectMock.mock.calls.length, 1);
+    // testItem() must never invoke the connector's own disconnect() lifecycle method: it would tear
+    // down this.client, the connector's persistent connection, instead of just the local test client.
+    assert.strictEqual(disconnectMock.mock.calls.length, 0);
   });
 
   it('should decode Buffer message as string when testing item', async () => {
-    mock.method(
+    const disconnectMock = mock.method(
       south,
       'disconnect',
       mock.fn(async () => undefined)
@@ -679,6 +681,8 @@ describe('SouthMQTT', () => {
     assert.strictEqual(parsed[0].message, 'hello from PLC');
     assert.strictEqual(result.connectionDuration, 15);
     assert.strictEqual(result.queryDuration, 25);
+    assert.strictEqual(mqttStream.end.mock.calls.length, 1);
+    assert.strictEqual(disconnectMock.mock.calls.length, 0);
   });
 
   it('should properly test item and manage unsubscribe error', async () => {
@@ -703,8 +707,10 @@ describe('SouthMQTT', () => {
 
     assert.strictEqual(mqttStream.unsubscribeAsync.mock.calls.length, 1);
     assert.deepStrictEqual(mqttStream.unsubscribeAsync.mock.calls[0].arguments, [configuration.items[0].settings.topic]);
-    assert.strictEqual(mqttStream.end.mock.calls.length, 0);
-    assert.strictEqual(disconnectMock.mock.calls.length, 1);
+    // Even on the message-handling error path, the local test client must still be closed exactly once.
+    assert.strictEqual(mqttStream.end.mock.calls.length, 1);
+    assert.deepStrictEqual(mqttStream.end.mock.calls[0].arguments, [true]);
+    assert.strictEqual(disconnectMock.mock.calls.length, 0);
     assert.strictEqual(
       error,
       `Error when testing item ${configuration.items[0].settings.topic} (received message "myMessage"): unsubscribe error`
@@ -729,7 +735,68 @@ describe('SouthMQTT', () => {
     await flushPromises();
     await testItemPromise;
 
-    assert.strictEqual(disconnectMock.mock.calls.length, 1);
+    // The local client was connected before subscribeAsync failed, so it must still be closed.
+    assert.strictEqual(mqttStream.end.mock.calls.length, 1);
+    assert.deepStrictEqual(mqttStream.end.mock.calls[0].arguments, [true]);
+    assert.strictEqual(disconnectMock.mock.calls.length, 0);
     assert.strictEqual(error, `Error when testing item ${configuration.items[0].settings.topic}: subscribe error`);
+  });
+
+  it('should not close any client when testing item fails to connect', async () => {
+    const disconnectMock = mock.method(
+      south,
+      'disconnect',
+      mock.fn(async () => undefined)
+    );
+    mqttExports.default.connectAsync = mock.fn(async () => {
+      throw new Error('connect error');
+    });
+
+    let error: unknown;
+    const testItemPromise = south.testItem(configuration.items[0], { history: undefined }).catch(err => {
+      error = err;
+    });
+    await flushPromises();
+    await testItemPromise;
+
+    // No client was ever created, so there is nothing to close and disconnect() must not be called.
+    assert.strictEqual(mqttStream.end.mock.calls.length, 0);
+    assert.strictEqual(disconnectMock.mock.calls.length, 0);
+    assert.strictEqual(error, `Error when testing item ${configuration.items[0].settings.topic}: connect error`);
+  });
+
+  it('should not touch or disconnect the connector own live client when testing item', async () => {
+    const disconnectMock = mock.method(
+      south,
+      'disconnect',
+      mock.fn(async () => undefined)
+    );
+
+    // Establish the connector's own persistent connection first, on a client distinct from the one
+    // testItem() will create, so a mix-up between the two is observable.
+    const liveClient = new MqttStreamMock();
+    mqttExports.default.connectAsync = mock.fn(async () => liveClient);
+    await south.connect();
+
+    const priv = south as unknown as { client: MqttClient | null };
+    assert.strictEqual(priv.client, liveClient);
+
+    const testClient = new MqttStreamMock();
+    mqttExports.default.connectAsync = mock.fn(async () => testClient);
+
+    const testItemPromise = south.testItem(configuration.items[0], { history: undefined });
+    await flushPromises();
+    testClient.emit('message', 'myTopic', 'myMessage', { dup: false });
+    await flushPromises();
+    await testItemPromise;
+
+    // The connector's live client must be left completely alone: not ended, not disconnected, still set.
+    assert.strictEqual(liveClient.end.mock.calls.length, 0);
+    assert.strictEqual(disconnectMock.mock.calls.length, 0);
+    assert.strictEqual(priv.client, liveClient);
+
+    // Only the local test client created inside testItem() gets closed.
+    assert.strictEqual(testClient.end.mock.calls.length, 1);
+    assert.deepStrictEqual(testClient.end.mock.calls[0].arguments, [true]);
   });
 });

--- a/backend/src/south/south-mqtt/south-mqtt.ts
+++ b/backend/src/south/south-mqtt/south-mqtt.ts
@@ -200,47 +200,55 @@ export default class SouthMQTT extends SouthConnector<SouthMQTTSettings, SouthMQ
     _testingSettings: SouthConnectorItemTestingSettings
   ): Promise<SouthConnectorItemQueryResult> {
     const options = await createConnectionOptions(this.connector.id, this.connector.settings, this.logger);
-    return new Promise<SouthConnectorItemQueryResult>((resolve, reject) => {
-      (async () => {
-        try {
-          const connectStart = DateTime.now().toMillis();
-          const client = await mqtt.connectAsync(this.connector.settings.url, options);
-          const connectionDuration = DateTime.now().toMillis() - connectStart;
-          const queryStart = DateTime.now().toMillis();
-          client.once('message', async (topic, message, _packet) => {
-            try {
-              const messageTimestamp: Instant = DateTime.now().toUTC().toISO()!;
-              await client.unsubscribeAsync(item.settings.topic);
-              client.end(true);
-              resolve({
-                result: {
-                  type: 'any-content',
-                  content: JSON.stringify([
-                    {
-                      message: message.toString(),
-                      timestamp: messageTimestamp,
-                      item: { id: item.id, name: item.name, topic: item.settings.topic }
-                    }
-                  ])
-                },
-                connectionDuration,
-                // The "query" here is really "how long we waited for the broker to push a matching
-                // message" — there's no traditional request/response, but this is still the
-                // meaningful span between subscribing and getting data.
-                queryDuration: DateTime.now().toMillis() - queryStart
-              });
-            } catch (error: unknown) {
-              reject(`Error when testing item ${item.settings.topic} (received message "${message}"): ${(error as Error).message}`);
-            }
-          });
-          await client.subscribeAsync(item.settings.topic);
-        } catch (error: unknown) {
-          reject(`Error when testing item ${item.settings.topic}: ${(error as Error).message}`);
-        }
-      })().catch(reject); // Immediately invoke the async IIFE and catch any errors
-    }).finally(async () => {
-      await this.disconnect();
-    });
+    // This is a short-lived local client used only for this one-off test, kept fully separate from
+    // this.client (the connector's persistent, shared subscription connection). It must be closed here,
+    // on every path (success, message-handling error, connect/subscribe error) — never through
+    // this.disconnect(), which would tear down the live connector connection instead.
+    let client: mqtt.MqttClient | undefined;
+    try {
+      return await new Promise<SouthConnectorItemQueryResult>((resolve, reject) => {
+        (async () => {
+          try {
+            const connectStart = DateTime.now().toMillis();
+            client = await mqtt.connectAsync(this.connector.settings.url, options);
+            const connectionDuration = DateTime.now().toMillis() - connectStart;
+            const queryStart = DateTime.now().toMillis();
+            client.once('message', async (topic, message, _packet) => {
+              try {
+                const messageTimestamp: Instant = DateTime.now().toUTC().toISO()!;
+                await client!.unsubscribeAsync(item.settings.topic);
+                resolve({
+                  result: {
+                    type: 'any-content',
+                    content: JSON.stringify([
+                      {
+                        message: message.toString(),
+                        timestamp: messageTimestamp,
+                        item: { id: item.id, name: item.name, topic: item.settings.topic }
+                      }
+                    ])
+                  },
+                  connectionDuration,
+                  // The "query" here is really "how long we waited for the broker to push a matching
+                  // message" — there's no traditional request/response, but this is still the
+                  // meaningful span between subscribing and getting data.
+                  queryDuration: DateTime.now().toMillis() - queryStart
+                });
+              } catch (error: unknown) {
+                reject(`Error when testing item ${item.settings.topic} (received message "${message}"): ${(error as Error).message}`);
+              }
+            });
+            await client.subscribeAsync(item.settings.topic);
+          } catch (error: unknown) {
+            reject(`Error when testing item ${item.settings.topic}: ${(error as Error).message}`);
+          }
+        })().catch(reject); // Immediately invoke the async IIFE and catch any errors
+      });
+    } finally {
+      // Close only the local test client. Do NOT call this.disconnect() here: it would close
+      // this.client, the connector's own live/persistent connection, as an unintended side effect.
+      client?.end(true);
+    }
   }
 
   async subscribe(items: Array<SouthConnectorItemEntity<SouthMQTTItemSettings>>): Promise<void> {


### PR DESCRIPTION
testItem() opened its own local MQTT client for the one-off test but the outer .finally() unconditionally called this.disconnect(), which tears down this.client, the connector's persistent, shared subscription connection. Testing an item from the UI while the connector was running would silently kill the live connection.

testItem() now tracks its local client in a function-scoped variable and closes only that client in a finally block, on every path (success, message-handling error, connect/subscribe error). this.disconnect() is no longer called from testItem() at all.

Adds/updates spec coverage: disconnect() is asserted never called from testItem(), the local client is closed on every path (including errors that previously left it open), and a new test verifies the connector's own live client (a distinct mock instance) is left completely untouched while testItem() runs against its own separate client.