### PR TITLE
fix(modbus): don't destroy live connection on testItem, fix reconnect backoff on directQuery failures

### DIFF
--- a/backend/src/south/south-modbus/south-modbus.spec.ts
+++ b/backend/src/south/south-modbus/south-modbus.spec.ts
@@ -688,6 +688,50 @@ describe('South Modbus', () => {
     await assert.rejects(south.directQuery(configuration.items), new Error('Could not read address: Modbus client not set'));
   });
 
+  it('should not keep resetting the reconnect timer when directQuery keeps failing while disconnected', async () => {
+    // Regression test: previously, every failed directQuery call unconditionally called disconnect()
+    // (which clears any pending reconnectTimeout) and then re-armed a brand new timer. If the scan
+    // mode interval is shorter than retryInterval, each subsequent scan tick — now failing fast with
+    // "Modbus client not set" because the connector is already disconnected — kept cancelling and
+    // recreating the timer, so connect() was never actually retried: the query failed forever at
+    // scan-mode rate without ever reconnecting.
+    const readHoldingRegistersMock = mock.fn(async (): Promise<never> => {
+      throw new Error('modbus function error');
+    });
+    (south as unknown as Record<string, unknown>)['socket'] = mockedEmitter;
+    (south as unknown as Record<string, unknown>)['modbusClient'] = { readHoldingRegisters: readHoldingRegistersMock };
+    (south as unknown as Record<string, unknown>)['connector'] = {
+      ...configuration,
+      settings: { ...configuration.settings, batchQuery: true }
+    };
+    south.addContent = mock.fn(async (): Promise<void> => undefined);
+    const disconnectSpy = mock.method(south, 'disconnect');
+
+    // First failure: the connection was actually live (socket/modbusClient set), so disconnect()
+    // runs for real and a reconnect timer is scheduled.
+    await assert.rejects(south.directQuery([configuration.items[1]]), new Error('modbus function error'));
+    assert.strictEqual(disconnectSpy.mock.calls.length, 1);
+    assert.strictEqual((south as unknown as Record<string, unknown>)['modbusClient'], null);
+    assert.notStrictEqual((south as unknown as Record<string, unknown>)['reconnectTimeout'], null);
+
+    // Simulate more scan-mode ticks firing before retryInterval elapses. Each hits the
+    // "Modbus client not set" fast-fail path since the connector is still disconnected/reconnecting —
+    // this must NOT call disconnect() again nor reset the pending reconnect timer.
+    mock.timers.tick(configuration.settings.retryInterval / 2);
+    await assert.rejects(south.directQuery(configuration.items), new Error('Could not read address: Modbus client not set'));
+    mock.timers.tick(configuration.settings.retryInterval / 2 - 1);
+    await assert.rejects(south.directQuery(configuration.items), new Error('Could not read address: Modbus client not set'));
+
+    assert.strictEqual(disconnectSpy.mock.calls.length, 1);
+    // No reconnect attempt yet — the original timer must still be the one counting down
+    assert.strictEqual(socketMock.mock.calls.length, 0);
+
+    // Advance past the *original* retryInterval (started at the first failure): if failed queries had
+    // kept resetting the timer, connect() would still not fire here.
+    mock.timers.tick(2);
+    assert.strictEqual(socketMock.mock.calls.length, 1);
+  });
+
   it('should call readCoil method', async () => {
     const mockedClient = {} as unknown as ModbusTCPClient;
     utilsModbusExports.readCoil = mock.fn(async (): Promise<string | undefined> => '123');
@@ -845,5 +889,51 @@ describe('South Modbus', () => {
         new Error(`${ERROR_CODES[code]}: ${errorMessage}`)
       );
     }
+  });
+
+  it('should close its own local socket on test item success without touching the connector live socket', async () => {
+    // Simulate a running connector with its own live socket/modbusClient
+    const liveSocket = { removeAllListeners: mock.fn(), destroy: mock.fn() };
+    const liveModbusClient = {};
+    (south as unknown as Record<string, unknown>)['socket'] = liveSocket;
+    (south as unknown as Record<string, unknown>)['modbusClient'] = liveModbusClient;
+    const disconnectMock = mock.fn(async (): Promise<void> => undefined);
+    south.disconnect = disconnectMock;
+    const destroyMock = mock.method(mockedEmitter, 'destroy');
+
+    await south.testItem(configuration.items[0], testData.south.itemTestingSettings);
+
+    // testItem's own local socket (the mocked net.Socket instance) must be destroyed
+    assert.strictEqual(destroyMock.mock.calls.length, 1);
+    // The connector's own disconnect() must never be invoked by testItem
+    assert.strictEqual(disconnectMock.mock.calls.length, 0);
+    // The connector's live socket/modbusClient must be left untouched
+    assert.strictEqual((south as unknown as Record<string, unknown>)['socket'], liveSocket);
+    assert.strictEqual((south as unknown as Record<string, unknown>)['modbusClient'], liveModbusClient);
+    assert.strictEqual(liveSocket.destroy.mock.calls.length, 0);
+    assert.strictEqual(liveSocket.removeAllListeners.mock.calls.length, 0);
+  });
+
+  it('should close its own local socket on test item failure without touching the connector live socket', async () => {
+    const liveSocket = { removeAllListeners: mock.fn(), destroy: mock.fn() };
+    const liveModbusClient = {};
+    (south as unknown as Record<string, unknown>)['socket'] = liveSocket;
+    (south as unknown as Record<string, unknown>)['modbusClient'] = liveModbusClient;
+    const disconnectMock = mock.fn(async (): Promise<void> => undefined);
+    south.disconnect = disconnectMock;
+    const destroyMock = mock.method(mockedEmitter, 'destroy');
+
+    utilsModbusExports.connectSocket = mock.fn(async () => {
+      throw new ModbusError('Error creating connection to socket', 'ECONNREFUSED');
+    });
+
+    await assert.rejects(south.testItem(configuration.items[0], testData.south.itemTestingSettings));
+
+    assert.strictEqual(destroyMock.mock.calls.length, 1);
+    assert.strictEqual(disconnectMock.mock.calls.length, 0);
+    assert.strictEqual((south as unknown as Record<string, unknown>)['socket'], liveSocket);
+    assert.strictEqual((south as unknown as Record<string, unknown>)['modbusClient'], liveModbusClient);
+    assert.strictEqual(liveSocket.destroy.mock.calls.length, 0);
+    assert.strictEqual(liveSocket.removeAllListeners.mock.calls.length, 0);
   });
 });

