### PR TITLE
fix(north,south): clear stale SMB sessions to avoid Windows error 1219

### DIFF
--- a/backend/src/north/north-file-writer/north-file-writer.spec.ts
+++ b/backend/src/north/north-file-writer/north-file-writer.spec.ts
@@ -373,6 +373,56 @@ describe('NorthFileWriter', () => {
 
           await assert.rejects(async () => north.testConnection());
         });
+
+        // Windows refuses to add a session for a server that already has one under a different
+        // identity (system error 1219). Clearing any existing session first, unconditionally,
+        // before adding the new one makes mounting self-healing regardless of what left a
+        // previous session dangling (unclean shutdown, a prior failed attempt, a leftover test).
+        it('should clear any existing session before authenticating a new one', async () => {
+          configuration.settings.username = 'user';
+          configuration.settings.outputFolder = '\\\\server\\share\\out';
+          north = new NorthFileWriter(configuration, cacheService);
+          const deleteSpy = mock.method(north as unknown as Private, 'deleteNetworkSession', async () => undefined);
+
+          // `net` is missing on the test runner, so the add still rejects with ENOENT — that's
+          // enough to confirm deleteNetworkSession always runs first, before the add is attempted.
+          await assert.rejects(async () => (north as unknown as Private)['mountNetworkShare']('\\\\server\\share\\out'));
+          assert.strictEqual(deleteSpy.mock.calls.length, 1);
+          assert.deepStrictEqual(deleteSpy.mock.calls[0].arguments, ['\\\\server']);
+        });
+
+        // testConnection() is a one-off diagnostic call, not paired with disconnect() — without
+        // tearing its session down itself, it would stay open (and could conflict with the next
+        // mount attempt, see the 1219 error above) until something else happened to clean it up.
+        it('should tear down the SMB session after a successful testConnection', async () => {
+          configuration.settings.username = 'user';
+          configuration.settings.outputFolder = '\\\\server\\share\\out';
+          north = new NorthFileWriter(configuration, cacheService);
+          mock.method(north as unknown as Private, 'mountNetworkShare', async () => undefined);
+          const unmountSpy = mock.method(north as unknown as Private, 'unmountNetworkShare', async () => undefined);
+          mock.method(fs, 'writeFile', async () => undefined);
+          mock.method(fs, 'unlink', async () => undefined);
+          mock.method(fs, 'readdir', async () => [] as unknown as Array<string>);
+
+          await north.testConnection();
+
+          assert.strictEqual(unmountSpy.mock.calls.length, 1);
+        });
+
+        it('should tear down the SMB session after a failed testConnection', async () => {
+          configuration.settings.username = 'user';
+          configuration.settings.outputFolder = '\\\\server\\share\\out';
+          north = new NorthFileWriter(configuration, cacheService);
+          mock.method(north as unknown as Private, 'mountNetworkShare', async () => undefined);
+          const unmountSpy = mock.method(north as unknown as Private, 'unmountNetworkShare', async () => undefined);
+          mock.method(fs, 'writeFile', async () => {
+            throw new Error('EACCES');
+          });
+
+          await assert.rejects(async () => north.testConnection());
+
+          assert.strictEqual(unmountSpy.mock.calls.length, 1);
+        });
       }
     );
   });

--- a/backend/src/north/north-file-writer/north-file-writer.ts
+++ b/backend/src/north/north-file-writer/north-file-writer.ts
@@ -49,6 +49,13 @@ export default class NorthFileWriter extends NorthConnector<NorthFileWriterSetti
     const user = this.connector.settings.domain
       ? `${this.connector.settings.domain}\\${this.connector.settings.username}`
       : this.connector.settings.username;