--- a/backend/src/south/south-modbus/south-modbus.ts
+++ b/backend/src/south/south-modbus/south-modbus.ts
@@ -125,8 +125,8 @@ export default class SouthModbus extends SouthConnector<SouthModbusSettings, Sou
     item: SouthConnectorItemEntity<SouthModbusItemSettings>,
     _testingSettings: SouthConnectorItemTestingSettings
   ): Promise<SouthConnectorItemQueryResult> {
+    const socket = new net.Socket();
     try {
-      const socket = new net.Socket();
       const modbusClient = new client.TCP(socket, this.connector.settings.slaveId);
       const connectStart = DateTime.now().toMillis();
       await connectSocket(socket, this.connector.settings);
@@ -134,7 +134,6 @@ export default class SouthModbus extends SouthConnector<SouthModbusSettings, Sou
       const queryStart = DateTime.now().toMillis();
       const dataValues: Array<OIBusTimeValue> = await this.modbusFunction(modbusClient, item);
       const queryDuration = DateTime.now().toMillis() - queryStart;
-      await this.disconnect();
       return {
         result: {
           type: 'time-values',
@@ -151,6 +150,8 @@ export default class SouthModbus extends SouthConnector<SouthModbusSettings, Sou
         default:
           throw new Error(`Unable to connect to socket: ${(error as Error).message}`);
       }
+    } finally {
+      socket.destroy();
     }
   }
 
@@ -204,9 +205,17 @@ export default class SouthModbus extends SouthConnector<SouthModbusSettings, Sou
       this.logger.debug(`Requested ${items.length} items in ${requestDuration} ms`);
       await this.addContent({ type: 'time-values', content: dataValues }, startRequest.toUTC().toISO(), items);
     } catch (error: unknown) {
-      await this.disconnect();
-      if (!this.disconnecting && this.connector.enabled && !this.reconnectTimeout) {
-        this.reconnectTimeout = setTimeout(this.connect.bind(this), this.connector.settings.retryInterval);
+      // Only tear down and (re)schedule a reconnect when this failure happened on a connection that
+      // was actually up (modbusClient/socket still set). Once they are null, a reconnect is already
+      // pending — either scheduled below on a previous tick or by the socket 'close' handler. Calling
+      // disconnect() unconditionally on every subsequent scan-mode tick would clear that pending timer
+      // and immediately re-arm a fresh one, so the retryInterval backoff would never elapse and
+      // connect() would never actually be retried — the query would fail forever at scan-mode rate.
+      if (this.modbusClient || this.socket) {
+        await this.disconnect();
+        if (!this.disconnecting && this.connector.enabled && !this.reconnectTimeout) {
+          this.reconnectTimeout = setTimeout(this.connect.bind(this), this.connector.settings.retryInterval);
+        }
       }
       throw error;
     }


### PR DESCRIPTION
testItem() was calling this.disconnect(), which tears down the connector's own persistent socket/modbusClient instead of the local socket it created for the one-off test read. This leaked the local test socket on every call and, if the connector was currently connected, silently killed the live connection as a side effect of a UI "test item" click. Fixed by destroying testItem()'s own local socket in a finally block, mirroring testConnection(), and no longer touching the connector's disconnect() at all.

directQuery() unconditionally called this.disconnect() and re-armed a new reconnectTimeout on every failure. Since disconnect() clears any pending reconnectTimeout, and the engine keeps calling directQuery() on every scan-mode tick regardless of connection state, a query failure that outlives one scan cycle (e.g. the modbus server going down) would have every subsequent tick's fast-fail ("Modbus client not set") cancel the pending reconnect timer and re-schedule a fresh one. If the scan-mode interval is shorter than retryInterval, the timer never actually elapses and connect() is never retried — the query fails forever at scan-mode rate without reconnecting. Fixed by only tearing down/rescheduling when the failure happened on a connection that was actually live (modbusClient/socket still set); once both are null, a reconnect is already pending and subsequent fast-fail attempts just rethrow without disturbing the timer.