+    // Clear any existing session to this server first. Windows refuses to add a new one when a
+    // connection is already active under a different identity (system error 1219: "Multiple
+    // connections to a server or shared resource by the same user, using more than one user
+    // name, are not allowed"). This can happen after an unclean shutdown, a previous failed
+    // mount attempt, or a prior testConnection() call that left its session open — best-effort,
+    // there may simply be nothing to remove.
+    await this.deleteNetworkSession(serverRoot);
     let password = '';
     try {
       password = this.connector.settings.password ? await encryptionService.decryptText(this.connector.settings.password) : '';
@@ -78,35 +85,46 @@ export default class NorthFileWriter extends NorthConnector<NorthFileWriterSetti
     if (!this.connector.settings.username) return;
     const serverRoot = folderPath.match(/^(\\\\[^\\]+)/)?.[1];
     if (!serverRoot) return;
+    await this.deleteNetworkSession(serverRoot);
+  }
+
+  private async deleteNetworkSession(serverRoot: string): Promise<void> {
     try {
       await execFile('net', ['use', `${serverRoot}\\IPC$`, '/delete', '/yes']);
     } catch {
-      // Ignore — session may have already been removed
+      // Ignore — session may not exist
     }
   }
 
   async testConnection(): Promise<OIBusConnectionTestResult> {
     await this.mountNetworkShare(this.connector.settings.outputFolder);
-    const outputFolder = path.resolve(this.connector.settings.outputFolder);
-
-    const testFile = path.join(outputFolder, `.oibus-write-test`);
     try {
-      await fs.writeFile(testFile, '');
-      await fs.unlink(testFile);
-    } catch (error: unknown) {
-      throw new Error(`Write access error on "${outputFolder}": ${(error as Error).message}`);
+      const outputFolder = path.resolve(this.connector.settings.outputFolder);
+
+      const testFile = path.join(outputFolder, `.oibus-write-test`);
+      try {
+        await fs.writeFile(testFile, '');
+        await fs.unlink(testFile);
+      } catch (error: unknown) {
+        throw new Error(`Write access error on "${outputFolder}": ${(error as Error).message}`);
+      }
+
+      const items: Array<{ key: string; value: string }> = [{ key: 'Output Folder', value: outputFolder }];
+
+      try {
+        const files = await fs.readdir(outputFolder);
+        items.push({ key: 'Files', value: String(files.length) });
+      } catch {
+        // File count not critical
+      }
+
+      return { items };
+    } finally {
+      // Tear down the session opened for this one-off test — testConnection() is not paired
+      // with a disconnect() call, so without this a session stays open until the next mount
+      // (which would otherwise be the only thing to clean it up).
+      await this.unmountNetworkShare(this.connector.settings.outputFolder);
     }
-
-    const items: Array<{ key: string; value: string }> = [{ key: 'Output Folder', value: outputFolder }];
-
-    try {
-      const files = await fs.readdir(outputFolder);
-      items.push({ key: 'Files', value: String(files.length) });
-    } catch {
-      // File count not critical
-    }
-
-    return { items };
   }
 
   async handleContent(fileStream: ReadStream, cacheMetadata: CacheMetadata): Promise<void> {

--- a/backend/src/south/south-folder-scanner/south-folder-scanner.spec.ts
+++ b/backend/src/south/south-folder-scanner/south-folder-scanner.spec.ts
@@ -581,6 +581,83 @@ describe('SouthFolderScanner', () => {
           await assert.doesNotReject((south as unknown as Private)['unmountNetworkShare']('C:\\local\\folder'));
         });
 
+        // Windows refuses to add a session for a server that already has one under a different
+        // identity (system error 1219). Clearing any existing session first, unconditionally,
+        // before adding the new one makes mounting self-healing regardless of what left a
+        // previous session dangling (unclean shutdown, a prior failed attempt, a leftover test).
+        it('should clear any existing session before authenticating a new one', async () => {
+          configuration.settings.username = 'user';
+          configuration.settings.inputFolder = '\\\\server\\share\\data';
+          south = new SouthFolderScanner(configuration, addContentCallback, southCacheRepository, 'cacheFolder');
+          type Private = Record<string, (...args: Array<unknown>) => Promise<unknown>>;
+          const deleteSpy = mock.method(south as unknown as Private, 'deleteNetworkSession', async () => undefined);
+
+          // `net` is missing on the test runner, so the add still rejects with ENOENT — that's
+          // enough to confirm deleteNetworkSession always runs first, before the add is attempted.
+          await assert.rejects(async () => (south as unknown as Private)['mountNetworkShare']('\\\\server\\share\\data'));
+          assert.strictEqual(deleteSpy.mock.calls.length, 1);
+          assert.deepStrictEqual(deleteSpy.mock.calls[0].arguments, ['\\\\server']);
+        });
+
+        // testConnection() is a one-off diagnostic call, not paired with disconnect() — without
+        // tearing its session down itself, it would stay open (and could conflict with the next
+        // mount attempt, see the 1219 error above) until something else happened to clean it up.
+        it('should tear down the SMB session after a successful testConnection', async () => {
+          configuration.settings.username = 'user';
+          configuration.settings.inputFolder = '\\\\server\\share\\data';
+          south = new SouthFolderScanner(configuration, addContentCallback, southCacheRepository, 'cacheFolder');
+          type Private = Record<string, (...args: Array<unknown>) => Promise<unknown>>;
+          mock.method(south as unknown as Private, 'mountNetworkShare', async () => undefined);
+          const unmountSpy = mock.method(south as unknown as Private, 'unmountNetworkShare', async () => undefined);
+          mock.method(fs, 'access', async () => undefined);
+          mock.method(fs, 'stat', async () => ({ isDirectory: () => true }));
+          mock.method(fs, 'readdir', async () => [] as unknown as Array<string>);
+
+          await south.testConnection();
+
+          assert.strictEqual(unmountSpy.mock.calls.length, 1);
+        });
+
+        it('should tear down the SMB session after a failed testConnection', async () => {
+          configuration.settings.username = 'user';
+          configuration.settings.inputFolder = '\\\\server\\share\\data';
+          south = new SouthFolderScanner(configuration, addContentCallback, southCacheRepository, 'cacheFolder');
+          type Private = Record<string, (...args: Array<unknown>) => Promise<unknown>>;
+          mock.method(south as unknown as Private, 'mountNetworkShare', async () => undefined);
+          const unmountSpy = mock.method(south as unknown as Private, 'unmountNetworkShare', async () => undefined);
+          mock.method(fs, 'access', async () => {
+            throw new Error('ENOENT');
+          });
+
+          await assert.rejects(async () => south.testConnection());
+
+          assert.strictEqual(unmountSpy.mock.calls.length, 1);
+        });
+
+        // testItem() used to reuse testConnection()'s mounted session for the file listing that
+        // follows it. Now that testConnection() tears its own session down before returning,
+        // testItem() must own its own mount/unmount pair around the whole operation instead of
+        // relying on testConnection() to leave the session up — this locks that in.
+        it('should keep the SMB session up for the whole testItem call, not just testConnection', async () => {
+          configuration.settings.username = 'user';
+          configuration.settings.inputFolder = '\\\\server\\share\\data';
+          south = new SouthFolderScanner(configuration, addContentCallback, southCacheRepository, 'cacheFolder');
+          type Private = Record<string, (...args: Array<unknown>) => Promise<unknown>>;
+          const mountSpy = mock.method(south as unknown as Private, 'mountNetworkShare', async () => undefined);
+          const unmountSpy = mock.method(south as unknown as Private, 'unmountNetworkShare', async () => undefined);
+          mock.method(fs, 'access', async () => undefined);
+          mock.method(fs, 'stat', async () => ({ isDirectory: () => true, mtimeMs: 1600000000000, size: 512 }));
+          mock.method(fs, 'readdir', async () => ['file1.csv']);
+          utilsExports.checkAge = mock.fn(() => true);
+
+          await south.testItem(configuration.items[0], { history: undefined } satisfies SouthConnectorItemTestingSettings);
+
+          // Mounted and unmounted exactly once for the whole call — testConnection() is used
+          // internally for its validation logic only, without mounting/unmounting on its own.
+          assert.strictEqual(mountSpy.mock.calls.length, 1);
+          assert.strictEqual(unmountSpy.mock.calls.length, 1);
+        });
+
         it('should silently ignore SMB session removal failures on Windows', async () => {
           configuration.settings.username = 'user';
           configuration.settings.inputFolder = '\\\\server\\share\\data';

--- a/backend/src/south/south-folder-scanner/south-folder-scanner.ts
+++ b/backend/src/south/south-folder-scanner/south-folder-scanner.ts
@@ -60,6 +60,13 @@ export default class SouthFolderScanner
     const user = this.connector.settings.domain
       ? `${this.connector.settings.domain}\\${this.connector.settings.username}`
       : this.connector.settings.username;
+    // Clear any existing session to this server first. Windows refuses to add a new one when a
+    // connection is already active under a different identity (system error 1219: "Multiple
+    // connections to a server or shared resource by the same user, using more than one user
+    // name, are not allowed"). This can happen after an unclean shutdown, a previous failed
+    // mount attempt, or a prior testConnection()/testItem() call that left its session open —
+    // best-effort, there may simply be nothing to remove.
+    await this.deleteNetworkSession(serverRoot);
     let password = '';
     try {
       password = this.connector.settings.password ? await encryptionService.decryptText(this.connector.settings.password) : '';
@@ -89,15 +96,36 @@ export default class SouthFolderScanner
     if (!this.connector.settings.username) return;
     const serverRoot = folderPath.match(/^(\\\\[^\\]+)/)?.[1];
     if (!serverRoot) return;
+    await this.deleteNetworkSession(serverRoot);
+  }
+
+  private async deleteNetworkSession(serverRoot: string): Promise<void> {
     try {
       await execFile('net', ['use', `${serverRoot}\\IPC$`, '/delete', '/yes']);
     } catch {
-      // Ignore — session may have already been removed
+      // Ignore — session may not exist
     }
   }
 
   override async testConnection(): Promise<OIBusConnectionTestResult> {
     await this.mountNetworkShare(this.connector.settings.inputFolder);
+    try {
+      return await this.checkFolderAccess();
+    } finally {
+      // Tear down the session opened for this one-off test — testConnection() is not paired
+      // with a disconnect() call, so without this a session stays open until the next mount
+      // (which would otherwise be the only thing to clean it up).
+      await this.unmountNetworkShare(this.connector.settings.inputFolder);
+    }
+  }
+
+  /**
+   * Checks that the input folder exists, is readable and is a directory. Assumes any required
+   * SMB session has already been mounted by the caller — does not manage the mount itself, so
+   * it can be reused by both testConnection() (which owns its own mount/unmount pair) and
+   * testItem() (which needs the mount to stay up for the file listing that follows).
+   */
+  private async checkFolderAccess(): Promise<OIBusConnectionTestResult> {
     const inputFolder = path.resolve(this.connector.settings.inputFolder);
 
     try {
@@ -133,31 +161,38 @@ export default class SouthFolderScanner
     item: SouthConnectorItemEntity<SouthFolderScannerItemSettings>,
     _testingSettings: SouthConnectorItemTestingSettings
   ): Promise<SouthConnectorItemQueryResult> {
-    const connectStart = DateTime.now().toMillis();
-    await this.testConnection();
-    const connectionDuration = DateTime.now().toMillis() - connectStart;
-    const queryStart = DateTime.now().toMillis();
-    const inputFolder = path.resolve(this.connector.settings.inputFolder);
-    const filesInFolder = await fs.readdir(inputFolder);
-    const filteredFiles = filesInFolder.filter(file => file.match(item.settings.regex));
-    const matchedFiles: Array<{ name: string; modifyTime: Instant }> = [];
-    for (const file of filteredFiles) {
-      const stats = await fs.stat(path.join(inputFolder, file));
-      if (checkAge(item, file, stats.mtimeMs, [], this.logger)) {
-        matchedFiles.push({ name: file, modifyTime: DateTime.fromMillis(stats.mtimeMs).toUTC().toISO()! });
+    // Mount for the whole operation (not via testConnection(), which tears its own session down
+    // before returning) since the file listing below needs the SMB session to still be up.
+    await this.mountNetworkShare(this.connector.settings.inputFolder);
+    try {
+      const connectStart = DateTime.now().toMillis();
+      await this.checkFolderAccess();
+      const connectionDuration = DateTime.now().toMillis() - connectStart;
+      const queryStart = DateTime.now().toMillis();
+      const inputFolder = path.resolve(this.connector.settings.inputFolder);
+      const filesInFolder = await fs.readdir(inputFolder);
+      const filteredFiles = filesInFolder.filter(file => file.match(item.settings.regex));
+      const matchedFiles: Array<{ name: string; modifyTime: Instant }> = [];
+      for (const file of filteredFiles) {
+        const stats = await fs.stat(path.join(inputFolder, file));
+        if (checkAge(item, file, stats.mtimeMs, [], this.logger)) {
+          matchedFiles.push({ name: file, modifyTime: DateTime.fromMillis(stats.mtimeMs).toUTC().toISO()! });
+        }
       }
+      const queryDuration = DateTime.now().toMillis() - queryStart;
+      const values: Array<OIBusTimeValue> = matchedFiles.map(file => ({
+        pointId: item.name,
+        timestamp: file.modifyTime,
+        data: { value: file.name }
+      }));
+      return {
+        result: { type: 'time-values', content: values },
+        connectionDuration,
+        queryDuration
+      };
+    } finally {
+      await this.unmountNetworkShare(this.connector.settings.inputFolder);
     }
-    const queryDuration = DateTime.now().toMillis() - queryStart;
-    const values: Array<OIBusTimeValue> = matchedFiles.map(file => ({
-      pointId: item.name,
-      timestamp: file.modifyTime,
-      data: { value: file.name }
-    }));
-    return {
-      result: { type: 'time-values', content: values },
-      connectionDuration,
-      queryDuration
-    };
   }
 
   /**


### PR DESCRIPTION
net use refuses to authenticate a new session to a server that already has one under a different identity (system error 1219: "Multiple connections to a server or shared resource by the same user, using more than one user name, are not allowed"). This surfaced in the field after switching from cmdkey to net use: repeated "Test settings" calls (which mounted a session but never tore it down) or an unclean restart could leave a stale session that then blocked the next legitimate one.

- mountNetworkShare now clears any existing session for the target server before authenticating a new one, unconditionally and best-effort.
- testConnection() now unmounts its session in a finally block, since it isn't paired with disconnect() and would otherwise leave one open.
- South Folder Scanner's testItem() used to piggyback on testConnection() leaving its session mounted; since testConnection() now tears its own down, testItem() mounts/unmounts around its own whole operation instead, and reuses the folder-access check via a new checkFolderAccess() helper that doesn't manage the mount itself.