### PR TITLE
Add an audit trail for configuration changes (create/update/delete with before/after snapshots) #4856

### DIFF
--- a/backend/shared/model/audit.model.ts
+++ b/backend/shared/model/audit.model.ts
@@ -1,0 +1,67 @@
+export type AuditAction = 'CREATE' | 'UPDATE' | 'DELETE';
+
+export type AuditEntityType =
+  | 'south_connector'
+  | 'south_item'
+  | 'south_item_group'
+  | 'north_connector'
+  | 'north_transformer'
+  | 'history_query'
+  | 'history_query_item'
+  | 'history_query_transformer'
+  | 'scan_mode'
+  | 'ip_filter'
+  | 'certificate'
+  | 'user'
+  | 'transformer'
+  | 'engine'
+  | 'oianalytics_registration';
+
+/**
+ * Data Transfer Object for an audit log entry.
+ * Represents a single create/update/delete event recorded against an audited entity.
+ */
+export interface AuditLogDTO {
+  /**
+   * The unique identifier of the audit log entry.
+   */
+  id: string;
+
+  /**
+   * The type of entity this audit log entry relates to.
+   * @example "south_connector"
+   */
+  entityType: AuditEntityType;
+
+  /**
+   * The identifier of the entity this audit log entry relates to.
+   */
+  entityId: string;
+
+  /**
+   * The kind of change performed on the entity.
+   * @example "UPDATE"
+   */
+  action: AuditAction;
+
+  /**
+   * A JSON snapshot of the entity before the change. `null` for `CREATE`.
+   */
+  previousState: Record<string, unknown> | null;
+
+  /**
+   * A JSON snapshot of the entity after the change. `null` for `DELETE`.
+   */
+  newState: Record<string, unknown> | null;
+
+  /**
+   * The identifier of the user who performed the change.
+   */
+  userId: string;
+
+  /**
+   * ISO timestamp of when the change was recorded.
+   * @example "2026-01-01T00:00:00.000Z"
+   */
+  createdAt: string;
+}

--- a/backend/shared/model/audit.model.ts
+++ b/backend/shared/model/audit.model.ts
@@ -1,21 +1,38 @@
-export type AuditAction = 'CREATE' | 'UPDATE' | 'DELETE';
+/**
+ * List of possible audit actions.
+ */
+export const AUDIT_ACTIONS = ['CREATE', 'UPDATE', 'DELETE'] as const;
+/**
+ * Type representing an audit action.
+ * @example 'UPDATE'
+ */
+export type AuditAction = (typeof AUDIT_ACTIONS)[number];
 
-export type AuditEntityType =
-  | 'south_connector'
-  | 'south_item'
-  | 'south_item_group'
-  | 'north_connector'
-  | 'north_transformer'
-  | 'history_query'
-  | 'history_query_item'
-  | 'history_query_transformer'
-  | 'scan_mode'
-  | 'ip_filter'
-  | 'certificate'
-  | 'user'
-  | 'transformer'
-  | 'engine'
-  | 'oianalytics_registration';
+/**
+ * List of possible audited entity types.
+ */
+export const AUDIT_ENTITY_TYPES = [
+  'south_connector',
+  'south_item',
+  'south_item_group',
+  'north_connector',
+  'north_transformer',
+  'history_query',
+  'history_query_item',
+  'history_query_transformer',
+  'scan_mode',
+  'ip_filter',
+  'certificate',
+  'user',
+  'transformer',
+  'engine',
+  'oianalytics_registration'
+] as const;
+/**
+ * Type representing an audited entity type.
+ * @example 'south_connector'
+ */
+export type AuditEntityType = (typeof AUDIT_ENTITY_TYPES)[number];
 
 /**
  * Data Transfer Object for an audit log entry.

--- a/backend/shared/model/engine.model.ts
+++ b/backend/shared/model/engine.model.ts
@@ -1057,6 +1057,13 @@ export interface EngineProxyCommandDTO {
  */
 export interface EngineLoggerCommandDTO {
   /**
+   * Number of days audit log entries are kept before being pruned. `null` (or 0) means audit logs
+   * are kept forever.
+   * @example 90
+   */
+  auditRetentionDuration: number | null;
+
+  /**
    * Console logging configuration.
    */
   console: {

--- a/backend/shared/model/engine.model.ts
+++ b/backend/shared/model/engine.model.ts
@@ -43,6 +43,13 @@ export interface EngineSettingsDTO extends BaseEntity {
   launcherVersion: string;
 
   /**
+   * Number of days audit log entries are kept before being pruned. `null` (or 0) means audit logs
+   * are kept forever.
+   * @example 90
+   */
+  auditRetentionDuration: number | null;
+
+  /**
    * General engine settings.
    */
   general: {
@@ -945,6 +952,13 @@ export interface EngineSettingsCommandDTO {
   proxyServer: EngineProxyCommandDTO;
 
   logger: EngineLoggerCommandDTO;
+
+  /**
+   * Number of days audit log entries are kept before being pruned. `null` (or 0) means audit logs
+   * are kept forever.
+   * @example 90
+   */
+  auditRetentionDuration: number | null;
 }
 
 /**

--- a/backend/src/engine/data-stream-engine.spec.ts
+++ b/backend/src/engine/data-stream-engine.spec.ts
@@ -818,13 +818,19 @@ describe('DataStreamEngine', () => {
         const spyReloadHistoryQuery = mock.method(engine, 'reloadHistoryQuery', async () => undefined);
         const spyUpdateNorthConfig = mock.method(engine, 'updateNorthConfiguration');
 
-        await engine.removeAndReloadTransformer(transformerId);
+        await engine.removeAndReloadTransformer(transformerId, 'user1');
 
         assert.ok(logger.debug.mock.calls.some(c => (c.arguments[0] as string).includes(transformerId)));
         assert.strictEqual(northConnectorRepository.removeTransformersByTransformerId.mock.calls.length, 1);
-        assert.deepStrictEqual(northConnectorRepository.removeTransformersByTransformerId.mock.calls[0].arguments, [transformerId]);
+        assert.deepStrictEqual(northConnectorRepository.removeTransformersByTransformerId.mock.calls[0].arguments, [
+          transformerId,
+          'user1'
+        ]);
         assert.strictEqual(historyQueryRepository.removeTransformersByTransformerId.mock.calls.length, 1);
-        assert.deepStrictEqual(historyQueryRepository.removeTransformersByTransformerId.mock.calls[0].arguments, [transformerId]);
+        assert.deepStrictEqual(historyQueryRepository.removeTransformersByTransformerId.mock.calls[0].arguments, [
+          transformerId,
+          'user1'
+        ]);
         assert.strictEqual(spyUpdateNorthConfig.mock.calls.length, 1);
         assert.deepStrictEqual(spyUpdateNorthConfig.mock.calls[0].arguments, [testData.north.list[0].id]);
         assert.strictEqual(spyReloadHistoryQuery.mock.calls.length, 1);
@@ -835,16 +841,18 @@ describe('DataStreamEngine', () => {
         const spyReloadHistoryQuery = mock.method(engine, 'reloadHistoryQuery', async () => undefined);
         const spyUpdateNorthConfig = mock.method(engine, 'updateNorthConfiguration');
 
-        await engine.removeAndReloadTransformer('non-existent-transformer-id');
+        await engine.removeAndReloadTransformer('non-existent-transformer-id', 'user1');
 
         assert.strictEqual(logger.debug.mock.calls.length, 0);
         assert.strictEqual(northConnectorRepository.removeTransformersByTransformerId.mock.calls.length, 1);
         assert.deepStrictEqual(northConnectorRepository.removeTransformersByTransformerId.mock.calls[0].arguments, [
-          'non-existent-transformer-id'
+          'non-existent-transformer-id',
+          'user1'
         ]);
         assert.strictEqual(historyQueryRepository.removeTransformersByTransformerId.mock.calls.length, 1);
         assert.deepStrictEqual(historyQueryRepository.removeTransformersByTransformerId.mock.calls[0].arguments, [
-          'non-existent-transformer-id'
+          'non-existent-transformer-id',
+          'user1'
         ]);
         assert.strictEqual(spyUpdateNorthConfig.mock.calls.length, 0);
         assert.strictEqual(spyReloadHistoryQuery.mock.calls.length, 0);

--- a/backend/src/engine/data-stream-engine.spec.ts
+++ b/backend/src/engine/data-stream-engine.spec.ts
@@ -827,10 +827,7 @@ describe('DataStreamEngine', () => {
           'user1'
         ]);
         assert.strictEqual(historyQueryRepository.removeTransformersByTransformerId.mock.calls.length, 1);
-        assert.deepStrictEqual(historyQueryRepository.removeTransformersByTransformerId.mock.calls[0].arguments, [
-          transformerId,
-          'user1'
-        ]);
+        assert.deepStrictEqual(historyQueryRepository.removeTransformersByTransformerId.mock.calls[0].arguments, [transformerId, 'user1']);
         assert.strictEqual(spyUpdateNorthConfig.mock.calls.length, 1);
         assert.deepStrictEqual(spyUpdateNorthConfig.mock.calls[0].arguments, [testData.north.list[0].id]);
         assert.strictEqual(spyReloadHistoryQuery.mock.calls.length, 1);

--- a/backend/src/engine/data-stream-engine.ts
+++ b/backend/src/engine/data-stream-engine.ts
@@ -676,7 +676,7 @@ export default class DataStreamEngine {
     }
   }
 
-  async removeAndReloadTransformer(transformerId: string): Promise<void> {
+  async removeAndReloadTransformer(transformerId: string, updatedBy: string): Promise<void> {
     const affectedNorthIds: Array<string> = [];
     for (const north of this.northConnectors.values()) {
       if (north.north.connectorConfiguration.transformers.some(t => t.transformer.id === transformerId)) {
@@ -697,8 +697,8 @@ export default class DataStreamEngine {
       );
     }
 
-    this.northConnectorRepository.removeTransformersByTransformerId(transformerId);
-    this.historyQueryRepository.removeTransformersByTransformerId(transformerId);
+    this.northConnectorRepository.removeTransformersByTransformerId(transformerId, updatedBy);
+    this.historyQueryRepository.removeTransformersByTransformerId(transformerId, updatedBy);
 
     for (const northId of affectedNorthIds) {
       this.updateNorthConfiguration(northId);

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -31,6 +31,7 @@ import CertificateService from './service/certificate.service';
 import UserService from './service/user.service';
 import LogService from './service/log.service';
 import CleanupService from './service/cache/cleanup.service';
+import AuditCleanupService from './service/audit-cleanup.service';
 import TransformerService from './service/transformer.service';
 
 const CONFIG_DATABASE = 'oibus.db';
@@ -268,9 +269,13 @@ export async function bootstrap(): Promise<void> {
   );
   await cleanupService.start();
 
+  const auditCleanupService = new AuditCleanupService(repositoryService.auditRepository, repositoryService.engineRepository);
+  await auditCleanupService.start();
+
   const server = new WebServer(
     oibusSettings.webServer.port,
     encryptionService,
+    repositoryService.auditService,
     scanModeService,
     ipFilterService,
     certificateService,
@@ -300,6 +305,7 @@ export async function bootstrap(): Promise<void> {
     await oIAnalyticsMessageService.stop();
     await server.stop();
     await cleanupService.stop();
+    await auditCleanupService.stop();
     oIAnalyticsRegistrationService.stop();
     await loggerService.stop();
     console.info('OIBus stopped');

--- a/backend/src/migration/entity-migrations/3/3.10/v3.10.0_3.spec.ts
+++ b/backend/src/migration/entity-migrations/3/3.10/v3.10.0_3.spec.ts
@@ -1,0 +1,104 @@
+import { describe, it, after, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import knex, { Knex } from 'knex';
+import { buildPreMigrationSchema } from '../../../../tests/utils/test-utils';
+import { down, up } from './v3.10.0_3';
+
+describe('Entity migration v3.10.0_3', () => {
+  let db: Knex;
+
+  after(async () => {
+    await db?.destroy();
+  });
+
+  beforeEach(async () => {
+    await db?.destroy();
+    db = knex({ client: 'better-sqlite3', connection: { filename: ':memory:' }, useNullAsDefault: true });
+    await buildPreMigrationSchema(db, 'v3.10.0_3');
+
+    await db('engines').insert({
+      id: 'test-engine-id',
+      name: 'Test Engine',
+      port: 2223,
+      log_console_level: 'silent',
+      log_file_level: 'silent',
+      log_file_max_file_size: 50,
+      log_file_number_of_files: 5,
+      log_database_level: 'silent',
+      log_database_max_number_of_logs: 100000,
+      log_loki_level: 'silent',
+      log_loki_interval: 60,
+      log_oia_level: 'silent',
+      log_oia_interval: 10,
+      proxy_enabled: 0,
+      proxy_port: 9000,
+      oibus_version: '3.9.0',
+      created_at: '2026-01-01T00:00:00Z',
+      updated_at: '2026-01-01T00:00:00Z'
+    });
+  });
+
+  describe('up', () => {
+    it('creates the audit_logs table with the expected columns', async () => {
+      await up(db);
+
+      await db('audit_logs').insert({
+        id: 'audit1',
+        entity_type: 'south_connector',
+        entity_id: 'south1',
+        action: 'CREATE',
+        previous_state: null,
+        new_state: JSON.stringify({ name: 'South 1' }),
+        user_id: 'user1',
+        created_at: '2026-01-01T00:00:00.000Z'
+      });
+      const row = await db('audit_logs').where('id', 'audit1').first();
+      assert.strictEqual(row.entity_type, 'south_connector');
+      assert.strictEqual(row.entity_id, 'south1');
+      assert.strictEqual(row.action, 'CREATE');
+      assert.strictEqual(row.previous_state, null);
+      assert.strictEqual(row.new_state, JSON.stringify({ name: 'South 1' }));
+      assert.strictEqual(row.user_id, 'user1');
+      assert.strictEqual(row.created_at, '2026-01-01T00:00:00.000Z');
+
+      await db('audit_logs').insert({
+        id: 'audit2',
+        entity_type: 'south_connector',
+        entity_id: 'south1',
+        action: 'DELETE',
+        previous_state: JSON.stringify({ name: 'South 1' }),
+        new_state: null,
+        user_id: 'user1',
+        created_at: '2026-01-02T00:00:00.000Z'
+      });
+      const row2 = await db('audit_logs').where('id', 'audit2').first();
+      assert.strictEqual(row2.previous_state, JSON.stringify({ name: 'South 1' }));
+      assert.strictEqual(row2.new_state, null);
+    });
+
+    it('adds audit_retention_duration to engines and backfills it to 90', async () => {
+      await up(db);
+
+      const engine = await db('engines').where('id', 'test-engine-id').first();
+      assert.strictEqual(engine.audit_retention_duration, 90);
+    });
+  });
+
+  describe('down', () => {
+    it('drops the audit_logs table', async () => {
+      await up(db);
+      await down(db);
+
+      const table = await db('sqlite_master').where({ type: 'table', name: 'audit_logs' }).first();
+      assert.strictEqual(table, undefined);
+    });
+
+    it('removes the audit_retention_duration column from engines', async () => {
+      await up(db);
+      await down(db);
+
+      const cols = (await db.raw('PRAGMA table_info(engines)')) as Array<{ name: string }>;
+      assert.ok(!cols.map(c => c.name).includes('audit_retention_duration'));
+    });
+  });
+});

--- a/backend/src/migration/entity-migrations/3/3.10/v3.10.0_3.ts
+++ b/backend/src/migration/entity-migrations/3/3.10/v3.10.0_3.ts
@@ -1,0 +1,44 @@
+import { Knex } from 'knex';
+
+const AUDIT_LOGS_TABLE = 'audit_logs';
+const ENGINES_TABLE = 'engines';
+
+/**
+ * Introduces the audit trail feature:
+ *
+ *  1. A new `audit_logs` table recording every create/update/delete performed on an audited entity
+ *     (south/north connectors, items, scan modes, users, ...). `previous_state`/`new_state` hold a
+ *     JSON snapshot of the entity before/after the change — null for `CREATE` (no previous state) and
+ *     `DELETE` (no new state) respectively. Indexed by `(entity_type, entity_id)` for per-entity
+ *     history lookups, and by `created_at` for retention pruning and time-ranged searches.
+ *  2. `engines.audit_retention_duration`, the number of days audit log rows are kept before being
+ *     pruned (null/0 meaning "keep forever"), backfilled to 90 on the existing row.
+ */
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.createTable(AUDIT_LOGS_TABLE, table => {
+    table.string('id').primary();
+    table.string('entity_type').notNullable();
+    table.string('entity_id').notNullable();
+    table.string('action').notNullable();
+    table.text('previous_state').nullable();
+    table.text('new_state').nullable();
+    table.string('user_id').notNullable();
+    table.string('created_at').notNullable();
+    table.index(['entity_type', 'entity_id']);
+    table.index(['created_at']);
+  });
+
+  await knex.schema.alterTable(ENGINES_TABLE, table => {
+    table.integer('audit_retention_duration').nullable();
+  });
+
+  await knex(ENGINES_TABLE).update({ audit_retention_duration: 90 });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.dropTableIfExists(AUDIT_LOGS_TABLE);
+
+  await knex.schema.alterTable(ENGINES_TABLE, table => {
+    table.dropColumn('audit_retention_duration');
+  });
+}

--- a/backend/src/model/audit.model.ts
+++ b/backend/src/model/audit.model.ts
@@ -1,0 +1,38 @@
+export type AuditAction = 'CREATE' | 'UPDATE' | 'DELETE';
+
+export type AuditEntityType =
+  | 'south_connector'
+  | 'south_item'
+  | 'south_item_group'
+  | 'north_connector'
+  | 'north_transformer'
+  | 'history_query'
+  | 'history_query_item'
+  | 'history_query_transformer'
+  | 'scan_mode'
+  | 'ip_filter'
+  | 'certificate'
+  | 'user'
+  | 'transformer'
+  | 'engine'
+  | 'oianalytics_registration';
+
+export interface AuditLog {
+  id: string;
+  entityType: AuditEntityType;
+  entityId: string;
+  action: AuditAction;
+  previousState: Record<string, unknown> | null;
+  newState: Record<string, unknown> | null;
+  userId: string;
+  createdAt: string;
+}
+
+export interface AuditSearchParam {
+  entityType?: AuditEntityType;
+  entityId?: string;
+  action?: AuditAction;
+  start?: string;
+  end?: string;
+  page: number;
+}

--- a/backend/src/model/engine.model.ts
+++ b/backend/src/model/engine.model.ts
@@ -5,6 +5,7 @@ import { AuthTokenDuration } from '../../shared/model/engine.model';
 export interface EngineSettings extends BaseEntity {
   version: string;
   launcherVersion: string;
+  auditRetentionDuration: number | null;
   general: {
     name: string;
   };

--- a/backend/src/repository/config/audit.repository.spec.ts
+++ b/backend/src/repository/config/audit.repository.spec.ts
@@ -283,10 +283,7 @@ describe('AuditRepository', () => {
       repository.deleteOlderThan('2021-06-15T00:00:00.000Z');
 
       const remaining = repository.search({ page: 0 });
-      assert.deepStrictEqual(
-        remaining.content.map(element => element.id).sort(),
-        ['audit2', 'audit3']
-      );
+      assert.deepStrictEqual(remaining.content.map(element => element.id).sort(), ['audit2', 'audit3']);
     });
   });
 });

--- a/backend/src/repository/config/audit.repository.spec.ts
+++ b/backend/src/repository/config/audit.repository.spec.ts
@@ -1,0 +1,292 @@
+import { before, after, beforeEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { Database } from 'better-sqlite3';
+import { emptyDatabase, initDatabase } from '../../tests/utils/test-utils';
+import AuditRepository from './audit.repository';
+import { AuditLog } from '../../model/audit.model';
+
+const TEST_DB_PATH = 'src/tests/test-config-audit.db';
+
+let database: Database;
+describe('AuditRepository', () => {
+  before(async () => {
+    database = await initDatabase('config', true, TEST_DB_PATH);
+  });
+
+  after(async () => {
+    database.close();
+    await emptyDatabase('config', TEST_DB_PATH);
+  });
+
+  let repository: AuditRepository;
+
+  beforeEach(() => {
+    database.prepare('DELETE FROM audit_logs;').run();
+    repository = new AuditRepository(database);
+  });
+
+  function insertRaw(row: {
+    id: string;
+    entityType: string;
+    entityId: string;
+    action: string;
+    previousState: string | null;
+    newState: string | null;
+    userId: string;
+    createdAt: string;
+  }): void {
+    database
+      .prepare(
+        `INSERT INTO audit_logs (id, entity_type, entity_id, action, previous_state, new_state, user_id, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?);`
+      )
+      .run(row.id, row.entityType, row.entityId, row.action, row.previousState, row.newState, row.userId, row.createdAt);
+  }
+
+  describe('record()', () => {
+    it('should insert a CREATE audit log with a null previous state', () => {
+      repository.record('south_connector', 'south1', 'CREATE', null, { name: 'my south' }, 'userTest', 'audit1');
+
+      const result = repository.findByEntity('south_connector', 'south1');
+      assert.strictEqual(result.length, 1);
+      assert.deepStrictEqual(result[0], {
+        id: 'audit1',
+        entityType: 'south_connector',
+        entityId: 'south1',
+        action: 'CREATE',
+        previousState: null,
+        newState: { name: 'my south' },
+        userId: 'userTest',
+        createdAt: result[0].createdAt
+      });
+      assert.ok(result[0].createdAt);
+    });
+
+    it('should insert a DELETE audit log with a null new state', () => {
+      repository.record('north_connector', 'north1', 'DELETE', { name: 'my north' }, null, 'userTest', 'audit2');
+
+      const result = repository.findByEntity('north_connector', 'north1');
+      assert.strictEqual(result.length, 1);
+      assert.deepStrictEqual(result[0].previousState, { name: 'my north' });
+      assert.strictEqual(result[0].newState, null);
+      assert.strictEqual(result[0].action, 'DELETE');
+    });
+
+    it('should insert an UPDATE audit log with both states populated and round-trip the JSON', () => {
+      const previousState = { name: 'old name', settings: { port: 502 } };
+      const newState = { name: 'new name', settings: { port: 503 } };
+      repository.record('south_connector', 'south2', 'UPDATE', previousState, newState, 'userTest', 'audit3');
+
+      const result = repository.findByEntity('south_connector', 'south2');
+      assert.strictEqual(result.length, 1);
+      assert.deepStrictEqual(result[0].previousState, previousState);
+      assert.deepStrictEqual(result[0].newState, newState);
+      assert.strictEqual(result[0].userId, 'userTest');
+    });
+
+    it('should generate a random id when none is provided', () => {
+      repository.record('scan_mode', 'scan1', 'CREATE', null, { name: 'my scan mode' }, 'userTest');
+
+      const result = repository.findByEntity('scan_mode', 'scan1');
+      assert.strictEqual(result.length, 1);
+      assert.ok(result[0].id);
+    });
+  });
+
+  describe('search()', () => {
+    beforeEach(() => {
+      insertRaw({
+        id: 'audit1',
+        entityType: 'south_connector',
+        entityId: 'south1',
+        action: 'CREATE',
+        previousState: null,
+        newState: JSON.stringify({ name: 'south1' }),
+        userId: 'user1',
+        createdAt: '2020-01-01T00:00:00.000Z'
+      });
+      insertRaw({
+        id: 'audit2',
+        entityType: 'south_connector',
+        entityId: 'south1',
+        action: 'UPDATE',
+        previousState: JSON.stringify({ name: 'south1' }),
+        newState: JSON.stringify({ name: 'south1-renamed' }),
+        userId: 'user2',
+        createdAt: '2021-06-15T00:00:00.000Z'
+      });
+      insertRaw({
+        id: 'audit3',
+        entityType: 'north_connector',
+        entityId: 'north1',
+        action: 'DELETE',
+        previousState: JSON.stringify({ name: 'north1' }),
+        newState: null,
+        userId: 'user1',
+        createdAt: '2022-01-01T00:00:00.000Z'
+      });
+    });
+
+    it('should return all elements with the correct page shape when no filter is applied', () => {
+      const result = repository.search({ page: 0 });
+      assert.strictEqual(result.totalElements, 3);
+      assert.strictEqual(result.totalPages, 1);
+      assert.strictEqual(result.size, 50);
+      assert.strictEqual(result.number, 0);
+      assert.strictEqual(result.content.length, 3);
+      // ordered newest first
+      assert.deepStrictEqual(
+        result.content.map(element => element.id),
+        ['audit3', 'audit2', 'audit1']
+      );
+    });
+
+    it('should filter by entityType', () => {
+      const result = repository.search({ entityType: 'north_connector', page: 0 });
+      assert.strictEqual(result.totalElements, 1);
+      assert.strictEqual(result.content[0].id, 'audit3');
+    });
+
+    it('should filter by entityId', () => {
+      const result = repository.search({ entityId: 'south1', page: 0 });
+      assert.strictEqual(result.totalElements, 2);
+      assert.deepStrictEqual(
+        result.content.map(element => element.id),
+        ['audit2', 'audit1']
+      );
+    });
+
+    it('should filter by action', () => {
+      const result = repository.search({ action: 'UPDATE', page: 0 });
+      assert.strictEqual(result.totalElements, 1);
+      assert.strictEqual(result.content[0].id, 'audit2');
+    });
+
+    it('should filter by start date', () => {
+      const result = repository.search({ start: '2021-01-01T00:00:00.000Z', page: 0 });
+      assert.strictEqual(result.totalElements, 2);
+      assert.deepStrictEqual(
+        result.content.map(element => element.id),
+        ['audit3', 'audit2']
+      );
+    });
+
+    it('should filter by end date', () => {
+      const result = repository.search({ end: '2021-01-01T00:00:00.000Z', page: 0 });
+      assert.strictEqual(result.totalElements, 1);
+      assert.strictEqual(result.content[0].id, 'audit1');
+    });
+
+    it('should filter by a start/end date range combined', () => {
+      const result = repository.search({
+        start: '2020-06-01T00:00:00.000Z',
+        end: '2021-12-31T00:00:00.000Z',
+        page: 0
+      });
+      assert.strictEqual(result.totalElements, 1);
+      assert.strictEqual(result.content[0].id, 'audit2');
+    });
+
+    it('should combine multiple filters', () => {
+      const result = repository.search({ entityType: 'south_connector', entityId: 'south1', action: 'CREATE', page: 0 });
+      assert.strictEqual(result.totalElements, 1);
+      assert.strictEqual(result.content[0].id, 'audit1');
+    });
+
+    it('should return 0 results for an out-of-range filter', () => {
+      const result = repository.search({ entityType: 'south_connector', entityId: 'unknown-entity', page: 0 });
+      assert.strictEqual(result.totalElements, 0);
+      assert.strictEqual(result.totalPages, 0);
+      assert.strictEqual(result.content.length, 0);
+    });
+  });
+
+  describe('findByEntity()', () => {
+    it('should return only rows for the given entity, ordered newest first', () => {
+      insertRaw({
+        id: 'audit1',
+        entityType: 'south_connector',
+        entityId: 'south1',
+        action: 'CREATE',
+        previousState: null,
+        newState: JSON.stringify({ name: 'south1' }),
+        userId: 'user1',
+        createdAt: '2020-01-01T00:00:00.000Z'
+      });
+      insertRaw({
+        id: 'audit2',
+        entityType: 'south_connector',
+        entityId: 'south1',
+        action: 'UPDATE',
+        previousState: JSON.stringify({ name: 'south1' }),
+        newState: JSON.stringify({ name: 'south1-renamed' }),
+        userId: 'user2',
+        createdAt: '2021-06-15T00:00:00.000Z'
+      });
+      insertRaw({
+        id: 'audit3',
+        entityType: 'north_connector',
+        entityId: 'north1',
+        action: 'DELETE',
+        previousState: JSON.stringify({ name: 'north1' }),
+        newState: null,
+        userId: 'user1',
+        createdAt: '2022-01-01T00:00:00.000Z'
+      });
+
+      const result: Array<AuditLog> = repository.findByEntity('south_connector', 'south1');
+      assert.deepStrictEqual(
+        result.map(element => element.id),
+        ['audit2', 'audit1']
+      );
+    });
+
+    it('should return an empty array when no audit log exists for the entity', () => {
+      const result = repository.findByEntity('south_connector', 'unknown-entity');
+      assert.deepStrictEqual(result, []);
+    });
+  });
+
+  describe('deleteOlderThan()', () => {
+    it('should delete only rows strictly older than the cutoff', () => {
+      insertRaw({
+        id: 'audit1',
+        entityType: 'south_connector',
+        entityId: 'south1',
+        action: 'CREATE',
+        previousState: null,
+        newState: JSON.stringify({ name: 'south1' }),
+        userId: 'user1',
+        createdAt: '2020-01-01T00:00:00.000Z'
+      });
+      insertRaw({
+        id: 'audit2',
+        entityType: 'south_connector',
+        entityId: 'south1',
+        action: 'UPDATE',
+        previousState: JSON.stringify({ name: 'south1' }),
+        newState: JSON.stringify({ name: 'south1-renamed' }),
+        userId: 'user2',
+        createdAt: '2021-06-15T00:00:00.000Z'
+      });
+      insertRaw({
+        id: 'audit3',
+        entityType: 'north_connector',
+        entityId: 'north1',
+        action: 'DELETE',
+        previousState: JSON.stringify({ name: 'north1' }),
+        newState: null,
+        userId: 'user1',
+        createdAt: '2021-06-15T00:00:00.000Z'
+      });
+
+      repository.deleteOlderThan('2021-06-15T00:00:00.000Z');
+
+      const remaining = repository.search({ page: 0 });
+      assert.deepStrictEqual(
+        remaining.content.map(element => element.id).sort(),
+        ['audit2', 'audit3']
+      );
+    });
+  });
+});

--- a/backend/src/repository/config/audit.repository.ts
+++ b/backend/src/repository/config/audit.repository.ts
@@ -1,0 +1,119 @@
+import { generateRandomId } from '../../service/utils';
+import { Database } from 'better-sqlite3';
+import { AuditAction, AuditEntityType, AuditLog, AuditSearchParam } from '../../model/audit.model';
+import { Page } from '../../../shared/model/types';
+
+const AUDIT_LOGS_TABLE = 'audit_logs';
+
+const PAGE_SIZE = 50;
+
+/**
+ * Repository used for recording and searching audit log entries
+ */
+export default class AuditRepository {
+  constructor(private readonly database: Database) {}
+
+  record(
+    entityType: AuditEntityType,
+    entityId: string,
+    action: AuditAction,
+    previousState: Record<string, unknown> | null,
+    newState: Record<string, unknown> | null,
+    userId: string,
+    id = generateRandomId(6)
+  ): void {
+    const query = `INSERT INTO ${AUDIT_LOGS_TABLE} (id, entity_type, entity_id, action, previous_state, new_state, user_id, created_at)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, strftime('%Y-%m-%dT%H:%M:%SZ', 'now'));`;
+    this.database
+      .prepare(query)
+      .run(
+        id,
+        entityType,
+        entityId,
+        action,
+        previousState !== null ? JSON.stringify(previousState) : null,
+        newState !== null ? JSON.stringify(newState) : null,
+        userId
+      );
+  }
+
+  search(searchParams: AuditSearchParam): Page<AuditLog> {
+    const queryParams = [];
+    let whereClause = 'WHERE id IS NOT NULL';
+    if (searchParams.entityType) {
+      whereClause += ` AND entity_type = ?`;
+      queryParams.push(searchParams.entityType);
+    }
+    if (searchParams.entityId) {
+      whereClause += ` AND entity_id = ?`;
+      queryParams.push(searchParams.entityId);
+    }
+    if (searchParams.action) {
+      whereClause += ` AND action = ?`;
+      queryParams.push(searchParams.action);
+    }
+    if (searchParams.start) {
+      whereClause += ` AND created_at >= ?`;
+      queryParams.push(searchParams.start);
+    }
+    if (searchParams.end) {
+      whereClause += ` AND created_at <= ?`;
+      queryParams.push(searchParams.end);
+    }
+
+    const query = `SELECT *
+                   FROM ${AUDIT_LOGS_TABLE} ${whereClause}
+                   ORDER BY created_at DESC
+                   LIMIT ${PAGE_SIZE} OFFSET ?;`;
+    const results: Array<AuditLog> = this.database
+      .prepare(query)
+      .all(...queryParams, PAGE_SIZE * searchParams.page)
+      .map(result => this.toAuditLog(result as Record<string, string>));
+    const totalElements = (
+      this.database
+        .prepare(
+          `SELECT COUNT(*) as count
+           FROM ${AUDIT_LOGS_TABLE} ${whereClause}`
+        )
+        .get(...queryParams) as { count: number }
+    ).count;
+    const totalPages = Math.ceil(totalElements / PAGE_SIZE);
+
+    return {
+      content: results,
+      size: PAGE_SIZE,
+      number: searchParams.page,
+      totalElements,
+      totalPages
+    };
+  }
+
+  findByEntity(entityType: AuditEntityType, entityId: string): Array<AuditLog> {
+    const query = `SELECT *
+                   FROM ${AUDIT_LOGS_TABLE}
+                   WHERE entity_type = ? AND entity_id = ?
+                   ORDER BY created_at DESC;`;
+    return this.database
+      .prepare(query)
+      .all(entityType, entityId)
+      .map(result => this.toAuditLog(result as Record<string, string>));
+  }
+
+  deleteOlderThan(cutoffIso: string): void {
+    const query = `DELETE FROM ${AUDIT_LOGS_TABLE} WHERE created_at < ?;`;
+    this.database.prepare(query).run(cutoffIso);
+  }
+
+  private toAuditLog(result: Record<string, string>): AuditLog {
+    return {
+      id: result.id,
+      entityType: result.entity_type as AuditEntityType,
+      entityId: result.entity_id,
+      action: result.action as AuditAction,
+      previousState: result.previous_state !== null ? JSON.parse(result.previous_state) : null,
+      newState: result.new_state !== null ? JSON.parse(result.new_state) : null,
+      userId: result.user_id,
+      createdAt: result.created_at
+    };
+  }
+}

--- a/backend/src/repository/config/certificate.repository.spec.ts
+++ b/backend/src/repository/config/certificate.repository.spec.ts
@@ -57,9 +57,11 @@ describe('CertificateRepository', () => {
       created.id,
       'CREATE',
       null,
-      created,
+      { ...created, privateKey: '' },
       created.createdBy
     ]);
+    // The private key itself must never be persisted in the audit trail
+    assert.notStrictEqual((recordMock.mock.calls[0].arguments[4] as { privateKey: string }).privateKey, created.privateKey);
   });
 
   it('should update a certificate', () => {
@@ -81,10 +83,13 @@ describe('CertificateRepository', () => {
       'certificate',
       updateCertificate.id,
       'UPDATE',
-      before,
-      result,
+      { ...before, privateKey: '' },
+      { ...result, privateKey: '' },
       updateCertificate.updatedBy
     ]);
+    // The private key itself must never be persisted in the audit trail, before or after
+    assert.notStrictEqual((recordMock.mock.calls[0].arguments[3] as { privateKey: string }).privateKey, before!.privateKey);
+    assert.notStrictEqual((recordMock.mock.calls[0].arguments[4] as { privateKey: string }).privateKey, result.privateKey);
   });
 
   it('should update name and description certificate', () => {
@@ -97,7 +102,14 @@ describe('CertificateRepository', () => {
 
     const recordMock = auditService.record as unknown as ReturnType<typeof mock.fn>;
     assert.strictEqual(recordMock.mock.calls.length, 1);
-    assert.deepStrictEqual(recordMock.mock.calls[0].arguments, ['certificate', 'new id', 'UPDATE', before, result, 'userTest']);
+    assert.deepStrictEqual(recordMock.mock.calls[0].arguments, [
+      'certificate',
+      'new id',
+      'UPDATE',
+      { ...before, privateKey: '' },
+      { ...result, privateKey: '' },
+      'userTest'
+    ]);
   });
 
   it('should delete certificate', () => {
@@ -107,6 +119,13 @@ describe('CertificateRepository', () => {
 
     const recordMock = auditService.record as unknown as ReturnType<typeof mock.fn>;
     assert.strictEqual(recordMock.mock.calls.length, 1);
-    assert.deepStrictEqual(recordMock.mock.calls[0].arguments, ['certificate', 'new id', 'DELETE', before, null, 'userTest']);
+    assert.deepStrictEqual(recordMock.mock.calls[0].arguments, [
+      'certificate',
+      'new id',
+      'DELETE',
+      { ...before, privateKey: '' },
+      null,
+      'userTest'
+    ]);
   });
 });

--- a/backend/src/repository/config/certificate.repository.spec.ts
+++ b/backend/src/repository/config/certificate.repository.spec.ts
@@ -1,9 +1,11 @@
 import { before, after, beforeEach, describe, it } from 'node:test';
 import assert from 'node:assert/strict';
+import { mock } from 'node:test';
 import { Database } from 'better-sqlite3';
-import { emptyDatabase, initDatabase, stripAuditFields } from '../../tests/utils/test-utils';
+import { createAuditServiceMock, emptyDatabase, initDatabase, stripAuditFields } from '../../tests/utils/test-utils';
 import testData from '../../tests/utils/test-data';
 import CertificateRepository from './certificate.repository';
+import AuditService from '../../service/audit.service';
 
 const TEST_DB_PATH = 'src/tests/test-config-certificate.db';
 
@@ -19,8 +21,10 @@ describe('CertificateRepository', () => {
   });
 
   let repository: CertificateRepository;
+  let auditService: AuditService;
   beforeEach(() => {
-    repository = new CertificateRepository(database);
+    auditService = createAuditServiceMock();
+    repository = new CertificateRepository(database, auditService);
   });
 
   it('should properly find all certificates', () => {
@@ -43,8 +47,19 @@ describe('CertificateRepository', () => {
   it('should create a certificate', () => {
     const createCertificate = JSON.parse(JSON.stringify(testData.certificates.list[0]));
     createCertificate.id = 'new id';
-    repository.create(createCertificate);
+    const created = repository.create(createCertificate);
     assert.deepStrictEqual(stripAuditFields(repository.findById('new id')), stripAuditFields(createCertificate));
+
+    const recordMock = auditService.record as unknown as ReturnType<typeof mock.fn>;
+    assert.strictEqual(recordMock.mock.calls.length, 1);
+    assert.deepStrictEqual(recordMock.mock.calls[0].arguments, [
+      'certificate',
+      created.id,
+      'CREATE',
+      null,
+      created,
+      created.createdBy
+    ]);
   });
 
   it('should update a certificate', () => {
@@ -53,23 +68,45 @@ describe('CertificateRepository', () => {
     updateCertificate.expiry = testData.constants.dates.DATE_2;
     updateCertificate.publicKey = 'new public key';
     updateCertificate.privateKey = 'new private key';
+    const before = repository.findById(updateCertificate.id);
     repository.update(updateCertificate);
     const result = repository.findById(updateCertificate.id)!;
     assert.strictEqual(result.expiry, updateCertificate.expiry);
     assert.strictEqual(result.publicKey, updateCertificate.publicKey);
     assert.strictEqual(result.privateKey, updateCertificate.privateKey);
+
+    const recordMock = auditService.record as unknown as ReturnType<typeof mock.fn>;
+    assert.strictEqual(recordMock.mock.calls.length, 1);
+    assert.deepStrictEqual(recordMock.mock.calls[0].arguments, [
+      'certificate',
+      updateCertificate.id,
+      'UPDATE',
+      before,
+      result,
+      updateCertificate.updatedBy
+    ]);
   });
 
   it('should update name and description certificate', () => {
+    const before = repository.findById('new id');
     repository.updateNameAndDescription('new id', 'new name', 'new description', 'userTest');
     const result = repository.findById('new id')!;
     assert.strictEqual(result.name, 'new name');
     assert.strictEqual(result.description, 'new description');
     assert.strictEqual(result.updatedBy, 'userTest');
+
+    const recordMock = auditService.record as unknown as ReturnType<typeof mock.fn>;
+    assert.strictEqual(recordMock.mock.calls.length, 1);
+    assert.deepStrictEqual(recordMock.mock.calls[0].arguments, ['certificate', 'new id', 'UPDATE', before, result, 'userTest']);
   });
 
   it('should delete certificate', () => {
-    repository.delete('new id');
+    const before = repository.findById('new id');
+    repository.delete('new id', 'userTest');
     assert.strictEqual(repository.findById('new id'), null);
+
+    const recordMock = auditService.record as unknown as ReturnType<typeof mock.fn>;
+    assert.strictEqual(recordMock.mock.calls.length, 1);
+    assert.deepStrictEqual(recordMock.mock.calls[0].arguments, ['certificate', 'new id', 'DELETE', before, null, 'userTest']);
   });
 });

--- a/backend/src/repository/config/certificate.repository.ts
+++ b/backend/src/repository/config/certificate.repository.ts
@@ -86,7 +86,14 @@ export default class CertificateRepository {
                        FROM ${CERTIFICATES_TABLE}
                        WHERE ROWID = ?;`;
     const created = this.toCertificate(this.database.prepare(query).get(result.lastInsertRowid) as Record<string, string>);
-    this.auditService.record('certificate', created.id, 'CREATE', null, created as unknown as Record<string, unknown>, created.createdBy);
+    this.auditService.record(
+      'certificate',
+      created.id,
+      'CREATE',
+      null,
+      this.redact(created) as unknown as Record<string, unknown>,
+      created.createdBy
+    );
     return created;
   }
 
@@ -113,8 +120,8 @@ export default class CertificateRepository {
       'certificate',
       certificate.id,
       'UPDATE',
-      before as unknown as Record<string, unknown>,
-      after as unknown as Record<string, unknown>,
+      this.redact(before) as unknown as Record<string, unknown>,
+      this.redact(after) as unknown as Record<string, unknown>,
       certificate.updatedBy
     );
   }
@@ -133,8 +140,8 @@ export default class CertificateRepository {
       'certificate',
       certificateId,
       'UPDATE',
-      before as unknown as Record<string, unknown>,
-      after as unknown as Record<string, unknown>,
+      this.redact(before) as unknown as Record<string, unknown>,
+      this.redact(after) as unknown as Record<string, unknown>,
       updatedBy
     );
   }
@@ -146,8 +153,17 @@ export default class CertificateRepository {
                        WHERE id = ?;`;
     this.database.prepare(query).run(id);
     if (before) {
-      this.auditService.record('certificate', id, 'DELETE', before as unknown as Record<string, unknown>, null, deletedBy);
+      this.auditService.record('certificate', id, 'DELETE', this.redact(before) as unknown as Record<string, unknown>, null, deletedBy);
     }
+  }
+
+  /**
+   * Returns a shallow copy of the certificate with the private key redacted, so the raw PEM
+   * private key material never ends up persisted in the audit trail.
+   */
+  private redact(certificate: Certificate | null): Record<string, unknown> | null {
+    if (!certificate) return null;
+    return { ...certificate, privateKey: '' };
   }
 
   private toCertificate(result: Record<string, string>): Certificate {

--- a/backend/src/repository/config/certificate.repository.ts
+++ b/backend/src/repository/config/certificate.repository.ts
@@ -1,5 +1,6 @@
 import { Database } from 'better-sqlite3';
 import { Certificate } from '../../model/certificate.model';
+import AuditService from '../../service/audit.service';
 
 const CERTIFICATES_TABLE = 'certificates';
 
@@ -7,7 +8,10 @@ const CERTIFICATES_TABLE = 'certificates';
  * Repository used for managing certificates within OIBus
  */
 export default class CertificateRepository {
-  constructor(private readonly database: Database) {}
+  constructor(
+    private readonly database: Database,
+    private readonly auditService: AuditService
+  ) {}
 
   list(): Array<Certificate> {
     const query = `SELECT id,
@@ -81,10 +85,13 @@ export default class CertificateRepository {
                               updated_at
                        FROM ${CERTIFICATES_TABLE}
                        WHERE ROWID = ?;`;
-    return this.toCertificate(this.database.prepare(query).get(result.lastInsertRowid) as Record<string, string>);
+    const created = this.toCertificate(this.database.prepare(query).get(result.lastInsertRowid) as Record<string, string>);
+    this.auditService.record('certificate', created.id, 'CREATE', null, created as unknown as Record<string, unknown>, created.createdBy);
+    return created;
   }
 
   update(certificate: Omit<Certificate, 'createdBy' | 'createdAt' | 'updatedAt'>): void {
+    const before = this.findById(certificate.id);
     const query =
       `UPDATE ${CERTIFICATES_TABLE} SET name = ?, description = ?, public_key  = ?, private_key = ?, certificate = ?, certificate_chain = ?, ` +
       `expiry = ?, updated_by = ?, updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now') WHERE id = ?;`;
@@ -101,9 +108,19 @@ export default class CertificateRepository {
         certificate.updatedBy,
         certificate.id
       );
+    const after = this.findById(certificate.id);
+    this.auditService.record(
+      'certificate',
+      certificate.id,
+      'UPDATE',
+      before as unknown as Record<string, unknown>,
+      after as unknown as Record<string, unknown>,
+      certificate.updatedBy
+    );
   }
 
   updateNameAndDescription(certificateId: string, newName: string, newDescription: string, updatedBy: string): void {
+    const before = this.findById(certificateId);
     const query = `UPDATE ${CERTIFICATES_TABLE}
                        SET name        = ?,
                            description = ?,
@@ -111,13 +128,26 @@ export default class CertificateRepository {
                            updated_at  = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
                        WHERE id = ?;`;
     this.database.prepare(query).run(newName, newDescription, updatedBy, certificateId);
+    const after = this.findById(certificateId);
+    this.auditService.record(
+      'certificate',
+      certificateId,
+      'UPDATE',
+      before as unknown as Record<string, unknown>,
+      after as unknown as Record<string, unknown>,
+      updatedBy
+    );
   }
 
-  delete(id: string): void {
+  delete(id: string, deletedBy: string): void {
+    const before = this.findById(id);
     const query = `DELETE
                        FROM ${CERTIFICATES_TABLE}
                        WHERE id = ?;`;
     this.database.prepare(query).run(id);
+    if (before) {
+      this.auditService.record('certificate', id, 'DELETE', before as unknown as Record<string, unknown>, null, deletedBy);
+    }
   }
 
   private toCertificate(result: Record<string, string>): Certificate {

--- a/backend/src/repository/config/engine.repository.spec.ts
+++ b/backend/src/repository/config/engine.repository.spec.ts
@@ -9,6 +9,27 @@ import { version } from '../../../package.json';
 import argon2 from 'argon2';
 import UserRepository from './user.repository';
 import AuditService from '../../service/audit.service';
+import { EngineSettings } from '../../model/engine.model';
+
+/**
+ * Mirrors EngineRepository's private redact(): the audit trail must never carry
+ * proxyServer.password, proxyServer.forward.password or logger.loki.password in the clear.
+ */
+function redactEngineForAudit(settings: EngineSettings | null): unknown {
+  if (!settings) return null;
+  return {
+    ...settings,
+    proxyServer: {
+      ...settings.proxyServer,
+      password: '',
+      forward: { ...settings.proxyServer.forward, password: '' }
+    },
+    logger: {
+      ...settings.logger,
+      loki: { ...settings.logger.loki, password: '' }
+    }
+  };
+}
 
 const TEST_DB_PATH = 'src/tests/test-config-engine.db';
 
@@ -65,7 +86,37 @@ describe('EngineRepository with populated database', () => {
 
       const recordMock = auditService.record as unknown as ReturnType<typeof mock.fn>;
       assert.strictEqual(recordMock.mock.calls.length, 1);
-      assert.deepStrictEqual(recordMock.mock.calls[0].arguments, ['engine', after!.id, 'UPDATE', before, after, testData.users.list[0].id]);
+      assert.deepStrictEqual(recordMock.mock.calls[0].arguments, [
+        'engine',
+        after!.id,
+        'UPDATE',
+        redactEngineForAudit(before),
+        redactEngineForAudit(after),
+        testData.users.list[0].id
+      ]);
+      // Password fields must never be persisted in the audit trail
+      const [, , , recordedBefore, recordedAfter] = recordMock.mock.calls[0].arguments as [
+        string,
+        string,
+        string,
+        { proxyServer: { password: string }; logger: { loki: { password: string } } },
+        { proxyServer: { password: string }; logger: { loki: { password: string } } }
+      ];
+      assert.strictEqual(recordedBefore.proxyServer.password, '');
+      assert.strictEqual(recordedBefore.logger.loki.password, '');
+      assert.strictEqual(recordedAfter.proxyServer.password, '');
+      assert.strictEqual(recordedAfter.logger.loki.password, '');
+    });
+
+    it('should round-trip auditRetentionDuration on update', () => {
+      const command = { ...testData.engine.command, auditRetentionDuration: 45 };
+      repository.update(command, testData.users.list[0].id);
+      const after = repository.get();
+      assert.strictEqual(after!.auditRetentionDuration, 45);
+
+      // Reset back to null so subsequent tests relying on the default fixture are unaffected
+      repository.update(testData.engine.command, testData.users.list[0].id);
+      assert.strictEqual(repository.get()!.auditRetentionDuration, null);
     });
 
     it('should update name only', () => {
@@ -76,7 +127,14 @@ describe('EngineRepository with populated database', () => {
 
       const recordMock = auditService.record as unknown as ReturnType<typeof mock.fn>;
       assert.strictEqual(recordMock.mock.calls.length, 1);
-      assert.deepStrictEqual(recordMock.mock.calls[0].arguments, ['engine', after!.id, 'UPDATE', before, after, testData.users.list[0].id]);
+      assert.deepStrictEqual(recordMock.mock.calls[0].arguments, [
+        'engine',
+        after!.id,
+        'UPDATE',
+        redactEngineForAudit(before),
+        redactEngineForAudit(after),
+        testData.users.list[0].id
+      ]);
     });
 
     it('should update web server port only', () => {
@@ -87,7 +145,14 @@ describe('EngineRepository with populated database', () => {
 
       const recordMock = auditService.record as unknown as ReturnType<typeof mock.fn>;
       assert.strictEqual(recordMock.mock.calls.length, 1);
-      assert.deepStrictEqual(recordMock.mock.calls[0].arguments, ['engine', after!.id, 'UPDATE', before, after, testData.users.list[0].id]);
+      assert.deepStrictEqual(recordMock.mock.calls[0].arguments, [
+        'engine',
+        after!.id,
+        'UPDATE',
+        redactEngineForAudit(before),
+        redactEngineForAudit(after),
+        testData.users.list[0].id
+      ]);
     });
 
     it('should update engine settings without a forward proxy (falls back to disabled defaults)', () => {
@@ -118,8 +183,8 @@ describe('EngineRepository with populated database', () => {
         'engine',
         result.id,
         'UPDATE',
-        before,
-        result,
+        redactEngineForAudit(before),
+        redactEngineForAudit(result),
         testData.users.list[0].id
       ]);
     });
@@ -151,7 +216,40 @@ describe('EngineRepository with populated database', () => {
 
       const recordMock = auditService.record as unknown as ReturnType<typeof mock.fn>;
       assert.strictEqual(recordMock.mock.calls.length, 1);
-      assert.deepStrictEqual(recordMock.mock.calls[0].arguments, ['engine', after!.id, 'UPDATE', before, after, testData.users.list[0].id]);
+      assert.deepStrictEqual(recordMock.mock.calls[0].arguments, [
+        'engine',
+        after!.id,
+        'UPDATE',
+        redactEngineForAudit(before),
+        redactEngineForAudit(after),
+        testData.users.list[0].id
+      ]);
+    });
+
+    it('should never persist a real loki password in the audit trail', () => {
+      const loggerCommandWithRealPassword = {
+        ...testData.engine.loggerCommand,
+        loki: { ...testData.engine.loggerCommand.loki, password: 'super-secret-loki-password' }
+      };
+      repository.updateLogger(loggerCommandWithRealPassword, testData.users.list[0].id);
+      const after = repository.get();
+      // The password is genuinely stored (readable back through get())...
+      assert.strictEqual(after!.logger.loki.password, 'super-secret-loki-password');
+
+      // ...but never persisted in clear in the audit trail
+      const recordMock = auditService.record as unknown as ReturnType<typeof mock.fn>;
+      assert.strictEqual(recordMock.mock.calls.length, 1);
+      const [, , , , recordedAfter] = recordMock.mock.calls[0].arguments as [
+        string,
+        string,
+        string,
+        unknown,
+        { logger: { loki: { password: string } } }
+      ];
+      assert.strictEqual(recordedAfter.logger.loki.password, '');
+
+      // Reset back to the shared fixture so subsequent tests are unaffected
+      repository.updateLogger(testData.engine.loggerCommand, testData.users.list[0].id);
     });
 
     it('should not call the audit service when updating the version', () => {
@@ -186,6 +284,7 @@ describe('EngineRepository with empty database', () => {
       assert.ok(result.id);
       assert.strictEqual(result.version, version);
       assert.strictEqual(result.launcherVersion, '3.5.0');
+      assert.strictEqual(result.auditRetentionDuration, 90);
       assert.strictEqual(result.general.name, 'OIBus');
       assert.strictEqual(result.webServer.port, 2223);
       assert.strictEqual(result.proxyServer.enabled, false);

--- a/backend/src/repository/config/engine.repository.spec.ts
+++ b/backend/src/repository/config/engine.repository.spec.ts
@@ -59,6 +59,7 @@ describe('EngineRepository with populated database', () => {
 
     it('should update engine settings', () => {
       const command = { ...testData.engine.command, general: { name: 'updated engine' } };
+      const { auditRetentionDuration: _loggerAuditRetentionDuration, ...loggerOnly } = command.logger;
       const before = repository.get();
       repository.update(command, testData.users.list[0].id);
       const after = repository.get();
@@ -81,7 +82,7 @@ describe('EngineRepository with populated database', () => {
           username: command.proxyServer.username,
           password: command.proxyServer.password
         },
-        logger: command.logger
+        logger: loggerOnly
       });
 
       const recordMock = auditService.record as unknown as ReturnType<typeof mock.fn>;
@@ -212,7 +213,9 @@ describe('EngineRepository with populated database', () => {
       const before = repository.get();
       repository.updateLogger(testData.engine.loggerCommand, testData.users.list[0].id);
       const after = repository.get();
-      assert.deepStrictEqual(after!.logger, testData.engine.loggerCommand);
+      const { auditRetentionDuration, ...loggerOnly } = testData.engine.loggerCommand;
+      assert.deepStrictEqual(after!.logger, loggerOnly);
+      assert.strictEqual(after!.auditRetentionDuration, auditRetentionDuration);
 
       const recordMock = auditService.record as unknown as ReturnType<typeof mock.fn>;
       assert.strictEqual(recordMock.mock.calls.length, 1);
@@ -224,6 +227,16 @@ describe('EngineRepository with populated database', () => {
         redactEngineForAudit(after),
         testData.users.list[0].id
       ]);
+    });
+
+    it('should persist and return the audit retention duration set through updateLogger', () => {
+      const loggerCommandWithRetention = { ...testData.engine.loggerCommand, auditRetentionDuration: 30 };
+      repository.updateLogger(loggerCommandWithRetention, testData.users.list[0].id);
+      const after = repository.get();
+      assert.strictEqual(after!.auditRetentionDuration, 30);
+
+      // Reset back to the shared fixture so subsequent tests are unaffected
+      repository.updateLogger(testData.engine.loggerCommand, testData.users.list[0].id);
     });
 
     it('should never persist a real loki password in the audit trail', () => {

--- a/backend/src/repository/config/engine.repository.spec.ts
+++ b/backend/src/repository/config/engine.repository.spec.ts
@@ -2,12 +2,13 @@ import { before, after, beforeEach, describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { mock } from 'node:test';
 import { Database } from 'better-sqlite3';
-import { emptyDatabase, flushPromises, initDatabase, stripAuditFields } from '../../tests/utils/test-utils';
+import { createAuditServiceMock, emptyDatabase, flushPromises, initDatabase, stripAuditFields } from '../../tests/utils/test-utils';
 import testData from '../../tests/utils/test-data';
 import EngineRepository from './engine.repository';
 import { version } from '../../../package.json';
 import argon2 from 'argon2';
 import UserRepository from './user.repository';
+import AuditService from '../../service/audit.service';
 
 const TEST_DB_PATH = 'src/tests/test-config-engine.db';
 
@@ -24,9 +25,11 @@ describe('EngineRepository with populated database', () => {
 
   describe('Engine', () => {
     let repository: EngineRepository;
+    let auditService: AuditService;
 
     beforeEach(() => {
-      repository = new EngineRepository(database, '3.5.0');
+      auditService = createAuditServiceMock();
+      repository = new EngineRepository(database, auditService, '3.5.0');
     });
 
     it('should properly get the engine settings', () => {
@@ -35,11 +38,14 @@ describe('EngineRepository with populated database', () => {
 
     it('should update engine settings', () => {
       const command = { ...testData.engine.command, general: { name: 'updated engine' } };
+      const before = repository.get();
       repository.update(command, testData.users.list[0].id);
-      assert.deepStrictEqual(stripAuditFields(repository.get()), {
+      const after = repository.get();
+      assert.deepStrictEqual(stripAuditFields(after), {
         id: testData.engine.settings.id,
         version: testData.engine.settings.version,
         launcherVersion: testData.engine.settings.launcherVersion,
+        auditRetentionDuration: null,
         general: { name: 'updated engine' },
         webServer: { port: command.webServer.port, authTokenDuration: command.webServer.authTokenDuration },
         proxyServer: {
@@ -56,16 +62,32 @@ describe('EngineRepository with populated database', () => {
         },
         logger: command.logger
       });
+
+      const recordMock = auditService.record as unknown as ReturnType<typeof mock.fn>;
+      assert.strictEqual(recordMock.mock.calls.length, 1);
+      assert.deepStrictEqual(recordMock.mock.calls[0].arguments, ['engine', after!.id, 'UPDATE', before, after, testData.users.list[0].id]);
     });
 
     it('should update name only', () => {
+      const before = repository.get();
       repository.updateName('my new name', testData.users.list[0].id);
-      assert.strictEqual(repository.get()!.general.name, 'my new name');
+      const after = repository.get();
+      assert.strictEqual(after!.general.name, 'my new name');
+
+      const recordMock = auditService.record as unknown as ReturnType<typeof mock.fn>;
+      assert.strictEqual(recordMock.mock.calls.length, 1);
+      assert.deepStrictEqual(recordMock.mock.calls[0].arguments, ['engine', after!.id, 'UPDATE', before, after, testData.users.list[0].id]);
     });
 
     it('should update web server port only', () => {
+      const before = repository.get();
       repository.updateWebServer(testData.engine.webServerCommand, testData.users.list[0].id);
-      assert.strictEqual(repository.get()!.webServer.port, testData.engine.webServerCommand.port);
+      const after = repository.get();
+      assert.strictEqual(after!.webServer.port, testData.engine.webServerCommand.port);
+
+      const recordMock = auditService.record as unknown as ReturnType<typeof mock.fn>;
+      assert.strictEqual(recordMock.mock.calls.length, 1);
+      assert.deepStrictEqual(recordMock.mock.calls[0].arguments, ['engine', after!.id, 'UPDATE', before, after, testData.users.list[0].id]);
     });
 
     it('should update engine settings without a forward proxy (falls back to disabled defaults)', () => {
@@ -84,10 +106,22 @@ describe('EngineRepository with populated database', () => {
 
     it('should update proxy settings with proxy disabled', () => {
       const disabledForward = { enabled: false, url: null, username: null, password: null };
+      const before = repository.get();
       repository.updateProxy({ enabled: false, port: null, forward: disabledForward }, testData.users.list[0].id);
       const result = repository.get()!;
       assert.strictEqual(result.proxyServer.enabled, false);
       assert.strictEqual(result.proxyServer.port, null);
+
+      const recordMock = auditService.record as unknown as ReturnType<typeof mock.fn>;
+      assert.strictEqual(recordMock.mock.calls.length, 1);
+      assert.deepStrictEqual(recordMock.mock.calls[0].arguments, [
+        'engine',
+        result.id,
+        'UPDATE',
+        before,
+        result,
+        testData.users.list[0].id
+      ]);
     });
 
     it('should update proxy settings with proxy enabled', () => {
@@ -110,8 +144,20 @@ describe('EngineRepository with populated database', () => {
     });
 
     it('should update logger settings only', () => {
+      const before = repository.get();
       repository.updateLogger(testData.engine.loggerCommand, testData.users.list[0].id);
-      assert.deepStrictEqual(repository.get()!.logger, testData.engine.loggerCommand);
+      const after = repository.get();
+      assert.deepStrictEqual(after!.logger, testData.engine.loggerCommand);
+
+      const recordMock = auditService.record as unknown as ReturnType<typeof mock.fn>;
+      assert.strictEqual(recordMock.mock.calls.length, 1);
+      assert.deepStrictEqual(recordMock.mock.calls[0].arguments, ['engine', after!.id, 'UPDATE', before, after, testData.users.list[0].id]);
+    });
+
+    it('should not call the audit service when updating the version', () => {
+      repository.updateVersion('9.9.100', '9.9.100');
+      const recordMock = auditService.record as unknown as ReturnType<typeof mock.fn>;
+      assert.strictEqual(recordMock.mock.calls.length, 0);
     });
 
     it('should update version', () => {
@@ -133,7 +179,7 @@ describe('EngineRepository with empty database', () => {
 
   describe('Engine', () => {
     it('should properly init engine settings table with default port', () => {
-      const repository = new EngineRepository(database, '3.5.0');
+      const repository = new EngineRepository(database, createAuditServiceMock(), '3.5.0');
       const result = stripAuditFields(repository.get());
 
       assert.ok(result);
@@ -161,7 +207,7 @@ describe('EngineRepository with empty database', () => {
     });
 
     it('should use a custom port when provided', () => {
-      const repository = new EngineRepository(database, '3.5.0', 3000);
+      const repository = new EngineRepository(database, createAuditServiceMock(), '3.5.0', 3000);
       // createDefault is a no-op because the record already exists from the previous test
       assert.strictEqual(repository.get()!.webServer.port, 2223);
     });
@@ -174,7 +220,7 @@ describe('EngineRepository with empty database', () => {
       });
       const consoleErrorMock = mock.method(console, 'error', () => null);
 
-      const repository = new UserRepository(database);
+      const repository = new UserRepository(database, createAuditServiceMock());
 
       await flushPromises();
       assert.strictEqual(repository.list().length, 0);
@@ -186,7 +232,7 @@ describe('EngineRepository with empty database', () => {
     it('should create a default admin user', async () => {
       mock.method(argon2, 'hash', async (password: string) => password);
 
-      const repository = new UserRepository(database);
+      const repository = new UserRepository(database, createAuditServiceMock());
 
       await flushPromises();
 
@@ -217,7 +263,7 @@ describe('EngineRepository with custom default port', () => {
   });
 
   it('should seed engine settings with a custom port', () => {
-    const repository = new EngineRepository(db, '3.5.0', 3000);
+    const repository = new EngineRepository(db, createAuditServiceMock(), '3.5.0', 3000);
     assert.strictEqual(repository.get()!.webServer.port, 3000);
   });
 });

--- a/backend/src/repository/config/engine.repository.ts
+++ b/backend/src/repository/config/engine.repository.ts
@@ -225,6 +225,7 @@ export default class EngineRepository {
     const before = this.get();
     const query =
       `UPDATE ${ENGINES_TABLE} SET ` +
+      'audit_retention_duration = ?, ' +
       'log_console_level = ?, ' +
       'log_file_level = ?, ' +
       'log_file_max_file_size = ?, ' +
@@ -247,6 +248,7 @@ export default class EngineRepository {
     this.database
       .prepare(query)
       .run(
+        command.auditRetentionDuration,
         command.console.level,
         command.file.level,
         command.file.maxFileSize,

--- a/backend/src/repository/config/engine.repository.ts
+++ b/backend/src/repository/config/engine.repository.ts
@@ -20,7 +20,7 @@ const DEFAULT_ENGINE_SETTINGS: Omit<
   EngineSettings,
   'id' | 'version' | 'launcherVersion' | 'createdBy' | 'updatedBy' | 'createdAt' | 'updatedAt'
 > = {
-  auditRetentionDuration: null,
+  auditRetentionDuration: 90,
   general: {
     name: 'OIBus'
   },
@@ -96,7 +96,7 @@ export default class EngineRepository {
 
   get(): EngineSettings | null {
     const query =
-      'SELECT id, name, port, auth_token_duration, oibus_version, oibus_launcher_version, proxy_enabled, proxy_port, ' +
+      'SELECT id, name, port, auth_token_duration, audit_retention_duration, oibus_version, oibus_launcher_version, proxy_enabled, proxy_port, ' +
       'forward_proxy_enabled, forward_proxy_url, forward_proxy_username, forward_proxy_password, proxy_username, proxy_password, ' +
       'log_console_level, log_file_level, log_file_max_file_size, log_file_number_of_files, ' +
       'log_database_level, log_database_max_number_of_logs, ' +
@@ -116,7 +116,7 @@ export default class EngineRepository {
   update(command: EngineSettingsCommandDTO, updatedBy: string): void {
     const before = this.get();
     const query =
-      `UPDATE ${ENGINES_TABLE} SET name = ?, port = ?, auth_token_duration = ?, proxy_enabled = ?, proxy_port = ?, ` +
+      `UPDATE ${ENGINES_TABLE} SET name = ?, port = ?, auth_token_duration = ?, audit_retention_duration = ?, proxy_enabled = ?, proxy_port = ?, ` +
       'forward_proxy_enabled = ?, forward_proxy_url = ?, forward_proxy_username = ?, forward_proxy_password = ?, proxy_username = ?, proxy_password = ?, ' +
       'log_console_level = ?, ' +
       'log_file_level = ?, ' +
@@ -144,6 +144,7 @@ export default class EngineRepository {
         command.general.name,
         command.webServer.port,
         command.webServer.authTokenDuration,
+        command.auditRetentionDuration,
         +command.proxyServer.enabled,
         command.proxyServer.port,
         +(command.proxyServer.forward ?? DISABLED_FORWARD).enabled,
@@ -172,14 +173,7 @@ export default class EngineRepository {
         updatedBy
       );
     const after = this.get();
-    this.auditService.record(
-      'engine',
-      after!.id,
-      'UPDATE',
-      before as unknown as Record<string, unknown>,
-      after as unknown as Record<string, unknown>,
-      updatedBy
-    );
+    this.auditService.record('engine', after!.id, 'UPDATE', this.redact(before), this.redact(after), updatedBy);
   }
 
   updateName(name: string, updatedBy: string): void {
@@ -189,14 +183,7 @@ export default class EngineRepository {
       `WHERE rowid=(SELECT MIN(rowid) FROM ${ENGINES_TABLE});`;
     this.database.prepare(query).run(name, updatedBy);
     const after = this.get();
-    this.auditService.record(
-      'engine',
-      after!.id,
-      'UPDATE',
-      before as unknown as Record<string, unknown>,
-      after as unknown as Record<string, unknown>,
-      updatedBy
-    );
+    this.auditService.record('engine', after!.id, 'UPDATE', this.redact(before), this.redact(after), updatedBy);
   }
 
   updateWebServer(command: EngineWebServerCommandDTO, updatedBy: string): void {
@@ -206,14 +193,7 @@ export default class EngineRepository {
       `WHERE rowid=(SELECT MIN(rowid) FROM ${ENGINES_TABLE});`;
     this.database.prepare(query).run(command.port, command.authTokenDuration, updatedBy);
     const after = this.get();
-    this.auditService.record(
-      'engine',
-      after!.id,
-      'UPDATE',
-      before as unknown as Record<string, unknown>,
-      after as unknown as Record<string, unknown>,
-      updatedBy
-    );
+    this.auditService.record('engine', after!.id, 'UPDATE', this.redact(before), this.redact(after), updatedBy);
   }
 
   updateProxy(command: EngineProxyCommandDTO, updatedBy: string): void {
@@ -238,14 +218,7 @@ export default class EngineRepository {
         updatedBy
       );
     const after = this.get();
-    this.auditService.record(
-      'engine',
-      after!.id,
-      'UPDATE',
-      before as unknown as Record<string, unknown>,
-      after as unknown as Record<string, unknown>,
-      updatedBy
-    );
+    this.auditService.record('engine', after!.id, 'UPDATE', this.redact(before), this.redact(after), updatedBy);
   }
 
   updateLogger(command: EngineLoggerCommandDTO, updatedBy: string): void {
@@ -294,14 +267,7 @@ export default class EngineRepository {
         updatedBy
       );
     const after = this.get();
-    this.auditService.record(
-      'engine',
-      after!.id,
-      'UPDATE',
-      before as unknown as Record<string, unknown>,
-      after as unknown as Record<string, unknown>,
-      updatedBy
-    );
+    this.auditService.record('engine', after!.id, 'UPDATE', this.redact(before), this.redact(after), updatedBy);
   }
 
   updateVersion(version: string, launcherVersion: string): void {
@@ -318,14 +284,14 @@ export default class EngineRepository {
     }
 
     const query =
-      `INSERT INTO ${ENGINES_TABLE} (id, name, oibus_version, oibus_launcher_version, port, auth_token_duration, proxy_enabled, proxy_port,` +
+      `INSERT INTO ${ENGINES_TABLE} (id, name, oibus_version, oibus_launcher_version, port, auth_token_duration, audit_retention_duration, proxy_enabled, proxy_port,` +
       'forward_proxy_enabled, forward_proxy_url, forward_proxy_username, forward_proxy_password, proxy_username, proxy_password, ' +
       'log_console_level, log_file_level, log_file_max_file_size, log_file_number_of_files, log_database_level, ' +
       'log_database_max_number_of_logs, log_loki_level, log_loki_interval, log_loki_address, ' +
       'log_loki_username, log_loki_password, log_oia_level, log_oia_interval, ' +
       'log_syslog_level, log_syslog_host, log_syslog_port, log_syslog_protocol, ' +
       `created_by, updated_by, created_at, updated_at) ` +
-      `VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, strftime('%Y-%m-%dT%H:%M:%SZ', 'now'), strftime('%Y-%m-%dT%H:%M:%SZ', 'now'));`;
+      `VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, strftime('%Y-%m-%dT%H:%M:%SZ', 'now'), strftime('%Y-%m-%dT%H:%M:%SZ', 'now'));`;
     this.database
       .prepare(query)
       .run(
@@ -335,6 +301,7 @@ export default class EngineRepository {
         launcherVersion,
         command.webServer.port,
         command.webServer.authTokenDuration,
+        command.auditRetentionDuration,
         +command.proxyServer.enabled,
         command.proxyServer.port,
         +command.proxyServer.forward.enabled,
@@ -365,13 +332,34 @@ export default class EngineRepository {
       );
   }
 
+  /**
+   * Returns a shallow-enough copy of the engine settings with password fields redacted, mirroring
+   * toEngineSettingsDTO in oibus.service.ts (which blanks proxyServer.password,
+   * proxyServer.forward.password and logger.loki.password before exposing settings to the frontend),
+   * so real secrets never end up persisted in the audit trail.
+   */
+  private redact(settings: EngineSettings | null): Record<string, unknown> | null {
+    if (!settings) return null;
+    return {
+      ...settings,
+      proxyServer: {
+        ...settings.proxyServer,
+        password: '',
+        forward: { ...settings.proxyServer.forward, password: '' }
+      },
+      logger: {
+        ...settings.logger,
+        loki: { ...settings.logger.loki, password: '' }
+      }
+    };
+  }
+
   private toEngineSettings(result: Record<string, string | number>): EngineSettings {
     return {
       id: result.id as string,
       version: result.oibus_version as string,
       launcherVersion: result.oibus_launcher_version as string,
-      // TODO: wire audit_retention_duration through get()/update()/createDefault() once the audit retention feature reads/writes it
-      auditRetentionDuration: null,
+      auditRetentionDuration: (result.audit_retention_duration as number | null) ?? null,
       general: {
         name: result.name as string
       },

--- a/backend/src/repository/config/engine.repository.ts
+++ b/backend/src/repository/config/engine.repository.ts
@@ -10,6 +10,7 @@ import {
 } from '../../../shared/model/engine.model';
 import { version } from '../../../package.json';
 import { LogLevel } from '../../../shared/model/logs.model';
+import AuditService from '../../service/audit.service';
 
 const ENGINES_TABLE = 'engines';
 
@@ -19,6 +20,7 @@ const DEFAULT_ENGINE_SETTINGS: Omit<
   EngineSettings,
   'id' | 'version' | 'launcherVersion' | 'createdBy' | 'updatedBy' | 'createdAt' | 'updatedAt'
 > = {
+  auditRetentionDuration: null,
   general: {
     name: 'OIBus'
   },
@@ -77,6 +79,7 @@ const DEFAULT_ENGINE_SETTINGS: Omit<
 export default class EngineRepository {
   constructor(
     private readonly database: Database,
+    private readonly auditService: AuditService,
     launcherVersion: string,
     defaultPort = DEFAULT_ENGINE_SETTINGS.webServer.port,
     defaultName = DEFAULT_ENGINE_SETTINGS.general.name
@@ -111,6 +114,7 @@ export default class EngineRepository {
   }
 
   update(command: EngineSettingsCommandDTO, updatedBy: string): void {
+    const before = this.get();
     const query =
       `UPDATE ${ENGINES_TABLE} SET name = ?, port = ?, auth_token_duration = ?, proxy_enabled = ?, proxy_port = ?, ` +
       'forward_proxy_enabled = ?, forward_proxy_url = ?, forward_proxy_username = ?, forward_proxy_password = ?, proxy_username = ?, proxy_password = ?, ' +
@@ -167,23 +171,53 @@ export default class EngineRepository {
         command.logger.syslog.protocol,
         updatedBy
       );
+    const after = this.get();
+    this.auditService.record(
+      'engine',
+      after!.id,
+      'UPDATE',
+      before as unknown as Record<string, unknown>,
+      after as unknown as Record<string, unknown>,
+      updatedBy
+    );
   }
 
   updateName(name: string, updatedBy: string): void {
+    const before = this.get();
     const query =
       `UPDATE ${ENGINES_TABLE} SET name = ?, updated_by = ?, updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now') ` +
       `WHERE rowid=(SELECT MIN(rowid) FROM ${ENGINES_TABLE});`;
     this.database.prepare(query).run(name, updatedBy);
+    const after = this.get();
+    this.auditService.record(
+      'engine',
+      after!.id,
+      'UPDATE',
+      before as unknown as Record<string, unknown>,
+      after as unknown as Record<string, unknown>,
+      updatedBy
+    );
   }
 
   updateWebServer(command: EngineWebServerCommandDTO, updatedBy: string): void {
+    const before = this.get();
     const query =
       `UPDATE ${ENGINES_TABLE} SET port = ?, auth_token_duration = ?, updated_by = ?, updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now') ` +
       `WHERE rowid=(SELECT MIN(rowid) FROM ${ENGINES_TABLE});`;
     this.database.prepare(query).run(command.port, command.authTokenDuration, updatedBy);
+    const after = this.get();
+    this.auditService.record(
+      'engine',
+      after!.id,
+      'UPDATE',
+      before as unknown as Record<string, unknown>,
+      after as unknown as Record<string, unknown>,
+      updatedBy
+    );
   }
 
   updateProxy(command: EngineProxyCommandDTO, updatedBy: string): void {
+    const before = this.get();
     const query =
       `UPDATE ${ENGINES_TABLE} SET proxy_enabled = ?, proxy_port = ?, ` +
       `forward_proxy_enabled = ?, forward_proxy_url = ?, forward_proxy_username = ?, forward_proxy_password = ?, ` +
@@ -203,9 +237,19 @@ export default class EngineRepository {
         command.password,
         updatedBy
       );
+    const after = this.get();
+    this.auditService.record(
+      'engine',
+      after!.id,
+      'UPDATE',
+      before as unknown as Record<string, unknown>,
+      after as unknown as Record<string, unknown>,
+      updatedBy
+    );
   }
 
   updateLogger(command: EngineLoggerCommandDTO, updatedBy: string): void {
+    const before = this.get();
     const query =
       `UPDATE ${ENGINES_TABLE} SET ` +
       'log_console_level = ?, ' +
@@ -249,6 +293,15 @@ export default class EngineRepository {
         command.oia.interval,
         updatedBy
       );
+    const after = this.get();
+    this.auditService.record(
+      'engine',
+      after!.id,
+      'UPDATE',
+      before as unknown as Record<string, unknown>,
+      after as unknown as Record<string, unknown>,
+      updatedBy
+    );
   }
 
   updateVersion(version: string, launcherVersion: string): void {
@@ -317,6 +370,8 @@ export default class EngineRepository {
       id: result.id as string,
       version: result.oibus_version as string,
       launcherVersion: result.oibus_launcher_version as string,
+      // TODO: wire audit_retention_duration through get()/update()/createDefault() once the audit retention feature reads/writes it
+      auditRetentionDuration: null,
       general: {
         name: result.name as string
       },

--- a/backend/src/repository/config/history-query.repository.spec.ts
+++ b/backend/src/repository/config/history-query.repository.spec.ts
@@ -1,13 +1,14 @@
-import { before, after, beforeEach, describe, it } from 'node:test';
+import { before, after, beforeEach, describe, it, mock } from 'node:test';
 import assert from 'node:assert/strict';
 import { Database } from 'better-sqlite3';
-import { emptyDatabase, initDatabase, stripAuditFields } from '../../tests/utils/test-utils';
+import { createAuditServiceMock, emptyDatabase, initDatabase, stripAuditFields } from '../../tests/utils/test-utils';
 import testData from '../../tests/utils/test-data';
 import HistoryQueryRepository from './history-query.repository';
 import { HistoryQueryEntity, HistoryQueryItemEntity } from '../../model/histor-query.model';
 import { SouthItemSettings, SouthSettings } from '../../../shared/model/south-settings.model';
 import { NorthSettings } from '../../../shared/model/north-settings.model';
 import { Transformer } from '../../model/transformer.model';
+import AuditService from '../../service/audit.service';
 
 const TEST_DB_PATH = 'src/tests/test-config-history-query.db';
 
@@ -23,12 +24,14 @@ describe('HistoryQueryRepository', () => {
   });
 
   let repository: HistoryQueryRepository;
+  let auditService: AuditService;
   // IDs for newly created history queries, shared across tests
   let newHistoryId: string;
   let newHistoryWithoutTransformerId: string;
 
   beforeEach(() => {
-    repository = new HistoryQueryRepository(database);
+    auditService = createAuditServiceMock();
+    repository = new HistoryQueryRepository(database, auditService);
   });
 
   it('should properly get history queries (light)', () => {
@@ -74,6 +77,20 @@ describe('HistoryQueryRepository', () => {
     assert.strictEqual(createdHistoryQuery.name, 'new history query');
     assert.strictEqual(createdHistoryQuery.items.length, 0);
 
+    const recordMock = auditService.record as unknown as ReturnType<typeof mock.fn>;
+    const historyCreateCalls = recordMock.mock.calls.filter(
+      call => call.arguments[0] === 'history_query' && call.arguments[1] === newHistoryId && call.arguments[2] === 'CREATE'
+    );
+    assert.strictEqual(historyCreateCalls.length, 1);
+    assert.deepStrictEqual(historyCreateCalls[0].arguments, [
+      'history_query',
+      newHistoryId,
+      'CREATE',
+      null,
+      createdHistoryQuery,
+      newHistoryQuery.updatedBy
+    ]);
+
     const newHistoryWithoutTransformer: HistoryQueryEntity<SouthSettings, NorthSettings, SouthItemSettings> = JSON.parse(
       JSON.stringify(testData.historyQueries.list[0])
     );
@@ -89,20 +106,37 @@ describe('HistoryQueryRepository', () => {
     const createdHistoryWithoutTransformer = repository.findHistoryById(newHistoryWithoutTransformerId)!;
     assert.deepStrictEqual(createdHistoryWithoutTransformer.northTransformers, []);
 
-    repository.addOrEditTransformer(newHistoryWithoutTransformerId, {
-      id: '',
-      transformer: testData.transformers.list[0] as Transformer,
-      options: {},
-      items: []
-    });
+    recordMock.mock.resetCalls();
+    repository.addOrEditTransformer(
+      newHistoryWithoutTransformerId,
+      {
+        id: '',
+        transformer: testData.transformers.list[0] as Transformer,
+        options: {},
+        items: []
+      },
+      'transformerUser'
+    );
     const createdHistoryWithTransformer = repository.findHistoryById(newHistoryWithoutTransformerId)!;
     assert.strictEqual(createdHistoryWithTransformer.northTransformers.length, 1);
     assert.strictEqual(createdHistoryWithTransformer.northTransformers[0].transformer.id, testData.transformers.list[0].id);
 
     const transformerId = createdHistoryWithTransformer.northTransformers[0].id;
-    repository.removeTransformer(transformerId);
+    const transformerCreateCalls = recordMock.mock.calls.filter(
+      call => call.arguments[0] === 'history_query_transformer' && call.arguments[1] === transformerId && call.arguments[2] === 'CREATE'
+    );
+    assert.strictEqual(transformerCreateCalls.length, 1);
+    assert.strictEqual(transformerCreateCalls[0].arguments[5], 'transformerUser');
+
+    recordMock.mock.resetCalls();
+    repository.removeTransformer(transformerId, 'removeUser');
     const createdHistoryWithRemovedTransformer = repository.findHistoryById(newHistoryWithoutTransformerId)!;
     assert.deepStrictEqual(createdHistoryWithRemovedTransformer.northTransformers, []);
+    const transformerDeleteCalls = recordMock.mock.calls.filter(
+      call => call.arguments[0] === 'history_query_transformer' && call.arguments[1] === transformerId && call.arguments[2] === 'DELETE'
+    );
+    assert.strictEqual(transformerDeleteCalls.length, 1);
+    assert.strictEqual(transformerDeleteCalls[0].arguments[5], 'removeUser');
   });
 
   it('should remove all transformers for a history query by transformer id', () => {
@@ -117,18 +151,31 @@ describe('HistoryQueryRepository', () => {
 
     assert.ok(newHistoryWithoutTransformer2.id);
 
-    repository.addOrEditTransformer(newHistoryWithoutTransformer2.id, {
-      id: '',
-      transformer: testData.transformers.list[0] as Transformer,
-      options: {},
-      items: []
-    });
+    repository.addOrEditTransformer(
+      newHistoryWithoutTransformer2.id,
+      {
+        id: '',
+        transformer: testData.transformers.list[0] as Transformer,
+        options: {},
+        items: []
+      },
+      'attachUser'
+    );
     const historyWithTransformer = repository.findHistoryById(newHistoryWithoutTransformer2.id)!;
     assert.strictEqual(historyWithTransformer.northTransformers.length, 1);
+    const transformerId = historyWithTransformer.northTransformers[0].id;
 
-    repository.removeTransformersByTransformerId(testData.transformers.list[0].id);
+    const recordMock = auditService.record as unknown as ReturnType<typeof mock.fn>;
+    recordMock.mock.resetCalls();
+    repository.removeTransformersByTransformerId(testData.transformers.list[0].id, 'bulkRemoveUser');
     const historyWithRemovedTransformers = repository.findHistoryById(newHistoryWithoutTransformer2.id)!;
     assert.deepStrictEqual(historyWithRemovedTransformers.northTransformers, []);
+
+    const transformerDeleteCalls = recordMock.mock.calls.filter(
+      call => call.arguments[0] === 'history_query_transformer' && call.arguments[1] === transformerId && call.arguments[2] === 'DELETE'
+    );
+    assert.strictEqual(transformerDeleteCalls.length, 1);
+    assert.strictEqual(transformerDeleteCalls[0].arguments[5], 'bulkRemoveUser');
   });
 
   it('should update a history query', () => {
@@ -155,7 +202,10 @@ describe('HistoryQueryRepository', () => {
       createdAt: '',
       updatedAt: ''
     };
+    const existingItem = testData.historyQueries.list[1].items[0];
+    const beforeItem = repository.findItemById(testData.historyQueries.list[1].id, existingItem.id);
     newHistoryQuery.items = [...testData.historyQueries.list[1].items, newItem1, newItem2];
+    newHistoryQuery.items[0] = { ...newHistoryQuery.items[0], name: 'renamed existing item' };
     newHistoryQuery.northTransformers = [
       {
         id: '',
@@ -164,12 +214,31 @@ describe('HistoryQueryRepository', () => {
         items: [{ id: 'temp_1', name: 'new item', enabled: true, createdBy: '', updatedBy: '', createdAt: '', updatedAt: '' }]
       }
     ];
+
+    const recordMock = auditService.record as unknown as ReturnType<typeof mock.fn>;
+    recordMock.mock.resetCalls();
     repository.saveHistory(newHistoryQuery);
 
     const updatedHistoryQuery = repository.findHistoryById(newHistoryQuery.id)!;
     assert.strictEqual(updatedHistoryQuery.items.length, 3);
     assert.strictEqual(updatedHistoryQuery.northTransformers.length, 1);
     assert.strictEqual(updatedHistoryQuery.northTransformers[0].items.length, 1);
+
+    const itemCreateCalls = recordMock.mock.calls.filter(
+      call => call.arguments[0] === 'history_query_item' && call.arguments[2] === 'CREATE'
+    );
+    assert.strictEqual(itemCreateCalls.length, 2);
+
+    const itemUpdateCalls = recordMock.mock.calls.filter(
+      call => call.arguments[0] === 'history_query_item' && call.arguments[1] === existingItem.id && call.arguments[2] === 'UPDATE'
+    );
+    assert.strictEqual(itemUpdateCalls.length, 1);
+    assert.deepStrictEqual(itemUpdateCalls[0].arguments[3], beforeItem);
+
+    const historyUpdateCalls = recordMock.mock.calls.filter(
+      call => call.arguments[0] === 'history_query' && call.arguments[1] === newHistoryQuery.id && call.arguments[2] === 'UPDATE'
+    );
+    assert.strictEqual(historyUpdateCalls.length, 1);
   });
 
   it('should save a history query with a "temp_" north transformer id (treated as new)', () => {
@@ -213,8 +282,81 @@ describe('HistoryQueryRepository', () => {
 
   it('should delete a history query', () => {
     assert.ok(repository.findHistoryById(newHistoryId));
-    repository.deleteHistory(newHistoryId);
+
+    const beforeHistory = repository.findHistoryById(newHistoryId)!;
+    const recordMock = auditService.record as unknown as ReturnType<typeof mock.fn>;
+    recordMock.mock.resetCalls();
+    repository.deleteHistory(newHistoryId, 'deleteUser');
     assert.strictEqual(repository.findHistoryById(newHistoryId), null);
+
+    const historyDeleteCall = recordMock.mock.calls.find(
+      call => call.arguments[0] === 'history_query' && call.arguments[1] === newHistoryId && call.arguments[2] === 'DELETE'
+    );
+    assert.deepStrictEqual(historyDeleteCall!.arguments, [
+      'history_query',
+      newHistoryId,
+      'DELETE',
+      beforeHistory,
+      null,
+      'deleteUser'
+    ]);
+  });
+
+  it('should cascade-delete items and transformers when deleting a history query', () => {
+    const newHistoryQuery: HistoryQueryEntity<SouthSettings, NorthSettings, SouthItemSettings> = JSON.parse(
+      JSON.stringify(testData.historyQueries.list[0])
+    );
+    newHistoryQuery.id = '';
+    newHistoryQuery.name = 'history to delete with items and transformers';
+    newHistoryQuery.northTransformers = [];
+    newHistoryQuery.items = [
+      {
+        id: '',
+        name: 'item to be cascade-deleted',
+        enabled: true,
+        settings: {} as SouthItemSettings,
+        createdBy: '',
+        updatedBy: '',
+        createdAt: '',
+        updatedAt: ''
+      }
+    ];
+    repository.saveHistory(newHistoryQuery);
+    repository.addOrEditTransformer(
+      newHistoryQuery.id,
+      {
+        id: '',
+        transformer: testData.transformers.list[0] as Transformer,
+        options: {},
+        items: []
+      },
+      'attachUser'
+    );
+
+    const before = repository.findHistoryById(newHistoryQuery.id)!;
+    assert.strictEqual(before.items.length, 1);
+    assert.strictEqual(before.northTransformers.length, 1);
+
+    const recordMock = auditService.record as unknown as ReturnType<typeof mock.fn>;
+    recordMock.mock.resetCalls();
+    repository.deleteHistory(newHistoryQuery.id, 'cascadeDeleteUser');
+
+    const itemDeleteCalls = recordMock.mock.calls.filter(
+      call => call.arguments[0] === 'history_query_item' && call.arguments[2] === 'DELETE'
+    );
+    assert.strictEqual(itemDeleteCalls.length, 1);
+    assert.strictEqual(itemDeleteCalls[0].arguments[5], 'cascadeDeleteUser');
+
+    const transformerDeleteCalls = recordMock.mock.calls.filter(
+      call => call.arguments[0] === 'history_query_transformer' && call.arguments[2] === 'DELETE'
+    );
+    assert.strictEqual(transformerDeleteCalls.length, 1);
+    assert.strictEqual(transformerDeleteCalls[0].arguments[5], 'cascadeDeleteUser');
+
+    const historyDeleteCalls = recordMock.mock.calls.filter(
+      call => call.arguments[0] === 'history_query' && call.arguments[1] === newHistoryQuery.id && call.arguments[2] === 'DELETE'
+    );
+    assert.strictEqual(historyDeleteCalls.length, 1);
   });
 
   it('should update status', () => {
@@ -251,14 +393,84 @@ describe('HistoryQueryRepository', () => {
     assert.strictEqual(repository.findItemById(testData.historyQueries.list[0].id, testData.historyQueries.list[1].items[0].id), null);
   });
 
+  it('should save a new item and audit it as CREATE', () => {
+    const newItem: HistoryQueryItemEntity<SouthItemSettings> = {
+      id: '',
+      name: 'saveItem created item',
+      enabled: true,
+      settings: {} as SouthItemSettings,
+      createdBy: 'creatorUser',
+      updatedBy: 'creatorUser',
+      createdAt: '',
+      updatedAt: ''
+    };
+    const recordMock = auditService.record as unknown as ReturnType<typeof mock.fn>;
+    recordMock.mock.resetCalls();
+    repository.saveItem(testData.historyQueries.list[1].id, newItem);
+    assert.ok(newItem.id);
+
+    const created = repository.findItemById(testData.historyQueries.list[1].id, newItem.id)!;
+    const createCalls = recordMock.mock.calls.filter(
+      call => call.arguments[0] === 'history_query_item' && call.arguments[1] === newItem.id && call.arguments[2] === 'CREATE'
+    );
+    assert.strictEqual(createCalls.length, 1);
+    assert.deepStrictEqual(createCalls[0].arguments, ['history_query_item', newItem.id, 'CREATE', null, created, 'creatorUser']);
+
+    recordMock.mock.resetCalls();
+    const updatedItem = { ...newItem, name: 'saveItem renamed item', updatedBy: 'updaterUser' };
+    repository.saveItem(testData.historyQueries.list[1].id, updatedItem);
+    const afterUpdate = repository.findItemById(testData.historyQueries.list[1].id, newItem.id)!;
+    const updateCalls = recordMock.mock.calls.filter(
+      call => call.arguments[0] === 'history_query_item' && call.arguments[1] === newItem.id && call.arguments[2] === 'UPDATE'
+    );
+    assert.strictEqual(updateCalls.length, 1);
+    assert.deepStrictEqual(updateCalls[0].arguments, [
+      'history_query_item',
+      newItem.id,
+      'UPDATE',
+      created,
+      afterUpdate,
+      'updaterUser'
+    ]);
+  });
+
   it('should delete item', () => {
-    repository.deleteItem(testData.historyQueries.list[0].id, testData.historyQueries.list[0].items[0].id);
+    const before = repository.findItemById(testData.historyQueries.list[0].id, testData.historyQueries.list[0].items[0].id);
+    const recordMock = auditService.record as unknown as ReturnType<typeof mock.fn>;
+    recordMock.mock.resetCalls();
+    repository.deleteItem(testData.historyQueries.list[0].id, testData.historyQueries.list[0].items[0].id, 'deleteItemUser');
     assert.strictEqual(repository.findItemById(testData.historyQueries.list[0].id, testData.historyQueries.list[0].items[0].id), null);
+
+    const deleteCall = recordMock.mock.calls.find(
+      call =>
+        call.arguments[0] === 'history_query_item' &&
+        call.arguments[1] === testData.historyQueries.list[0].items[0].id &&
+        call.arguments[2] === 'DELETE'
+    );
+    assert.deepStrictEqual(deleteCall!.arguments, [
+      'history_query_item',
+      testData.historyQueries.list[0].items[0].id,
+      'DELETE',
+      before,
+      null,
+      'deleteItemUser'
+    ]);
   });
 
   it('should delete all item by south', () => {
-    repository.deleteAllItemsByHistory(testData.historyQueries.list[0].id);
+    const beforeItems = repository.findAllItemsForHistory(testData.historyQueries.list[0].id);
+    const recordMock = auditService.record as unknown as ReturnType<typeof mock.fn>;
+    recordMock.mock.resetCalls();
+    repository.deleteAllItemsByHistory(testData.historyQueries.list[0].id, 'deleteAllUser');
     assert.strictEqual(repository.findAllItemsForHistory(testData.historyQueries.list[0].id).length, 0);
+
+    const deleteCalls = recordMock.mock.calls.filter(
+      call => call.arguments[0] === 'history_query_item' && call.arguments[2] === 'DELETE'
+    );
+    assert.strictEqual(deleteCalls.length, beforeItems.length);
+    for (const call of deleteCalls) {
+      assert.strictEqual(call.arguments[5], 'deleteAllUser');
+    }
   });
 
   it('should disable and enable item', () => {
@@ -274,9 +486,9 @@ describe('HistoryQueryRepository', () => {
     );
   });
 
-  it('should save all items without and delete previous items', () => {
-    // At this point list[1] has 3 items (from 'update a history query' test)
-    // saveAllItems with deleteItemsNotPresent=false: keeps existing items not in the list
+  it('should save all items without deleting previous items (deleteItemsNotPresent=false)', () => {
+    // deleteItemsNotPresent=false: items already in the DB but not present in itemsToSave are left untouched
+    const beforeCount = repository.findAllItemsForHistory(testData.historyQueries.list[1].id).length;
     const existingItems: Array<HistoryQueryItemEntity<SouthItemSettings>> = JSON.parse(
       JSON.stringify(testData.historyQueries.list[1].items)
     );
@@ -293,10 +505,11 @@ describe('HistoryQueryRepository', () => {
     const itemsToSave = [...existingItems, newItem];
     itemsToSave[0].name = 'updated name';
 
-    repository.saveAllItems(testData.historyQueries.list[1].id, itemsToSave, false);
+    repository.saveAllItems(testData.historyQueries.list[1].id, itemsToSave, false, 'saveAllUser');
 
     const results = repository.findAllItemsForHistory(testData.historyQueries.list[1].id);
-    assert.strictEqual(results.length, 4);
+    // Only the new item is added on top of whatever already existed; the pre-existing item is renamed, not duplicated.
+    assert.strictEqual(results.length, beforeCount + 1);
 
     assert.strictEqual(
       repository.findItemById(testData.historyQueries.list[1].id, testData.historyQueries.list[1].items[0].id)!.name,
@@ -307,15 +520,12 @@ describe('HistoryQueryRepository', () => {
     assert.ok(repository.findItemById(testData.historyQueries.list[1].id, newItem.id));
   });
 
-  it('should save all items without deleting previous items', () => {
-    // deleteItemsNotPresent=true: deletes all existing items, then only inserts new ones (id='')
-    // list[0].items were deleted, so their IDs won't match anything after the delete
-    const existingItems: Array<HistoryQueryItemEntity<SouthItemSettings>> = JSON.parse(
-      JSON.stringify(testData.historyQueries.list[0].items)
-    );
+  it('should save all items and delete previous items (deleteItemsNotPresent=true)', () => {
+    // deleteItemsNotPresent=true: deletes all existing items for this history query, then only inserts the new ones (id='')
+    const beforeItems = repository.findAllItemsForHistory(testData.historyQueries.list[1].id);
     const newItem: HistoryQueryItemEntity<SouthItemSettings> = {
       id: '',
-      name: 'new history item',
+      name: 'new history item after delete-all',
       enabled: false,
       settings: {} as SouthItemSettings,
       createdBy: '',
@@ -323,17 +533,22 @@ describe('HistoryQueryRepository', () => {
       createdAt: '',
       updatedAt: ''
     };
-    const itemsToSave = [...existingItems, newItem];
-    itemsToSave[0].name = 'updated name';
+    const itemsToSave = [newItem];
 
-    repository.saveAllItems(testData.historyQueries.list[1].id, itemsToSave, true);
+    const recordMock = auditService.record as unknown as ReturnType<typeof mock.fn>;
+    recordMock.mock.resetCalls();
+    repository.saveAllItems(testData.historyQueries.list[1].id, itemsToSave, true, 'deleteAllThenSaveUser');
 
     const results = repository.findAllItemsForHistory(testData.historyQueries.list[1].id);
-    // deleteAll=true deletes all 4 items, then only the new item (id='') gets inserted
-    // items with existing IDs get UPDATE which matches nothing (already deleted)
+    // deleteAll=true deletes every pre-existing item first, then only the new item gets inserted
     assert.strictEqual(results.length, 1);
     assert.ok(newItem.id);
     assert.ok(repository.findItemById(testData.historyQueries.list[1].id, newItem.id));
+
+    const deleteAllCalls = recordMock.mock.calls.filter(
+      call => call.arguments[0] === 'history_query_item' && call.arguments[2] === 'DELETE' && call.arguments[5] === 'deleteAllThenSaveUser'
+    );
+    assert.strictEqual(deleteAllCalls.length, beforeItems.length);
   });
 
   it('should not bump updated_at when saving a history query item that has not changed', () => {
@@ -363,10 +578,15 @@ describe('HistoryQueryRepository', () => {
     const resavedHistoryQuery: HistoryQueryEntity<SouthSettings, NorthSettings, SouthItemSettings> = JSON.parse(
       JSON.stringify(historyQuery)
     );
+    const recordMock = auditService.record as unknown as ReturnType<typeof mock.fn>;
+    recordMock.mock.resetCalls();
     repository.saveHistory(resavedHistoryQuery);
 
     const row = database.prepare(`SELECT updated_at FROM history_items WHERE id = ?;`).get(itemId) as { updated_at: string };
     assert.strictEqual(row.updated_at, '2000-01-01T00:00:00Z');
+
+    const itemAuditCalls = recordMock.mock.calls.filter(call => call.arguments[0] === 'history_query_item' && call.arguments[1] === itemId);
+    assert.strictEqual(itemAuditCalls.length, 0);
   });
 
   it('should bump updated_at when saving a history query item that has changed', () => {

--- a/backend/src/repository/config/history-query.repository.spec.ts
+++ b/backend/src/repository/config/history-query.repository.spec.ts
@@ -87,9 +87,11 @@ describe('HistoryQueryRepository', () => {
       newHistoryId,
       'CREATE',
       null,
-      createdHistoryQuery,
+      { ...createdHistoryQuery, southSettings: { ...createdHistoryQuery.southSettings, password: '' } },
       newHistoryQuery.updatedBy
     ]);
+    // The south settings' secret field must never be persisted in the audit trail
+    assert.strictEqual((historyCreateCalls[0].arguments[4] as { southSettings: { password: string } }).southSettings.password, '');
 
     const newHistoryWithoutTransformer: HistoryQueryEntity<SouthSettings, NorthSettings, SouthItemSettings> = JSON.parse(
       JSON.stringify(testData.historyQueries.list[0])
@@ -296,10 +298,18 @@ describe('HistoryQueryRepository', () => {
       'history_query',
       newHistoryId,
       'DELETE',
-      beforeHistory,
+      {
+        ...beforeHistory,
+        southSettings: { ...beforeHistory.southSettings, password: '' },
+        northSettings: { ...beforeHistory.northSettings, password: '' }
+      },
       null,
       'deleteUser'
     ]);
+    // The south/north settings' secret fields must never be persisted in the audit trail
+    const redactedBefore = historyDeleteCall!.arguments[3] as { southSettings: { password: string }; northSettings: { password: string } };
+    assert.strictEqual(redactedBefore.southSettings.password, '');
+    assert.strictEqual(redactedBefore.northSettings.password, '');
   });
 
   it('should cascade-delete items and transformers when deleting a history query', () => {
@@ -424,14 +434,7 @@ describe('HistoryQueryRepository', () => {
       call => call.arguments[0] === 'history_query_item' && call.arguments[1] === newItem.id && call.arguments[2] === 'UPDATE'
     );
     assert.strictEqual(updateCalls.length, 1);
-    assert.deepStrictEqual(updateCalls[0].arguments, [
-      'history_query_item',
-      newItem.id,
-      'UPDATE',
-      created,
-      afterUpdate,
-      'updaterUser'
-    ]);
+    assert.deepStrictEqual(updateCalls[0].arguments, ['history_query_item', newItem.id, 'UPDATE', created, afterUpdate, 'updaterUser']);
   });
 
   it('should delete item', () => {
@@ -464,9 +467,7 @@ describe('HistoryQueryRepository', () => {
     repository.deleteAllItemsByHistory(testData.historyQueries.list[0].id, 'deleteAllUser');
     assert.strictEqual(repository.findAllItemsForHistory(testData.historyQueries.list[0].id).length, 0);
 
-    const deleteCalls = recordMock.mock.calls.filter(
-      call => call.arguments[0] === 'history_query_item' && call.arguments[2] === 'DELETE'
-    );
+    const deleteCalls = recordMock.mock.calls.filter(call => call.arguments[0] === 'history_query_item' && call.arguments[2] === 'DELETE');
     assert.strictEqual(deleteCalls.length, beforeItems.length);
     for (const call of deleteCalls) {
       assert.strictEqual(call.arguments[5], 'deleteAllUser');

--- a/backend/src/repository/config/history-query.repository.ts
+++ b/backend/src/repository/config/history-query.repository.ts
@@ -14,6 +14,10 @@ import { ScanMode } from '../../model/scan-mode.model';
 import { scanModeColumns, toScanMode } from './scan-mode.repository';
 import { SouthConnectorItemEntityLight } from '../../model/south-connector.model';
 import AuditService from '../../service/audit.service';
+import { encryptionService } from '../../service/encryption.service';
+import { southManifestList } from '../../service/south-manifests';
+import { northManifestList } from '../../service/north-manifests';
+import { OIBusObjectAttribute } from '../../../shared/model/form.model';
 
 const HISTORY_QUERIES_TABLE = 'history_queries';
 const HISTORY_ITEMS_TABLE = 'history_items';
@@ -214,7 +218,7 @@ export default class HistoryQueryRepository {
               item.id,
               'CREATE',
               null,
-              created as unknown as Record<string, unknown>,
+              this.redactItem(created, history.southType),
               item.updatedBy
             );
           } else {
@@ -231,8 +235,8 @@ export default class HistoryQueryRepository {
                 'history_query_item',
                 item.id,
                 'UPDATE',
-                (beforeItemsById.get(item.id) ?? null) as unknown as Record<string, unknown> | null,
-                after as unknown as Record<string, unknown>,
+                this.redactItem(beforeItemsById.get(item.id) ?? null, history.southType),
+                this.redactItem(after, history.southType),
                 item.updatedBy
               );
             }
@@ -246,7 +250,7 @@ export default class HistoryQueryRepository {
               'history_query_item',
               removedItemId,
               'DELETE',
-              removedItem as unknown as Record<string, unknown>,
+              this.redactItem(removedItem, history.southType),
               null,
               history.updatedBy
             );
@@ -268,7 +272,7 @@ export default class HistoryQueryRepository {
             'history_query_item',
             removedItemId,
             'DELETE',
-            removedItem as unknown as Record<string, unknown>,
+            this.redactItem(removedItem, history.southType),
             null,
             history.updatedBy
           );
@@ -276,9 +280,7 @@ export default class HistoryQueryRepository {
       }
 
       const keepIds = history.northTransformers.filter(t => t.id).map(t => t.id);
-      const removedTransformerIds = (beforeHistory?.northTransformers ?? [])
-        .filter(t => !keepIds.includes(t.id))
-        .map(t => t.id);
+      const removedTransformerIds = (beforeHistory?.northTransformers ?? []).filter(t => !keepIds.includes(t.id)).map(t => t.id);
       for (const removedId of removedTransformerIds) {
         this.auditService.record(
           'history_query_transformer',
@@ -332,8 +334,8 @@ export default class HistoryQueryRepository {
         'history_query',
         history.id,
         isNew ? 'CREATE' : 'UPDATE',
-        beforeHistory as unknown as Record<string, unknown> | null,
-        afterHistory as unknown as Record<string, unknown>,
+        this.redactHistory(beforeHistory),
+        this.redactHistory(afterHistory),
         history.updatedBy
       );
     });
@@ -369,7 +371,7 @@ export default class HistoryQueryRepository {
 
       if (before) {
         for (const item of before.items) {
-          this.auditService.record('history_query_item', item.id, 'DELETE', item as unknown as Record<string, unknown>, null, deletedBy);
+          this.auditService.record('history_query_item', item.id, 'DELETE', this.redactItem(item, before.southType), null, deletedBy);
         }
         for (const transformer of before.northTransformers) {
           this.auditService.record(
@@ -381,7 +383,7 @@ export default class HistoryQueryRepository {
             deletedBy
           );
         }
-        this.auditService.record('history_query', id, 'DELETE', before as unknown as Record<string, unknown>, null, deletedBy);
+        this.auditService.record('history_query', id, 'DELETE', this.redactHistory(before), null, deletedBy);
       }
     });
     transaction();
@@ -423,8 +425,7 @@ export default class HistoryQueryRepository {
 
   removeTransformer(id: string, deletedBy: string): void {
     const historyId = this.database.prepare(`SELECT history_id FROM ${HISTORY_TRANSFORMERS_TABLE} WHERE id = ?;`).get(id) as
-      | { history_id: string }
-      | undefined;
+      { history_id: string } | undefined;
     const before = historyId ? (this.findTransformersForHistory(historyId.history_id).find(t => t.id === id) ?? null) : null;
     const transaction = this.database.transaction(() => {
       this.database.prepare(`DELETE FROM ${HISTORY_QUERY_TRANSFORMERS_ITEMS_TABLE} WHERE id = ?;`).run(id);
@@ -538,6 +539,7 @@ export default class HistoryQueryRepository {
   saveItem<I extends SouthItemSettings>(historyId: string, item: HistoryQueryItemEntity<I>): void {
     const wasNew = !item.id;
     const before = wasNew ? null : this.findItemById(historyId, item.id);
+    const southType = this.findHistoryById(historyId)?.southType;
     if (!item.id) {
       item.id = generateRandomId(6);
       const insertQuery =
@@ -556,8 +558,10 @@ export default class HistoryQueryRepository {
       'history_query_item',
       item.id,
       wasNew ? 'CREATE' : 'UPDATE',
-      before as unknown as Record<string, unknown> | null,
-      after as unknown as Record<string, unknown>,
+      southType
+        ? this.redactItem(before as unknown as HistoryQueryItemEntity<SouthItemSettings> | null, southType)
+        : (before as unknown as Record<string, unknown> | null),
+      southType ? this.redactItem(after, southType) : (after as unknown as Record<string, unknown>),
       item.updatedBy
     );
   }
@@ -581,6 +585,7 @@ export default class HistoryQueryRepository {
 
   deleteItem(historyId: string, itemId: string, deletedBy: string): void {
     const before = this.findItemById(historyId, itemId);
+    const southType = this.findHistoryById(historyId)?.southType;
     const transaction = this.database.transaction(() => {
       this.database
         .prepare(
@@ -592,7 +597,14 @@ export default class HistoryQueryRepository {
         .run(historyId, itemId);
       this.database.prepare(`DELETE FROM ${HISTORY_ITEMS_TABLE} WHERE history_id = ? AND id = ?;`).run(historyId, itemId);
       if (before) {
-        this.auditService.record('history_query_item', itemId, 'DELETE', before as unknown as Record<string, unknown>, null, deletedBy);
+        this.auditService.record(
+          'history_query_item',
+          itemId,
+          'DELETE',
+          southType ? this.redactItem(before, southType) : (before as unknown as Record<string, unknown>),
+          null,
+          deletedBy
+        );
       }
     });
     transaction();
@@ -600,6 +612,7 @@ export default class HistoryQueryRepository {
 
   deleteAllItemsByHistory(historyId: string, deletedBy: string): void {
     const beforeItems = this.findAllItemsForHistory(historyId);
+    const southType = this.findHistoryById(historyId)?.southType;
     const transaction = this.database.transaction(() => {
       this.database
         .prepare(
@@ -611,7 +624,14 @@ export default class HistoryQueryRepository {
         .run(historyId);
       this.database.prepare(`DELETE FROM ${HISTORY_ITEMS_TABLE} WHERE history_id = ?;`).run(historyId);
       for (const item of beforeItems) {
-        this.auditService.record('history_query_item', item.id, 'DELETE', item as unknown as Record<string, unknown>, null, deletedBy);
+        this.auditService.record(
+          'history_query_item',
+          item.id,
+          'DELETE',
+          southType ? this.redactItem(item, southType) : (item as unknown as Record<string, unknown>),
+          null,
+          deletedBy
+        );
       }
     });
     transaction();
@@ -658,6 +678,39 @@ export default class HistoryQueryRepository {
     const query = `SELECT ${scanModeColumns()} FROM ${SCAN_MODE} WHERE id = ?;`;
     const result = this.database.prepare(query).get(scanModeId) as Record<string, string>;
     return toScanMode(result);
+  }
+
+  /**
+   * Returns a shallow copy of the history query with its south/north settings' secret fields redacted,
+   * using the same manifest-driven filtering applied before exposing the history query to the frontend
+   * (see toHistoryQueryDTO in history-query.service.ts), so real secrets never end up persisted in the
+   * audit trail.
+   */
+  private redactHistory(
+    entity: HistoryQueryEntity<SouthSettings, NorthSettings, SouthItemSettings> | null
+  ): Record<string, unknown> | null {
+    if (!entity) return null;
+    const southManifest = southManifestList.find(element => element.id === entity.southType);
+    const northManifest = northManifestList.find(element => element.id === entity.northType);
+    return {
+      ...entity,
+      southSettings: southManifest ? encryptionService.filterSecrets(entity.southSettings, southManifest.settings) : entity.southSettings,
+      northSettings: northManifest ? encryptionService.filterSecrets(entity.northSettings, northManifest.settings) : entity.northSettings
+    };
+  }
+
+  /**
+   * Returns a shallow copy of the history query item with its settings' secret fields redacted, using
+   * the same item-level manifest lookup as toHistoryQueryItemDTO in history-query-item-dto.utils.ts.
+   */
+  private redactItem(entity: HistoryQueryItemEntity<SouthItemSettings> | null, southType: string): Record<string, unknown> | null {
+    if (!entity) return null;
+    const manifest = southManifestList.find(element => element.id === southType);
+    if (!manifest) return entity as unknown as Record<string, unknown>;
+    const itemSettingsManifest = manifest.items.rootAttribute.attributes.find(attribute => attribute.key === 'settings') as
+      OIBusObjectAttribute | undefined;
+    if (!itemSettingsManifest) return entity as unknown as Record<string, unknown>;
+    return { ...entity, settings: encryptionService.filterSecrets(entity.settings, itemSettingsManifest) };
   }
 
   private toHistoryQueryItemEntity(result: Record<string, string>): HistoryQueryItemEntity<SouthItemSettings> {

--- a/backend/src/repository/config/history-query.repository.ts
+++ b/backend/src/repository/config/history-query.repository.ts
@@ -13,6 +13,7 @@ import { toTransformer } from './transformer.repository';
 import { ScanMode } from '../../model/scan-mode.model';
 import { scanModeColumns, toScanMode } from './scan-mode.repository';
 import { SouthConnectorItemEntityLight } from '../../model/south-connector.model';
+import AuditService from '../../service/audit.service';
 
 const HISTORY_QUERIES_TABLE = 'history_queries';
 const HISTORY_ITEMS_TABLE = 'history_items';
@@ -23,7 +24,10 @@ const SCAN_MODE = 'scan_modes';
 const PAGE_SIZE = 50;
 
 export default class HistoryQueryRepository {
-  constructor(private readonly database: Database) {}
+  constructor(
+    private readonly database: Database,
+    private readonly auditService: AuditService
+  ) {}
 
   findAllHistoriesLight(): Array<HistoryQueryEntityLight> {
     const query = `SELECT id, name, description, status, start_time, end_time, south_type, north_type, created_by, updated_by, created_at, updated_at FROM ${HISTORY_QUERIES_TABLE};`;
@@ -66,6 +70,11 @@ export default class HistoryQueryRepository {
   }
 
   saveHistory(history: HistoryQueryEntity<SouthSettings, NorthSettings, SouthItemSettings>): void {
+    const isNew = !history.id;
+    const beforeHistory = history.id ? this.findHistoryById(history.id) : null;
+    const beforeItemsById = history.id
+      ? new Map(this.findAllItemsForHistory(history.id).map(i => [i.id, i]))
+      : new Map<string, HistoryQueryItemEntity<SouthItemSettings>>();
     const transaction = this.database.transaction(() => {
       if (!history.id) {
         history.id = generateRandomId(6);
@@ -199,6 +208,15 @@ export default class HistoryQueryRepository {
             }
             item.id = randomId;
             insert.run(item.id, item.name, +item.enabled, history.id, JSON.stringify(item.settings), item.createdBy, item.updatedBy);
+            const created = this.findItemById(history.id, item.id);
+            this.auditService.record(
+              'history_query_item',
+              item.id,
+              'CREATE',
+              null,
+              created as unknown as Record<string, unknown>,
+              item.updatedBy
+            );
           } else {
             const existing = existingItemsById.get(item.id);
             const hasChanged =
@@ -208,7 +226,30 @@ export default class HistoryQueryRepository {
               existing.settings !== JSON.stringify(item.settings);
             if (hasChanged) {
               update.run(item.name, +item.enabled, JSON.stringify(item.settings), item.updatedBy, item.id);
+              const after = this.findItemById(history.id, item.id);
+              this.auditService.record(
+                'history_query_item',
+                item.id,
+                'UPDATE',
+                (beforeItemsById.get(item.id) ?? null) as unknown as Record<string, unknown> | null,
+                after as unknown as Record<string, unknown>,
+                item.updatedBy
+              );
             }
+          }
+        }
+
+        const incomingItemIds = new Set(history.items.filter(item => item.id).map(item => item.id));
+        for (const [removedItemId, removedItem] of beforeItemsById) {
+          if (!incomingItemIds.has(removedItemId)) {
+            this.auditService.record(
+              'history_query_item',
+              removedItemId,
+              'DELETE',
+              removedItem as unknown as Record<string, unknown>,
+              null,
+              history.updatedBy
+            );
           }
         }
       } else {
@@ -222,9 +263,33 @@ export default class HistoryQueryRepository {
           .run(history.id);
 
         this.database.prepare(`DELETE FROM ${HISTORY_ITEMS_TABLE} WHERE history_id = ?;`).run(history.id);
+        for (const [removedItemId, removedItem] of beforeItemsById) {
+          this.auditService.record(
+            'history_query_item',
+            removedItemId,
+            'DELETE',
+            removedItem as unknown as Record<string, unknown>,
+            null,
+            history.updatedBy
+          );
+        }
       }
 
       const keepIds = history.northTransformers.filter(t => t.id).map(t => t.id);
+      const removedTransformerIds = (beforeHistory?.northTransformers ?? [])
+        .filter(t => !keepIds.includes(t.id))
+        .map(t => t.id);
+      for (const removedId of removedTransformerIds) {
+        this.auditService.record(
+          'history_query_transformer',
+          removedId,
+          'DELETE',
+          beforeHistory!.northTransformers.find(t => t.id === removedId) as unknown as Record<string, unknown>,
+          null,
+          history.updatedBy
+        );
+      }
+
       if (keepIds.length === 0) {
         this.database
           .prepare(
@@ -259,8 +324,18 @@ export default class HistoryQueryRepository {
         if (transformerWithOptions.id.startsWith('temp_')) {
           transformerWithOptions.id = '';
         }
-        this.addOrEditTransformer(history.id, transformerWithOptions);
+        this.addOrEditTransformer(history.id, transformerWithOptions, history.updatedBy);
       }
+
+      const afterHistory = this.findHistoryById(history.id);
+      this.auditService.record(
+        'history_query',
+        history.id,
+        isNew ? 'CREATE' : 'UPDATE',
+        beforeHistory as unknown as Record<string, unknown> | null,
+        afterHistory as unknown as Record<string, unknown>,
+        history.updatedBy
+      );
     });
     transaction();
   }
@@ -270,7 +345,8 @@ export default class HistoryQueryRepository {
     this.database.prepare(query).run(status, id);
   }
 
-  deleteHistory(id: string): void {
+  deleteHistory(id: string, deletedBy: string): void {
+    const before = this.findHistoryById(id);
     const transaction = this.database.transaction(() => {
       // 1. Delete items
       this.database
@@ -290,11 +366,30 @@ export default class HistoryQueryRepository {
 
       // 4. Delete the history itself
       this.database.prepare(`DELETE FROM ${HISTORY_QUERIES_TABLE} WHERE id = ?;`).run(id);
+
+      if (before) {
+        for (const item of before.items) {
+          this.auditService.record('history_query_item', item.id, 'DELETE', item as unknown as Record<string, unknown>, null, deletedBy);
+        }
+        for (const transformer of before.northTransformers) {
+          this.auditService.record(
+            'history_query_transformer',
+            transformer.id,
+            'DELETE',
+            transformer as unknown as Record<string, unknown>,
+            null,
+            deletedBy
+          );
+        }
+        this.auditService.record('history_query', id, 'DELETE', before as unknown as Record<string, unknown>, null, deletedBy);
+      }
     });
     transaction();
   }
 
-  addOrEditTransformer(historyId: string, transformerWithOptions: HistoryTransformerWithOptions): void {
+  addOrEditTransformer(historyId: string, transformerWithOptions: HistoryTransformerWithOptions, updatedBy: string): void {
+    const wasNew = !transformerWithOptions.id;
+    const before = wasNew ? null : (this.findTransformersForHistory(historyId).find(t => t.id === transformerWithOptions.id) ?? null);
     if (!transformerWithOptions.id) {
       transformerWithOptions.id = generateRandomId(6);
       const query = `INSERT INTO ${HISTORY_TRANSFORMERS_TABLE} (id, history_id, transformer_id, options) VALUES (?, ?, ?, ?);`;
@@ -314,17 +409,40 @@ export default class HistoryQueryRepository {
         .prepare(`INSERT INTO ${HISTORY_QUERY_TRANSFORMERS_ITEMS_TABLE} (id, item_id) VALUES (?, ?);`)
         .run(transformerWithOptions.id, item.id);
     }
+
+    const after = this.findTransformersForHistory(historyId).find(t => t.id === transformerWithOptions.id) ?? null;
+    this.auditService.record(
+      'history_query_transformer',
+      transformerWithOptions.id,
+      wasNew ? 'CREATE' : 'UPDATE',
+      before as unknown as Record<string, unknown> | null,
+      after as unknown as Record<string, unknown> | null,
+      updatedBy
+    );
   }
 
-  removeTransformer(id: string): void {
+  removeTransformer(id: string, deletedBy: string): void {
+    const historyId = this.database.prepare(`SELECT history_id FROM ${HISTORY_TRANSFORMERS_TABLE} WHERE id = ?;`).get(id) as
+      | { history_id: string }
+      | undefined;
+    const before = historyId ? (this.findTransformersForHistory(historyId.history_id).find(t => t.id === id) ?? null) : null;
     const transaction = this.database.transaction(() => {
       this.database.prepare(`DELETE FROM ${HISTORY_QUERY_TRANSFORMERS_ITEMS_TABLE} WHERE id = ?;`).run(id);
       this.database.prepare(`DELETE FROM ${HISTORY_TRANSFORMERS_TABLE} WHERE id = ?;`).run(id);
+      if (before) {
+        this.auditService.record('history_query_transformer', id, 'DELETE', before as unknown as Record<string, unknown>, null, deletedBy);
+      }
     });
     transaction();
   }
 
-  removeTransformersByTransformerId(transformerId: string): void {
+  removeTransformersByTransformerId(transformerId: string, deletedBy: string): void {
+    const affected = this.database
+      .prepare(`SELECT id, history_id FROM ${HISTORY_TRANSFORMERS_TABLE} WHERE transformer_id = ?;`)
+      .all(transformerId) as Array<{ id: string; history_id: string }>;
+    const beforeById = new Map(
+      affected.map(row => [row.id, this.findTransformersForHistory(row.history_id).find(t => t.id === row.id) ?? null])
+    );
     const transaction = this.database.transaction(() => {
       this.database
         .prepare(
@@ -332,6 +450,19 @@ export default class HistoryQueryRepository {
         )
         .run(transformerId);
       this.database.prepare(`DELETE FROM ${HISTORY_TRANSFORMERS_TABLE} WHERE transformer_id = ?;`).run(transformerId);
+      for (const row of affected) {
+        const before = beforeById.get(row.id);
+        if (before) {
+          this.auditService.record(
+            'history_query_transformer',
+            row.id,
+            'DELETE',
+            before as unknown as Record<string, unknown>,
+            null,
+            deletedBy
+          );
+        }
+      }
     });
     transaction();
   }
@@ -405,6 +536,8 @@ export default class HistoryQueryRepository {
   }
 
   saveItem<I extends SouthItemSettings>(historyId: string, item: HistoryQueryItemEntity<I>): void {
+    const wasNew = !item.id;
+    const before = wasNew ? null : this.findItemById(historyId, item.id);
     if (!item.id) {
       item.id = generateRandomId(6);
       const insertQuery =
@@ -417,12 +550,27 @@ export default class HistoryQueryRepository {
       const query = `UPDATE ${HISTORY_ITEMS_TABLE} SET name = ?, enabled = ?, settings = ?, updated_by = ?, updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now') WHERE id = ?;`;
       this.database.prepare(query).run(item.name, +item.enabled, JSON.stringify(item.settings), item.updatedBy, item.id);
     }
+
+    const after = this.findItemById(historyId, item.id);
+    this.auditService.record(
+      'history_query_item',
+      item.id,
+      wasNew ? 'CREATE' : 'UPDATE',
+      before as unknown as Record<string, unknown> | null,
+      after as unknown as Record<string, unknown>,
+      item.updatedBy
+    );
   }
 
-  saveAllItems(historyId: string, items: Array<HistoryQueryItemEntity<SouthItemSettings>>, deleteItemsNotPresent: boolean): void {
+  saveAllItems(
+    historyId: string,
+    items: Array<HistoryQueryItemEntity<SouthItemSettings>>,
+    deleteItemsNotPresent: boolean,
+    deletedBy: string
+  ): void {
     const transaction = this.database.transaction(() => {
       if (deleteItemsNotPresent) {
-        this.deleteAllItemsByHistory(historyId);
+        this.deleteAllItemsByHistory(historyId, deletedBy);
       }
       for (const item of items) {
         this.saveItem(historyId, item);
@@ -431,7 +579,8 @@ export default class HistoryQueryRepository {
     transaction();
   }
 
-  deleteItem(historyId: string, itemId: string): void {
+  deleteItem(historyId: string, itemId: string, deletedBy: string): void {
+    const before = this.findItemById(historyId, itemId);
     const transaction = this.database.transaction(() => {
       this.database
         .prepare(
@@ -442,11 +591,15 @@ export default class HistoryQueryRepository {
         )
         .run(historyId, itemId);
       this.database.prepare(`DELETE FROM ${HISTORY_ITEMS_TABLE} WHERE history_id = ? AND id = ?;`).run(historyId, itemId);
+      if (before) {
+        this.auditService.record('history_query_item', itemId, 'DELETE', before as unknown as Record<string, unknown>, null, deletedBy);
+      }
     });
     transaction();
   }
 
-  deleteAllItemsByHistory(historyId: string): void {
+  deleteAllItemsByHistory(historyId: string, deletedBy: string): void {
+    const beforeItems = this.findAllItemsForHistory(historyId);
     const transaction = this.database.transaction(() => {
       this.database
         .prepare(
@@ -457,6 +610,9 @@ export default class HistoryQueryRepository {
         )
         .run(historyId);
       this.database.prepare(`DELETE FROM ${HISTORY_ITEMS_TABLE} WHERE history_id = ?;`).run(historyId);
+      for (const item of beforeItems) {
+        this.auditService.record('history_query_item', item.id, 'DELETE', item as unknown as Record<string, unknown>, null, deletedBy);
+      }
     });
     transaction();
   }

--- a/backend/src/repository/config/ip-filter.repository.spec.ts
+++ b/backend/src/repository/config/ip-filter.repository.spec.ts
@@ -1,9 +1,11 @@
 import { before, after, beforeEach, describe, it } from 'node:test';
 import assert from 'node:assert/strict';
+import { mock } from 'node:test';
 import { Database } from 'better-sqlite3';
-import { emptyDatabase, initDatabase, stripAuditFields } from '../../tests/utils/test-utils';
+import { createAuditServiceMock, emptyDatabase, initDatabase, stripAuditFields } from '../../tests/utils/test-utils';
 import testData from '../../tests/utils/test-data';
 import IpFilterRepository from './ip-filter.repository';
+import AuditService from '../../service/audit.service';
 
 const TEST_DB_PATH = 'src/tests/test-config-ip-filter.db';
 
@@ -19,10 +21,12 @@ describe('IpFilterRepository', () => {
   });
 
   let repository: IpFilterRepository;
+  let auditService: AuditService;
   let createdId: string;
 
   beforeEach(() => {
-    repository = new IpFilterRepository(database);
+    auditService = createAuditServiceMock();
+    repository = new IpFilterRepository(database, auditService);
   });
 
   it('findAll() should properly get all IP filters', () => {
@@ -50,18 +54,32 @@ describe('IpFilterRepository', () => {
     assert.strictEqual(created.updatedBy, 'userTest');
     assert.strictEqual(created.address, testData.ipFilters.command.address);
     assert.strictEqual(created.description, testData.ipFilters.command.description);
+
+    const recordMock = auditService.record as unknown as ReturnType<typeof mock.fn>;
+    assert.strictEqual(recordMock.mock.calls.length, 1);
+    assert.deepStrictEqual(recordMock.mock.calls[0].arguments, ['ip_filter', created.id, 'CREATE', null, created, 'userTest']);
   });
 
   it('update() should update an IP filter', () => {
+    const before = repository.findById(createdId);
     repository.update(createdId, testData.ipFilters.command, 'userTest');
     const result = repository.findById(createdId)!;
     assert.strictEqual(result.address, testData.ipFilters.command.address);
     assert.strictEqual(result.updatedBy, 'userTest');
+
+    const recordMock = auditService.record as unknown as ReturnType<typeof mock.fn>;
+    assert.strictEqual(recordMock.mock.calls.length, 1);
+    assert.deepStrictEqual(recordMock.mock.calls[0].arguments, ['ip_filter', createdId, 'UPDATE', before, result, 'userTest']);
   });
 
   it('delete() should delete an IP filter', () => {
-    assert.notStrictEqual(repository.findById(createdId), null);
-    repository.delete(createdId);
+    const before = repository.findById(createdId);
+    assert.notStrictEqual(before, null);
+    repository.delete(createdId, 'userTest');
     assert.strictEqual(repository.findById(createdId), null);
+
+    const recordMock = auditService.record as unknown as ReturnType<typeof mock.fn>;
+    assert.strictEqual(recordMock.mock.calls.length, 1);
+    assert.deepStrictEqual(recordMock.mock.calls[0].arguments, ['ip_filter', createdId, 'DELETE', before, null, 'userTest']);
   });
 });

--- a/backend/src/repository/config/ip-filter.repository.ts
+++ b/backend/src/repository/config/ip-filter.repository.ts
@@ -1,6 +1,7 @@
 import { generateRandomId } from '../../service/utils';
 import { Database } from 'better-sqlite3';
 import { IPFilter } from '../../model/ip-filter.model';
+import AuditService from '../../service/audit.service';
 
 const IP_FILTERS_TABLE = 'ip_filters';
 
@@ -8,7 +9,10 @@ const IP_FILTERS_TABLE = 'ip_filters';
  * Repository used for ip filters (allow connection to OIBus from these IP addresses)
  */
 export default class IpFilterRepository {
-  constructor(private readonly database: Database) {}
+  constructor(
+    private readonly database: Database,
+    private readonly auditService: AuditService
+  ) {}
 
   list(): Array<IPFilter> {
     const query = `SELECT id, address, description, created_by, updated_by, created_at, updated_at FROM ${IP_FILTERS_TABLE};`;
@@ -32,17 +36,33 @@ export default class IpFilterRepository {
     const insertQuery = `INSERT INTO ${IP_FILTERS_TABLE} (id, address, description, created_by, updated_by, created_at, updated_at) VALUES (?, ?, ?, ?, ?, strftime('%Y-%m-%dT%H:%M:%SZ', 'now'), strftime('%Y-%m-%dT%H:%M:%SZ', 'now'));`;
     const result = this.database.prepare(insertQuery).run(id, command.address, command.description, createdBy, createdBy);
     const query = `SELECT id, address, description, created_by, updated_by, created_at, updated_at FROM ${IP_FILTERS_TABLE} WHERE ROWID = ?;`;
-    return this.toIPFilter(this.database.prepare(query).get(result.lastInsertRowid) as Record<string, string>);
+    const created = this.toIPFilter(this.database.prepare(query).get(result.lastInsertRowid) as Record<string, string>);
+    this.auditService.record('ip_filter', created.id, 'CREATE', null, created as unknown as Record<string, unknown>, createdBy);
+    return created;
   }
 
   update(id: string, command: Omit<IPFilter, 'id' | 'createdBy' | 'updatedBy' | 'createdAt' | 'updatedAt'>, updatedBy: string): void {
+    const before = this.findById(id);
     const query = `UPDATE ${IP_FILTERS_TABLE} SET address = ?, description = ?, updated_by = ?, updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now') WHERE id = ?;`;
     this.database.prepare(query).run(command.address, command.description, updatedBy, id);
+    const after = this.findById(id);
+    this.auditService.record(
+      'ip_filter',
+      id,
+      'UPDATE',
+      before as unknown as Record<string, unknown>,
+      after as unknown as Record<string, unknown>,
+      updatedBy
+    );
   }
 
-  delete(id: string): void {
+  delete(id: string, deletedBy: string): void {
+    const before = this.findById(id);
     const query = `DELETE FROM ${IP_FILTERS_TABLE} WHERE id = ?;`;
     this.database.prepare(query).run(id);
+    if (before) {
+      this.auditService.record('ip_filter', id, 'DELETE', before as unknown as Record<string, unknown>, null, deletedBy);
+    }
   }
 
   private toIPFilter(result: Record<string, string>): IPFilter {

--- a/backend/src/repository/config/north-connector.repository.spec.ts
+++ b/backend/src/repository/config/north-connector.repository.spec.ts
@@ -84,9 +84,11 @@ describe('NorthConnectorRepository', () => {
       newNorthConnector.id,
       'CREATE',
       null,
-      createdConnector,
+      { ...createdConnector, settings: { ...createdConnector.settings, password: '' } },
       newNorthConnector.updatedBy
     ]);
+    // The connector's secret settings field must never be persisted in the audit trail
+    assert.strictEqual((connectorCreateCalls[0].arguments[4] as { settings: { password: string } }).settings.password, '');
 
     const newNorthConnectorWithoutTransformer: NorthConnectorEntity<NorthSettings> = JSON.parse(JSON.stringify(testData.north.list[0]));
     newNorthConnectorWithoutTransformer.id = '';
@@ -162,41 +164,45 @@ describe('NorthConnectorRepository', () => {
 
     assert.ok(newNorthConnector.id);
 
-    repository.addOrEditTransformer(newNorthConnector.id, {
-      id: '',
-      transformer: testData.transformers.list[0] as Transformer,
-      options: {},
-      source: {
-        type: 'south',
-        south: {
-          id: testData.south.list[0].id,
-          name: testData.south.list[0].name,
-          type: testData.south.list[0].type,
-          description: testData.south.list[0].description,
-          enabled: testData.south.list[0].enabled,
-          createdBy: '',
-          updatedBy: '',
-          createdAt: '',
-          updatedAt: ''
-        },
-        group: {
-          id: group.id,
-          name: group.name,
-          southId: testData.south.list[0].id,
-          scanMode: testData.scanMode.list[0],
-          startTimeOffset: 0,
-          endTimeOffset: null,
-          maxReadInterval: 3600,
-          readDelay: 200,
-          items: [],
-          createdBy: '',
-          updatedBy: '',
-          createdAt: '',
-          updatedAt: ''
-        },
-        items: []
-      }
-    }, 'userTest');
+    repository.addOrEditTransformer(
+      newNorthConnector.id,
+      {
+        id: '',
+        transformer: testData.transformers.list[0] as Transformer,
+        options: {},
+        source: {
+          type: 'south',
+          south: {
+            id: testData.south.list[0].id,
+            name: testData.south.list[0].name,
+            type: testData.south.list[0].type,
+            description: testData.south.list[0].description,
+            enabled: testData.south.list[0].enabled,
+            createdBy: '',
+            updatedBy: '',
+            createdAt: '',
+            updatedAt: ''
+          },
+          group: {
+            id: group.id,
+            name: group.name,
+            southId: testData.south.list[0].id,
+            scanMode: testData.scanMode.list[0],
+            startTimeOffset: 0,
+            endTimeOffset: null,
+            maxReadInterval: 3600,
+            readDelay: 200,
+            items: [],
+            createdBy: '',
+            updatedBy: '',
+            createdAt: '',
+            updatedAt: ''
+          },
+          items: []
+        }
+      },
+      'userTest'
+    );
 
     const connector = repository.findNorthById(newNorthConnector.id)!;
     assert.strictEqual(connector.transformers.length, 1);
@@ -307,10 +313,12 @@ describe('NorthConnectorRepository', () => {
       'north_connector',
       newNorthConnector.id,
       'DELETE',
-      beforeConnector,
+      { ...beforeConnector, settings: { ...beforeConnector.settings, password: '' } },
       null,
       'deleteUser'
     ]);
+    // The connector's secret settings field must never be persisted in the audit trail
+    assert.strictEqual((connectorDeleteCall!.arguments[3] as { settings: { password: string } }).settings.password, '');
   });
 
   it('should save a north connector with a "temp_" transformer id (treated as new)', () => {
@@ -340,28 +348,32 @@ describe('NorthConnectorRepository', () => {
     newNorthConnector.transformers = [];
     repository.saveNorth(newNorthConnector);
 
-    repository.addOrEditTransformer(newNorthConnector.id, {
-      id: '',
-      transformer: testData.transformers.list[0] as Transformer,
-      options: {},
-      source: {
-        type: 'south',
-        south: {
-          id: testData.south.list[0].id,
-          name: testData.south.list[0].name,
-          type: testData.south.list[0].type,
-          description: testData.south.list[0].description,
-          enabled: testData.south.list[0].enabled,
-          createdBy: '',
-          updatedBy: '',
-          createdAt: '',
-          updatedAt: ''
-        },
-        items: [
-          { id: testData.south.list[0].items[0].id, name: '', enabled: true, createdBy: '', updatedBy: '', createdAt: '', updatedAt: '' }
-        ]
-      }
-    }, 'userTest');
+    repository.addOrEditTransformer(
+      newNorthConnector.id,
+      {
+        id: '',
+        transformer: testData.transformers.list[0] as Transformer,
+        options: {},
+        source: {
+          type: 'south',
+          south: {
+            id: testData.south.list[0].id,
+            name: testData.south.list[0].name,
+            type: testData.south.list[0].type,
+            description: testData.south.list[0].description,
+            enabled: testData.south.list[0].enabled,
+            createdBy: '',
+            updatedBy: '',
+            createdAt: '',
+            updatedAt: ''
+          },
+          items: [
+            { id: testData.south.list[0].items[0].id, name: '', enabled: true, createdBy: '', updatedBy: '', createdAt: '', updatedAt: '' }
+          ]
+        }
+      },
+      'userTest'
+    );
 
     let connector = repository.findNorthById(newNorthConnector.id)!;
     assert.strictEqual(connector.transformers.length, 1);
@@ -369,26 +381,30 @@ describe('NorthConnectorRepository', () => {
     const transformerId = connector.transformers[0].id;
 
     // Update the same transformer, still without a group, to hit the update-path false branch too
-    repository.addOrEditTransformer(newNorthConnector.id, {
-      id: transformerId,
-      transformer: testData.transformers.list[0] as Transformer,
-      options: { updated: true },
-      source: {
-        type: 'south',
-        south: {
-          id: testData.south.list[0].id,
-          name: testData.south.list[0].name,
-          type: testData.south.list[0].type,
-          description: testData.south.list[0].description,
-          enabled: testData.south.list[0].enabled,
-          createdBy: '',
-          updatedBy: '',
-          createdAt: '',
-          updatedAt: ''
-        },
-        items: []
-      }
-    }, 'userTest');
+    repository.addOrEditTransformer(
+      newNorthConnector.id,
+      {
+        id: transformerId,
+        transformer: testData.transformers.list[0] as Transformer,
+        options: { updated: true },
+        source: {
+          type: 'south',
+          south: {
+            id: testData.south.list[0].id,
+            name: testData.south.list[0].name,
+            type: testData.south.list[0].type,
+            description: testData.south.list[0].description,
+            enabled: testData.south.list[0].enabled,
+            createdBy: '',
+            updatedBy: '',
+            createdAt: '',
+            updatedAt: ''
+          },
+          items: []
+        }
+      },
+      'userTest'
+    );
     connector = repository.findNorthById(newNorthConnector.id)!;
     assert.strictEqual(connector.transformers.length, 1);
     assert.deepStrictEqual(connector.transformers[0].options, { updated: true });
@@ -415,64 +431,72 @@ describe('NorthConnectorRepository', () => {
     newNorthConnector.transformers = [];
     repository.saveNorth(newNorthConnector);
 
-    repository.addOrEditTransformer(newNorthConnector.id, {
-      id: '',
-      transformer: testData.transformers.list[0] as Transformer,
-      options: {},
-      source: {
-        type: 'south',
-        south: {
-          id: testData.south.list[0].id,
-          name: testData.south.list[0].name,
-          type: testData.south.list[0].type,
-          description: testData.south.list[0].description,
-          enabled: testData.south.list[0].enabled,
-          createdBy: '',
-          updatedBy: '',
-          createdAt: '',
-          updatedAt: ''
-        },
-        items: []
-      }
-    }, 'userTest');
+    repository.addOrEditTransformer(
+      newNorthConnector.id,
+      {
+        id: '',
+        transformer: testData.transformers.list[0] as Transformer,
+        options: {},
+        source: {
+          type: 'south',
+          south: {
+            id: testData.south.list[0].id,
+            name: testData.south.list[0].name,
+            type: testData.south.list[0].type,
+            description: testData.south.list[0].description,
+            enabled: testData.south.list[0].enabled,
+            createdBy: '',
+            updatedBy: '',
+            createdAt: '',
+            updatedAt: ''
+          },
+          items: []
+        }
+      },
+      'userTest'
+    );
     const connector = repository.findNorthById(newNorthConnector.id)!;
     const transformerId = connector.transformers[0].id;
 
-    repository.addOrEditTransformer(newNorthConnector.id, {
-      id: transformerId,
-      transformer: testData.transformers.list[0] as Transformer,
-      options: {},
-      source: {
-        type: 'south',
-        south: {
-          id: testData.south.list[0].id,
-          name: testData.south.list[0].name,
-          type: testData.south.list[0].type,
-          description: testData.south.list[0].description,
-          enabled: testData.south.list[0].enabled,
-          createdBy: '',
-          updatedBy: '',
-          createdAt: '',
-          updatedAt: ''
-        },
-        group: {
-          id: group.id,
-          name: group.name,
-          southId: testData.south.list[0].id,
-          scanMode: testData.scanMode.list[0],
-          startTimeOffset: 0,
-          endTimeOffset: null,
-          maxReadInterval: 3600,
-          readDelay: 200,
-          items: [],
-          createdBy: '',
-          updatedBy: '',
-          createdAt: '',
-          updatedAt: ''
-        },
-        items: []
-      }
-    }, 'userTest');
+    repository.addOrEditTransformer(
+      newNorthConnector.id,
+      {
+        id: transformerId,
+        transformer: testData.transformers.list[0] as Transformer,
+        options: {},
+        source: {
+          type: 'south',
+          south: {
+            id: testData.south.list[0].id,
+            name: testData.south.list[0].name,
+            type: testData.south.list[0].type,
+            description: testData.south.list[0].description,
+            enabled: testData.south.list[0].enabled,
+            createdBy: '',
+            updatedBy: '',
+            createdAt: '',
+            updatedAt: ''
+          },
+          group: {
+            id: group.id,
+            name: group.name,
+            southId: testData.south.list[0].id,
+            scanMode: testData.scanMode.list[0],
+            startTimeOffset: 0,
+            endTimeOffset: null,
+            maxReadInterval: 3600,
+            readDelay: 200,
+            items: [],
+            createdBy: '',
+            updatedBy: '',
+            createdAt: '',
+            updatedAt: ''
+          },
+          items: []
+        }
+      },
+      'userTest'
+    );
     const updatedConnector = repository.findNorthById(newNorthConnector.id)!;
     assert.strictEqual((updatedConnector.transformers[0].source as SourceOriginSouth).group?.id, group.id);
   });

--- a/backend/src/repository/config/north-connector.repository.spec.ts
+++ b/backend/src/repository/config/north-connector.repository.spec.ts
@@ -1,7 +1,7 @@
-import { before, after, beforeEach, describe, it } from 'node:test';
+import { before, after, beforeEach, describe, it, mock } from 'node:test';
 import assert from 'node:assert/strict';
 import { Database } from 'better-sqlite3';
-import { emptyDatabase, initDatabase, stripAuditFields } from '../../tests/utils/test-utils';
+import { createAuditServiceMock, emptyDatabase, initDatabase, stripAuditFields } from '../../tests/utils/test-utils';
 import testData from '../../tests/utils/test-data';
 import NorthConnectorRepository from './north-connector.repository';
 import SouthItemGroupRepository from './south-item-group.repository';
@@ -9,6 +9,7 @@ import { NorthConnectorEntity } from '../../model/north-connector.model';
 import { NorthSettings } from '../../../shared/model/north-settings.model';
 import { SourceOriginSouth, Transformer } from '../../model/transformer.model';
 import TransformerRepository from './transformer.repository';
+import AuditService from '../../service/audit.service';
 
 const TEST_DB_PATH = 'src/tests/test-config-north.db';
 
@@ -24,10 +25,12 @@ describe('NorthConnectorRepository', () => {
   });
 
   let repository: NorthConnectorRepository;
+  let auditService: AuditService;
 
   beforeEach(() => {
-    new TransformerRepository(database); // ensure standard transformers are seeded
-    repository = new NorthConnectorRepository(database);
+    new TransformerRepository(database, createAuditServiceMock()); // ensure standard transformers are seeded
+    auditService = createAuditServiceMock();
+    repository = new NorthConnectorRepository(database, auditService);
   });
 
   it('should properly get north connectors', () => {
@@ -71,6 +74,20 @@ describe('NorthConnectorRepository', () => {
     assert.strictEqual(createdConnector.id, newNorthConnector.id);
     assert.strictEqual(createdConnector.name, 'new connector');
 
+    const recordMock = auditService.record as unknown as ReturnType<typeof mock.fn>;
+    const connectorCreateCalls = recordMock.mock.calls.filter(
+      call => call.arguments[0] === 'north_connector' && call.arguments[1] === newNorthConnector.id && call.arguments[2] === 'CREATE'
+    );
+    assert.strictEqual(connectorCreateCalls.length, 1);
+    assert.deepStrictEqual(connectorCreateCalls[0].arguments, [
+      'north_connector',
+      newNorthConnector.id,
+      'CREATE',
+      null,
+      createdConnector,
+      newNorthConnector.updatedBy
+    ]);
+
     const newNorthConnectorWithoutTransformer: NorthConnectorEntity<NorthSettings> = JSON.parse(JSON.stringify(testData.north.list[0]));
     newNorthConnectorWithoutTransformer.id = '';
     newNorthConnectorWithoutTransformer.name = 'new connector without transformer';
@@ -81,24 +98,48 @@ describe('NorthConnectorRepository', () => {
     const createdConnectorWithoutTransformer = repository.findNorthById(newNorthConnectorWithoutTransformer.id)!;
     assert.deepStrictEqual(createdConnectorWithoutTransformer.transformers, []);
 
-    repository.addOrEditTransformer(newNorthConnectorWithoutTransformer.id, {
-      id: '',
-      transformer: testData.transformers.list[0] as Transformer,
-      options: {},
-      source: { type: 'oianalytics-setpoint' }
-    });
+    recordMock.mock.resetCalls();
+    repository.addOrEditTransformer(
+      newNorthConnectorWithoutTransformer.id,
+      {
+        id: '',
+        transformer: testData.transformers.list[0] as Transformer,
+        options: {},
+        source: { type: 'oianalytics-setpoint' }
+      },
+      'transformerUser'
+    );
     const createdConnectorWithTransformer = repository.findNorthById(newNorthConnectorWithoutTransformer.id)!;
     assert.strictEqual(createdConnectorWithTransformer.transformers.length, 1);
     assert.strictEqual(createdConnectorWithTransformer.transformers[0].transformer.id, testData.transformers.list[0].id);
 
     const transformerId = createdConnectorWithTransformer.transformers[0].id;
-    repository.removeTransformer(transformerId);
+    const transformerCreateCalls = recordMock.mock.calls.filter(
+      call => call.arguments[0] === 'north_transformer' && call.arguments[1] === transformerId && call.arguments[2] === 'CREATE'
+    );
+    assert.strictEqual(transformerCreateCalls.length, 1);
+    assert.deepStrictEqual(transformerCreateCalls[0].arguments, [
+      'north_transformer',
+      transformerId,
+      'CREATE',
+      null,
+      createdConnectorWithTransformer.transformers[0],
+      'transformerUser'
+    ]);
+
+    recordMock.mock.resetCalls();
+    repository.removeTransformer(transformerId, 'removeUser');
     const createdConnectorWithRemovedTransformer = repository.findNorthById(newNorthConnectorWithoutTransformer.id)!;
     assert.deepStrictEqual(createdConnectorWithRemovedTransformer.transformers, []);
+    const transformerDeleteCalls = recordMock.mock.calls.filter(
+      call => call.arguments[0] === 'north_transformer' && call.arguments[1] === transformerId && call.arguments[2] === 'DELETE'
+    );
+    assert.strictEqual(transformerDeleteCalls.length, 1);
+    assert.strictEqual(transformerDeleteCalls[0].arguments[5], 'removeUser');
   });
 
   it('should save a north connector transformer with a group', () => {
-    const groupRepository = new SouthItemGroupRepository(database);
+    const groupRepository = new SouthItemGroupRepository(database, createAuditServiceMock());
 
     const group = groupRepository.create(
       {
@@ -155,7 +196,7 @@ describe('NorthConnectorRepository', () => {
         },
         items: []
       }
-    });
+    }, 'userTest');
 
     const connector = repository.findNorthById(newNorthConnector.id)!;
     assert.strictEqual(connector.transformers.length, 1);
@@ -173,27 +214,54 @@ describe('NorthConnectorRepository', () => {
 
     assert.ok(newNorthConnectorWithoutTransformer2.id);
 
-    repository.addOrEditTransformer(newNorthConnectorWithoutTransformer2.id, {
-      id: '',
-      transformer: testData.transformers.list[0] as Transformer,
-      options: {},
-      source: { type: 'oianalytics-setpoint' }
-    });
+    repository.addOrEditTransformer(
+      newNorthConnectorWithoutTransformer2.id,
+      {
+        id: '',
+        transformer: testData.transformers.list[0] as Transformer,
+        options: {},
+        source: { type: 'oianalytics-setpoint' }
+      },
+      'userTest'
+    );
     const connectorWithTransformer = repository.findNorthById(newNorthConnectorWithoutTransformer2.id)!;
     assert.strictEqual(connectorWithTransformer.transformers.length, 1);
+    const transformerId = connectorWithTransformer.transformers[0].id;
 
-    repository.removeTransformersByTransformerId(testData.transformers.list[0].id);
+    const recordMock = auditService.record as unknown as ReturnType<typeof mock.fn>;
+    recordMock.mock.resetCalls();
+    repository.removeTransformersByTransformerId(testData.transformers.list[0].id, 'bulkRemoveUser');
     const connectorWithRemovedTransformers = repository.findNorthById(newNorthConnectorWithoutTransformer2.id)!;
     assert.deepStrictEqual(connectorWithRemovedTransformers.transformers, []);
+    const transformerDeleteCalls = recordMock.mock.calls.filter(
+      call => call.arguments[0] === 'north_transformer' && call.arguments[1] === transformerId && call.arguments[2] === 'DELETE'
+    );
+    assert.strictEqual(transformerDeleteCalls.length, 1);
+    assert.strictEqual(transformerDeleteCalls[0].arguments[5], 'bulkRemoveUser');
   });
 
   it('should update a north connector', () => {
     const newNorthConnector: NorthConnectorEntity<NorthSettings> = JSON.parse(JSON.stringify(testData.north.list[1]));
     newNorthConnector.caching.throttling.maxSize = 999;
+    const beforeConnector = repository.findNorthById(newNorthConnector.id);
     repository.saveNorth(newNorthConnector);
 
     const updatedConnector = repository.findNorthById(newNorthConnector.id)!;
     assert.strictEqual(updatedConnector.caching.throttling.maxSize, 999);
+
+    const recordMock = auditService.record as unknown as ReturnType<typeof mock.fn>;
+    const connectorUpdateCalls = recordMock.mock.calls.filter(
+      call => call.arguments[0] === 'north_connector' && call.arguments[1] === newNorthConnector.id && call.arguments[2] === 'UPDATE'
+    );
+    assert.strictEqual(connectorUpdateCalls.length, 1);
+    assert.deepStrictEqual(connectorUpdateCalls[0].arguments, [
+      'north_connector',
+      newNorthConnector.id,
+      'UPDATE',
+      beforeConnector,
+      updatedConnector,
+      newNorthConnector.updatedBy
+    ]);
   });
 
   it('should delete a north connector', () => {
@@ -203,9 +271,46 @@ describe('NorthConnectorRepository', () => {
     newNorthConnector.transformers = [];
     repository.saveNorth(newNorthConnector);
 
-    assert.ok(repository.findNorthById(newNorthConnector.id));
-    repository.deleteNorth(newNorthConnector.id);
+    repository.addOrEditTransformer(
+      newNorthConnector.id,
+      {
+        id: '',
+        transformer: testData.transformers.list[0] as Transformer,
+        options: {},
+        source: { type: 'oianalytics-setpoint' }
+      },
+      'attachUser'
+    );
+
+    const beforeConnector = repository.findNorthById(newNorthConnector.id)!;
+    assert.ok(beforeConnector);
+    const transformerIds = beforeConnector.transformers.map(t => t.id);
+    assert.ok(transformerIds.length > 0);
+
+    const recordMock = auditService.record as unknown as ReturnType<typeof mock.fn>;
+    recordMock.mock.resetCalls();
+    repository.deleteNorth(newNorthConnector.id, 'deleteUser');
     assert.strictEqual(repository.findNorthById(newNorthConnector.id), null);
+
+    const transformerDeleteCalls = recordMock.mock.calls.filter(
+      call => call.arguments[0] === 'north_transformer' && call.arguments[2] === 'DELETE'
+    );
+    assert.strictEqual(transformerDeleteCalls.length, transformerIds.length);
+    for (const call of transformerDeleteCalls) {
+      assert.strictEqual(call.arguments[5], 'deleteUser');
+    }
+
+    const connectorDeleteCall = recordMock.mock.calls.find(
+      call => call.arguments[0] === 'north_connector' && call.arguments[1] === newNorthConnector.id && call.arguments[2] === 'DELETE'
+    );
+    assert.deepStrictEqual(connectorDeleteCall!.arguments, [
+      'north_connector',
+      newNorthConnector.id,
+      'DELETE',
+      beforeConnector,
+      null,
+      'deleteUser'
+    ]);
   });
 
   it('should save a north connector with a "temp_" transformer id (treated as new)', () => {
@@ -256,7 +361,7 @@ describe('NorthConnectorRepository', () => {
           { id: testData.south.list[0].items[0].id, name: '', enabled: true, createdBy: '', updatedBy: '', createdAt: '', updatedAt: '' }
         ]
       }
-    });
+    }, 'userTest');
 
     let connector = repository.findNorthById(newNorthConnector.id)!;
     assert.strictEqual(connector.transformers.length, 1);
@@ -283,14 +388,14 @@ describe('NorthConnectorRepository', () => {
         },
         items: []
       }
-    });
+    }, 'userTest');
     connector = repository.findNorthById(newNorthConnector.id)!;
     assert.strictEqual(connector.transformers.length, 1);
     assert.deepStrictEqual(connector.transformers[0].options, { updated: true });
   });
 
   it('should update a south transformer to have a group', () => {
-    const groupRepository = new SouthItemGroupRepository(database);
+    const groupRepository = new SouthItemGroupRepository(database, createAuditServiceMock());
     const group = groupRepository.create(
       {
         name: 'Update Transformer Group',
@@ -329,7 +434,7 @@ describe('NorthConnectorRepository', () => {
         },
         items: []
       }
-    });
+    }, 'userTest');
     const connector = repository.findNorthById(newNorthConnector.id)!;
     const transformerId = connector.transformers[0].id;
 
@@ -367,7 +472,7 @@ describe('NorthConnectorRepository', () => {
         },
         items: []
       }
-    });
+    }, 'userTest');
     const updatedConnector = repository.findNorthById(newNorthConnector.id)!;
     assert.strictEqual((updatedConnector.transformers[0].source as SourceOriginSouth).group?.id, group.id);
   });

--- a/backend/src/repository/config/north-connector.repository.ts
+++ b/backend/src/repository/config/north-connector.repository.ts
@@ -11,6 +11,8 @@ import { scanModeAliasedColumns, scanModeColumns, toScanMode } from './scan-mode
 import { OIBusSouthType } from '../../../shared/model/south-connector.model';
 import { toSouthItemGroup } from './south-item-group.repository';
 import AuditService from '../../service/audit.service';
+import { encryptionService } from '../../service/encryption.service';
+import { northManifestList } from '../../service/north-manifests';
 
 const NORTH_CONNECTORS_TABLE = 'north_connectors';
 const SOUTH_CONNECTORS_TABLE = 'south_connectors';
@@ -131,9 +133,7 @@ export default class NorthConnectorRepository {
       }
 
       const keepIds = north.transformers.filter(t => t.id).map(t => t.id);
-      const removedTransformerIds = (beforeConnector?.transformers ?? [])
-        .filter(t => !keepIds.includes(t.id))
-        .map(t => t.id);
+      const removedTransformerIds = (beforeConnector?.transformers ?? []).filter(t => !keepIds.includes(t.id)).map(t => t.id);
       for (const removedId of removedTransformerIds) {
         this.auditService.record(
           'north_transformer',
@@ -186,8 +186,8 @@ export default class NorthConnectorRepository {
         'north_connector',
         north.id,
         isNewConnector ? 'CREATE' : 'UPDATE',
-        beforeConnector as unknown as Record<string, unknown> | null,
-        afterConnector as unknown as Record<string, unknown>,
+        this.redactConnector(beforeConnector),
+        this.redactConnector(afterConnector),
         north.updatedBy
       );
     });
@@ -234,16 +234,28 @@ export default class NorthConnectorRepository {
             deletedBy
           );
         }
-        this.auditService.record('north_connector', id, 'DELETE', before as unknown as Record<string, unknown>, null, deletedBy);
+        this.auditService.record('north_connector', id, 'DELETE', this.redactConnector(before), null, deletedBy);
       }
     });
 
     transaction();
   }
 
+  /**
+   * Returns a shallow copy of the north connector with its settings' secret fields redacted, using the
+   * same manifest-driven filtering applied before exposing the connector to the frontend (see
+   * toNorthConnectorDTO in north.service.ts), so real secrets never end up persisted in the audit trail.
+   */
+  private redactConnector(entity: NorthConnectorEntity<NorthSettings> | null): Record<string, unknown> | null {
+    if (!entity) return null;
+    const manifest = northManifestList.find(element => element.id === entity.type);
+    if (!manifest) return entity as unknown as Record<string, unknown>;
+    return { ...entity, settings: encryptionService.filterSecrets(entity.settings, manifest.settings) };
+  }
+
   addOrEditTransformer(northId: string, transformerWithOptions: NorthTransformerWithOptions, updatedBy: string): void {
     const wasNew = !transformerWithOptions.id;
-    const before = wasNew ? null : this.findTransformersForNorth(northId).find(t => t.id === transformerWithOptions.id) ?? null;
+    const before = wasNew ? null : (this.findTransformersForNorth(northId).find(t => t.id === transformerWithOptions.id) ?? null);
     if (!transformerWithOptions.id) {
       transformerWithOptions.id = generateRandomId(6);
       const query = `INSERT INTO ${NORTH_TRANSFORMERS_TABLE} (id, north_id, transformer_id, options, source_type, source_api_data_source_id, source_south_south_id, source_south_group_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?);`;
@@ -305,8 +317,7 @@ export default class NorthConnectorRepository {
 
   removeTransformer(id: string, deletedBy: string): void {
     const northId = this.database.prepare(`SELECT north_id FROM ${NORTH_TRANSFORMERS_TABLE} WHERE id = ?;`).get(id) as
-      | { north_id: string }
-      | undefined;
+      { north_id: string } | undefined;
     const before = northId ? (this.findTransformersForNorth(northId.north_id).find(t => t.id === id) ?? null) : null;
     const transaction = this.database.transaction(() => {
       this.database.prepare(`DELETE FROM ${NORTH_TRANSFORMERS_ITEMS_TABLE} WHERE id = ?;`).run(id);

--- a/backend/src/repository/config/north-connector.repository.ts
+++ b/backend/src/repository/config/north-connector.repository.ts
@@ -10,6 +10,7 @@ import { ScanMode } from '../../model/scan-mode.model';
 import { scanModeAliasedColumns, scanModeColumns, toScanMode } from './scan-mode.repository';
 import { OIBusSouthType } from '../../../shared/model/south-connector.model';
 import { toSouthItemGroup } from './south-item-group.repository';
+import AuditService from '../../service/audit.service';
 
 const NORTH_CONNECTORS_TABLE = 'north_connectors';
 const SOUTH_CONNECTORS_TABLE = 'south_connectors';
@@ -22,7 +23,10 @@ const GROUP_ITEMS_TABLE = 'group_items';
 const SCAN_MODE_TABLE = 'scan_modes';
 
 export default class NorthConnectorRepository {
-  constructor(private readonly database: Database) {}
+  constructor(
+    private readonly database: Database,
+    private readonly auditService: AuditService
+  ) {}
 
   findAllNorth(): Array<NorthConnectorEntityLight> {
     const query = `SELECT id, name, type, description, enabled, created_by, updated_by, created_at, updated_at FROM ${NORTH_CONNECTORS_TABLE};`;
@@ -60,6 +64,8 @@ export default class NorthConnectorRepository {
   }
 
   saveNorth(north: NorthConnectorEntity<NorthSettings>): void {
+    const isNewConnector = !north.id;
+    const beforeConnector = north.id ? this.findNorthById(north.id) : null;
     const transaction = this.database.transaction(() => {
       if (!north.id) {
         north.id = generateRandomId(6);
@@ -125,6 +131,20 @@ export default class NorthConnectorRepository {
       }
 
       const keepIds = north.transformers.filter(t => t.id).map(t => t.id);
+      const removedTransformerIds = (beforeConnector?.transformers ?? [])
+        .filter(t => !keepIds.includes(t.id))
+        .map(t => t.id);
+      for (const removedId of removedTransformerIds) {
+        this.auditService.record(
+          'north_transformer',
+          removedId,
+          'DELETE',
+          beforeConnector!.transformers.find(t => t.id === removedId) as unknown as Record<string, unknown>,
+          null,
+          north.updatedBy
+        );
+      }
+
       if (keepIds.length === 0) {
         this.database
           .prepare(
@@ -158,8 +178,18 @@ export default class NorthConnectorRepository {
         if (transformerWithOptions.id.startsWith('temp_')) {
           transformerWithOptions.id = '';
         }
-        this.addOrEditTransformer(north.id, transformerWithOptions);
+        this.addOrEditTransformer(north.id, transformerWithOptions, north.updatedBy);
       }
+
+      const afterConnector = this.findNorthById(north.id);
+      this.auditService.record(
+        'north_connector',
+        north.id,
+        isNewConnector ? 'CREATE' : 'UPDATE',
+        beforeConnector as unknown as Record<string, unknown> | null,
+        afterConnector as unknown as Record<string, unknown>,
+        north.updatedBy
+      );
     });
     transaction();
   }
@@ -174,7 +204,8 @@ export default class NorthConnectorRepository {
     this.database.prepare(query).run(0, id);
   }
 
-  deleteNorth(id: string): void {
+  deleteNorth(id: string, deletedBy: string): void {
+    const before = this.findNorthById(id);
     const transaction = this.database.transaction(() => {
       // 1. Delete items
       this.database
@@ -191,12 +222,28 @@ export default class NorthConnectorRepository {
 
       // 3. Delete the connector itself
       this.database.prepare(`DELETE FROM ${NORTH_CONNECTORS_TABLE} WHERE id = ?;`).run(id);
+
+      if (before) {
+        for (const transformer of before.transformers) {
+          this.auditService.record(
+            'north_transformer',
+            transformer.id,
+            'DELETE',
+            transformer as unknown as Record<string, unknown>,
+            null,
+            deletedBy
+          );
+        }
+        this.auditService.record('north_connector', id, 'DELETE', before as unknown as Record<string, unknown>, null, deletedBy);
+      }
     });
 
     transaction();
   }
 
-  addOrEditTransformer(northId: string, transformerWithOptions: NorthTransformerWithOptions): void {
+  addOrEditTransformer(northId: string, transformerWithOptions: NorthTransformerWithOptions, updatedBy: string): void {
+    const wasNew = !transformerWithOptions.id;
+    const before = wasNew ? null : this.findTransformersForNorth(northId).find(t => t.id === transformerWithOptions.id) ?? null;
     if (!transformerWithOptions.id) {
       transformerWithOptions.id = generateRandomId(6);
       const query = `INSERT INTO ${NORTH_TRANSFORMERS_TABLE} (id, north_id, transformer_id, options, source_type, source_api_data_source_id, source_south_south_id, source_south_group_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?);`;
@@ -244,17 +291,40 @@ export default class NorthConnectorRepository {
         }
       }
     }
+
+    const after = this.findTransformersForNorth(northId).find(t => t.id === transformerWithOptions.id) ?? null;
+    this.auditService.record(
+      'north_transformer',
+      transformerWithOptions.id,
+      wasNew ? 'CREATE' : 'UPDATE',
+      before as unknown as Record<string, unknown> | null,
+      after as unknown as Record<string, unknown> | null,
+      updatedBy
+    );
   }
 
-  removeTransformer(id: string): void {
+  removeTransformer(id: string, deletedBy: string): void {
+    const northId = this.database.prepare(`SELECT north_id FROM ${NORTH_TRANSFORMERS_TABLE} WHERE id = ?;`).get(id) as
+      | { north_id: string }
+      | undefined;
+    const before = northId ? (this.findTransformersForNorth(northId.north_id).find(t => t.id === id) ?? null) : null;
     const transaction = this.database.transaction(() => {
       this.database.prepare(`DELETE FROM ${NORTH_TRANSFORMERS_ITEMS_TABLE} WHERE id = ?;`).run(id);
       this.database.prepare(`DELETE FROM ${NORTH_TRANSFORMERS_TABLE} WHERE id = ?;`).run(id);
+      if (before) {
+        this.auditService.record('north_transformer', id, 'DELETE', before as unknown as Record<string, unknown>, null, deletedBy);
+      }
     });
     transaction();
   }
 
-  removeTransformersByTransformerId(transformerId: string): void {
+  removeTransformersByTransformerId(transformerId: string, deletedBy: string): void {
+    const affected = this.database
+      .prepare(`SELECT id, north_id FROM ${NORTH_TRANSFORMERS_TABLE} WHERE transformer_id = ?;`)
+      .all(transformerId) as Array<{ id: string; north_id: string }>;
+    const beforeById = new Map(
+      affected.map(row => [row.id, this.findTransformersForNorth(row.north_id).find(t => t.id === row.id) ?? null])
+    );
     const transaction = this.database.transaction(() => {
       this.database
         .prepare(
@@ -262,6 +332,12 @@ export default class NorthConnectorRepository {
         )
         .run(transformerId);
       this.database.prepare(`DELETE FROM ${NORTH_TRANSFORMERS_TABLE} WHERE transformer_id = ?;`).run(transformerId);
+      for (const row of affected) {
+        const before = beforeById.get(row.id);
+        if (before) {
+          this.auditService.record('north_transformer', row.id, 'DELETE', before as unknown as Record<string, unknown>, null, deletedBy);
+        }
+      }
     });
     transaction();
   }

--- a/backend/src/repository/config/oianalytics-registration.repository.spec.ts
+++ b/backend/src/repository/config/oianalytics-registration.repository.spec.ts
@@ -1,10 +1,11 @@
-import { before, after, beforeEach, describe, it } from 'node:test';
+import { before, after, beforeEach, describe, it, mock } from 'node:test';
 import assert from 'node:assert/strict';
 import { Database } from 'better-sqlite3';
-import { emptyDatabase, initDatabase, stripAuditFields } from '../../tests/utils/test-utils';
+import { createAuditServiceMock, emptyDatabase, initDatabase, stripAuditFields } from '../../tests/utils/test-utils';
 import testData from '../../tests/utils/test-data';
 import OianalyticsRegistrationRepository from './oianalytics-registration.repository';
 import { OIAnalyticsRegistration } from '../../model/oianalytics-registration.model';
+import AuditService from '../../service/audit.service';
 
 const TEST_DB_PATH = 'src/tests/test-config-registration.db';
 
@@ -20,9 +21,11 @@ describe('OianalyticsRegistrationRepository with populated database', () => {
   });
 
   let repository: OianalyticsRegistrationRepository;
+  let auditService: AuditService;
 
   beforeEach(() => {
-    repository = new OianalyticsRegistrationRepository(database);
+    auditService = createAuditServiceMock();
+    repository = new OianalyticsRegistrationRepository(database, auditService);
   });
 
   it('should properly get the registration settings', () => {
@@ -94,14 +97,52 @@ describe('OianalyticsRegistrationRepository with populated database', () => {
     assert.strictEqual(result.proxyUrl, specificCommand.proxyUrl);
     assert.strictEqual(result.proxyUsername, specificCommand.proxyUsername);
     assert.strictEqual(result.proxyPassword, specificCommand.proxyPassword);
+
+    const recordMock = auditService.record as unknown as ReturnType<typeof mock.fn>;
+    assert.strictEqual(recordMock.mock.calls.length, 1);
+    const [entityType, entityId, action, previousState, newState, userId] = recordMock.mock.calls[0].arguments as [
+      string,
+      string,
+      string,
+      Record<string, unknown>,
+      Record<string, unknown>,
+      string
+    ];
+    assert.strictEqual(entityType, 'oianalytics_registration');
+    assert.strictEqual(entityId, result.id);
+    assert.strictEqual(action, 'UPDATE');
+    assert.strictEqual(userId, testData.users.list[0].id);
+    assert.strictEqual(previousState.publicCipherKey, '[REDACTED]');
+    assert.strictEqual(previousState.privateCipherKey, '[REDACTED]');
+    assert.strictEqual(newState.publicCipherKey, '[REDACTED]');
+    assert.strictEqual(newState.privateCipherKey, '[REDACTED]');
   });
 
   it('should update keys', () => {
-    repository.updateKeys('private key', 'public key');
+    repository.updateKeys('private key', 'public key', testData.users.list[0].id);
 
     const result = repository.get()!;
     assert.strictEqual(result.privateCipherKey, 'private key');
     assert.strictEqual(result.publicCipherKey, 'public key');
+
+    const recordMock = auditService.record as unknown as ReturnType<typeof mock.fn>;
+    assert.strictEqual(recordMock.mock.calls.length, 1);
+    const [entityType, entityId, action, previousState, newState, userId] = recordMock.mock.calls[0].arguments as [
+      string,
+      string,
+      string,
+      Record<string, unknown>,
+      Record<string, unknown>,
+      string
+    ];
+    assert.strictEqual(entityType, 'oianalytics_registration');
+    assert.strictEqual(entityId, result.id);
+    assert.strictEqual(action, 'UPDATE');
+    assert.strictEqual(userId, testData.users.list[0].id);
+    assert.strictEqual(previousState.publicCipherKey, '[REDACTED]');
+    assert.strictEqual(previousState.privateCipherKey, '[REDACTED]');
+    assert.strictEqual(newState.publicCipherKey, '[REDACTED]');
+    assert.strictEqual(newState.privateCipherKey, '[REDACTED]');
   });
 });
 
@@ -116,7 +157,7 @@ describe('OianalyticsRegistrationRepository with empty database', () => {
   });
 
   it('should properly init registration settings table', () => {
-    const repository = new OianalyticsRegistrationRepository(database);
+    const repository = new OianalyticsRegistrationRepository(database, createAuditServiceMock());
     const result = stripAuditFields(repository.get());
 
     assert.ok(result);

--- a/backend/src/repository/config/oianalytics-registration.repository.spec.ts
+++ b/backend/src/repository/config/oianalytics-registration.repository.spec.ts
@@ -116,6 +116,18 @@ describe('OianalyticsRegistrationRepository with populated database', () => {
     assert.strictEqual(previousState.privateCipherKey, '[REDACTED]');
     assert.strictEqual(newState.publicCipherKey, '[REDACTED]');
     assert.strictEqual(newState.privateCipherKey, '[REDACTED]');
+    // The token, proxy password and api gateway header value must never be persisted in the audit trail
+    assert.strictEqual(previousState.token, '[REDACTED]');
+    assert.strictEqual(previousState.proxyPassword, '[REDACTED]');
+    assert.strictEqual(previousState.apiGatewayHeaderValue, '[REDACTED]');
+    assert.strictEqual(newState.token, '[REDACTED]');
+    assert.notStrictEqual(newState.proxyPassword, specificCommand.proxyPassword);
+    assert.strictEqual(newState.proxyPassword, '[REDACTED]');
+    assert.strictEqual(newState.apiGatewayHeaderValue, '[REDACTED]');
+    // Unrelated fields pass through unchanged
+    assert.strictEqual(newState.useProxy, specificCommand.useProxy);
+    assert.strictEqual(newState.proxyUrl, specificCommand.proxyUrl);
+    assert.strictEqual(newState.proxyUsername, specificCommand.proxyUsername);
   });
 
   it('should update keys', () => {

--- a/backend/src/repository/config/oianalytics-registration.repository.ts
+++ b/backend/src/repository/config/oianalytics-registration.repository.ts
@@ -3,11 +3,15 @@ import { Database } from 'better-sqlite3';
 import { Instant } from '../../../shared/model/types';
 import { OIAnalyticsRegistration, OIAnalyticsRegistrationEditCommand } from '../../model/oianalytics-registration.model';
 import { RegistrationStatus } from '../../../shared/model/engine.model';
+import AuditService from '../../service/audit.service';
 
 const REGISTRATIONS_TABLE = 'registrations';
 
 export default class OIAnalyticsRegistrationRepository {
-  constructor(private readonly database: Database) {
+  constructor(
+    private readonly database: Database,
+    private readonly auditService: AuditService
+  ) {
     this.createDefault({
       host: '',
       useProxy: false,
@@ -212,6 +216,7 @@ export default class OIAnalyticsRegistrationRepository {
   }
 
   update(command: Omit<OIAnalyticsRegistrationEditCommand, 'host'>, updatedBy: string): void {
+    const before = this.get();
     const query =
       `UPDATE ${REGISTRATIONS_TABLE} SET ` +
       `use_proxy = ?, proxy_url = ?, proxy_username = ?, proxy_password = ?, use_api_gateway = ?, api_gateway_header_key = ?, api_gateway_header_value = ?, api_gateway_base_endpoint = ?, ` +
@@ -288,11 +293,16 @@ export default class OIAnalyticsRegistrationRepository {
         +command.commandPermissions.testCustomTransformer,
         updatedBy
       );
+    const after = this.get();
+    this.auditService.record('oianalytics_registration', after!.id, 'UPDATE', this.redact(before), this.redact(after), updatedBy);
   }
 
-  updateKeys(privateKey: string, publicKey: string): void {
+  updateKeys(privateKey: string, publicKey: string, updatedBy: string): void {
+    const before = this.get();
     const query = `UPDATE ${REGISTRATIONS_TABLE} SET private_key = ?, public_key = ? WHERE rowid=(SELECT MIN(rowid) FROM ${REGISTRATIONS_TABLE});`;
     this.database.prepare(query).run(privateKey, publicKey);
+    const after = this.get();
+    this.auditService.record('oianalytics_registration', after!.id, 'UPDATE', this.redact(before), this.redact(after), updatedBy);
   }
 
   protected createDefault(command: OIAnalyticsRegistrationEditCommand): void {
@@ -379,6 +389,15 @@ export default class OIAnalyticsRegistrationRepository {
         'system',
         'system'
       );
+  }
+
+  /**
+   * Returns a shallow copy of the registration with the cipher key material redacted, so real key
+   * bytes never end up persisted in the audit trail, even for calls that do not touch the keys.
+   */
+  private redact(registration: OIAnalyticsRegistration | null): Record<string, unknown> | null {
+    if (!registration) return null;
+    return { ...registration, publicCipherKey: '[REDACTED]', privateCipherKey: '[REDACTED]' };
   }
 
   private toOIAnalyticsRegistration(result: Record<string, string | number>): OIAnalyticsRegistration {

--- a/backend/src/repository/config/oianalytics-registration.repository.ts
+++ b/backend/src/repository/config/oianalytics-registration.repository.ts
@@ -397,7 +397,14 @@ export default class OIAnalyticsRegistrationRepository {
    */
   private redact(registration: OIAnalyticsRegistration | null): Record<string, unknown> | null {
     if (!registration) return null;
-    return { ...registration, publicCipherKey: '[REDACTED]', privateCipherKey: '[REDACTED]' };
+    return {
+      ...registration,
+      publicCipherKey: '[REDACTED]',
+      privateCipherKey: '[REDACTED]',
+      token: '[REDACTED]',
+      proxyPassword: '[REDACTED]',
+      apiGatewayHeaderValue: '[REDACTED]'
+    };
   }
 
   private toOIAnalyticsRegistration(result: Record<string, string | number>): OIAnalyticsRegistration {

--- a/backend/src/repository/config/scan-mode.repository.spec.ts
+++ b/backend/src/repository/config/scan-mode.repository.spec.ts
@@ -1,10 +1,12 @@
 import { before, after, beforeEach, describe, it } from 'node:test';
 import assert from 'node:assert/strict';
+import { mock } from 'node:test';
 import { Database } from 'better-sqlite3';
-import { emptyDatabase, initDatabase, stripAuditFields } from '../../tests/utils/test-utils';
+import { createAuditServiceMock, emptyDatabase, initDatabase, stripAuditFields } from '../../tests/utils/test-utils';
 import testData from '../../tests/utils/test-data';
 import ScanModeRepository, { scanModeAliasedColumns, scanModeColumns, toScanMode, toScanModeFromPrefixedRow } from './scan-mode.repository';
 import { ActivationWindow, ScanModeInterval } from '../../../shared/model/scan-mode.model';
+import AuditService from '../../service/audit.service';
 
 const TEST_DB_PATH = 'src/tests/test-config-scan-mode.db';
 
@@ -26,10 +28,12 @@ describe('ScanModeRepository with populated database', () => {
   });
 
   let repository: ScanModeRepository;
+  let auditService: AuditService;
   let createdId: string;
 
   beforeEach(() => {
-    repository = new ScanModeRepository(database);
+    auditService = createAuditServiceMock();
+    repository = new ScanModeRepository(database, auditService);
   });
 
   it('should properly get all scan modes', () => {
@@ -56,6 +60,10 @@ describe('ScanModeRepository with populated database', () => {
     assert.strictEqual(created.cron, testData.scanMode.command.cron);
     assert.strictEqual(created.interval, null);
     assert.strictEqual(created.activationWindow, null);
+
+    const recordMock = auditService.record as unknown as ReturnType<typeof mock.fn>;
+    assert.strictEqual(recordMock.mock.calls.length, 1);
+    assert.deepStrictEqual(recordMock.mock.calls[0].arguments, ['scan_mode', created.id, 'CREATE', null, created, 'userTest']);
   });
 
   it('should create an interval scan mode, normalizing cron to an empty string', () => {
@@ -93,6 +101,7 @@ describe('ScanModeRepository with populated database', () => {
   });
 
   it('should update a scan mode', () => {
+    const before = repository.findById(createdId);
     repository.update(createdId, testData.scanMode.command, 'userTest');
     const result = repository.findById(createdId)!;
     assert.strictEqual(result.name, testData.scanMode.command.name);
@@ -101,6 +110,10 @@ describe('ScanModeRepository with populated database', () => {
     assert.strictEqual(result.cron, testData.scanMode.command.cron);
     assert.strictEqual(result.interval, null);
     assert.strictEqual(result.activationWindow, null);
+
+    const recordMock = auditService.record as unknown as ReturnType<typeof mock.fn>;
+    assert.strictEqual(recordMock.mock.calls.length, 1);
+    assert.deepStrictEqual(recordMock.mock.calls[0].arguments, ['scan_mode', createdId, 'UPDATE', before, result, 'userTest']);
   });
 
   it('should update a scan mode to an interval type and back to cron', () => {
@@ -128,9 +141,14 @@ describe('ScanModeRepository with populated database', () => {
   });
 
   it('should delete a scan mode', () => {
-    assert.notStrictEqual(repository.findById(createdId), null);
-    repository.delete(createdId);
+    const before = repository.findById(createdId);
+    assert.notStrictEqual(before, null);
+    repository.delete(createdId, 'userTest');
     assert.strictEqual(repository.findById(createdId), null);
+
+    const recordMock = auditService.record as unknown as ReturnType<typeof mock.fn>;
+    assert.strictEqual(recordMock.mock.calls.length, 1);
+    assert.deepStrictEqual(recordMock.mock.calls[0].arguments, ['scan_mode', createdId, 'DELETE', before, null, 'userTest']);
   });
 });
 
@@ -145,7 +163,7 @@ describe('ScanModeRepository with empty database', () => {
   });
 
   it('should properly init scan mode table with default scan modes', () => {
-    const repository = new ScanModeRepository(database);
+    const repository = new ScanModeRepository(database, createAuditServiceMock());
     // 7 default scan modes are created (6 with generated IDs + 1 with hardcoded 'subscription' id)
     const all = repository.findAll();
     assert.strictEqual(all.length, 7);

--- a/backend/src/repository/config/scan-mode.repository.ts
+++ b/backend/src/repository/config/scan-mode.repository.ts
@@ -2,6 +2,7 @@ import { generateRandomId } from '../../service/utils';
 import { Database } from 'better-sqlite3';
 import { ScanMode } from '../../model/scan-mode.model';
 import { ActivationWindow, ScanModeInterval, ScanModeType } from '../../../shared/model/scan-mode.model';
+import AuditService from '../../service/audit.service';
 
 const SCAN_MODES_TABLE = 'scan_modes';
 
@@ -58,7 +59,10 @@ const DEFAULT_SCAN_MODES: Array<{ id?: string; name: string; description: string
  * Repository used for scan modes (cron definitions)
  */
 export default class ScanModeRepository {
-  constructor(private readonly database: Database) {
+  constructor(
+    private readonly database: Database,
+    private readonly auditService: AuditService
+  ) {
     this.createDefault();
   }
 
@@ -107,10 +111,13 @@ export default class ScanModeRepository {
         createdBy
       );
     const query = `SELECT ${scanModeColumns()} FROM ${SCAN_MODES_TABLE} WHERE ROWID = ?;`;
-    return toScanMode(this.database.prepare(query).get(result.lastInsertRowid) as Record<string, string>);
+    const created = toScanMode(this.database.prepare(query).get(result.lastInsertRowid) as Record<string, string>);
+    this.auditService.record('scan_mode', created.id, 'CREATE', null, created as unknown as Record<string, unknown>, createdBy);
+    return created;
   }
 
   update(id: string, command: Omit<ScanMode, 'id' | 'createdBy' | 'updatedBy' | 'createdAt' | 'updatedAt'>, updatedBy: string): void {
+    const before = this.findById(id);
     const query =
       `UPDATE ${SCAN_MODES_TABLE} SET name = ?, description = ?, type = ?, cron = ?, interval = ?, activation_window = ?, ` +
       `updated_by = ?, updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now') WHERE id = ?;`;
@@ -126,11 +133,24 @@ export default class ScanModeRepository {
         updatedBy,
         id
       );
+    const after = this.findById(id);
+    this.auditService.record(
+      'scan_mode',
+      id,
+      'UPDATE',
+      before as unknown as Record<string, unknown>,
+      after as unknown as Record<string, unknown>,
+      updatedBy
+    );
   }
 
-  delete(id: string): void {
+  delete(id: string, deletedBy: string): void {
+    const before = this.findById(id);
     const query = `DELETE FROM ${SCAN_MODES_TABLE} WHERE id = ?;`;
     this.database.prepare(query).run(id);
+    if (before) {
+      this.auditService.record('scan_mode', id, 'DELETE', before as unknown as Record<string, unknown>, null, deletedBy);
+    }
   }
 }
 

--- a/backend/src/repository/config/south-connector.repository.spec.ts
+++ b/backend/src/repository/config/south-connector.repository.spec.ts
@@ -1,12 +1,14 @@
 import { before, after, beforeEach, describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { Database } from 'better-sqlite3';
-import { emptyDatabase, initDatabase, stripAuditFields } from '../../tests/utils/test-utils';
+import { createAuditServiceMock, emptyDatabase, initDatabase, stripAuditFields } from '../../tests/utils/test-utils';
 import testData from '../../tests/utils/test-data';
 import SouthConnectorRepository, { toItemEntityFromJoinedRow, toSouthItemGroupLight } from './south-connector.repository';
 import SouthItemGroupRepository from './south-item-group.repository';
 import { SouthConnectorEntity, SouthConnectorItemEntity, SouthItemGroupEntityLight } from '../../model/south-connector.model';
 import { SouthItemSettings, SouthSettings } from '../../../shared/model/south-settings.model';
+import { mock } from 'node:test';
+import AuditService from '../../service/audit.service';
 
 const TEST_DB_PATH = 'src/tests/test-config-south.db';
 
@@ -22,9 +24,11 @@ describe('SouthConnectorRepository', () => {
   });
 
   let repository: SouthConnectorRepository;
+  let auditService: AuditService;
 
   beforeEach(() => {
-    repository = new SouthConnectorRepository(database);
+    auditService = createAuditServiceMock();
+    repository = new SouthConnectorRepository(database, auditService);
   });
 
   it('should properly get south connectors', () => {
@@ -56,6 +60,18 @@ describe('SouthConnectorRepository', () => {
     assert.strictEqual(createdConnector.id, newSouthConnector.id);
     assert.strictEqual(createdConnector.name, 'new connector');
     assert.strictEqual(createdConnector.items.length, 0);
+
+    const recordMock = auditService.record as unknown as ReturnType<typeof mock.fn>;
+    const connectorCalls = recordMock.mock.calls.filter(call => call.arguments[0] === 'south_connector');
+    assert.strictEqual(connectorCalls.length, 1);
+    assert.deepStrictEqual(connectorCalls[0].arguments, [
+      'south_connector',
+      newSouthConnector.id,
+      'CREATE',
+      null,
+      createdConnector,
+      newSouthConnector.updatedBy
+    ]);
   });
 
   it('should update a south connector', () => {
@@ -79,10 +95,27 @@ describe('SouthConnectorRepository', () => {
       recoveryStrategy: null
     };
     newSouthConnector.items = [...testData.south.list[1].items, newItem];
+    const beforeConnector = repository.findSouthById(newSouthConnector.id);
     repository.saveSouth(newSouthConnector);
 
     const updatedConnector = repository.findSouthById(newSouthConnector.id)!;
     assert.strictEqual(updatedConnector.items.length, 3);
+
+    const recordMock = auditService.record as unknown as ReturnType<typeof mock.fn>;
+    const connectorCalls = recordMock.mock.calls.filter(call => call.arguments[0] === 'south_connector');
+    assert.strictEqual(connectorCalls.length, 1);
+    assert.deepStrictEqual(connectorCalls[0].arguments, [
+      'south_connector',
+      newSouthConnector.id,
+      'UPDATE',
+      beforeConnector,
+      updatedConnector,
+      newSouthConnector.updatedBy
+    ]);
+
+    const itemCreateCalls = recordMock.mock.calls.filter(call => call.arguments[0] === 'south_item' && call.arguments[2] === 'CREATE');
+    assert.strictEqual(itemCreateCalls.length, 1);
+    assert.strictEqual(itemCreateCalls[0].arguments[1], newItem.id);
   });
 
   it('should update a south connector item with non-null historian fields', () => {
@@ -92,6 +125,7 @@ describe('SouthConnectorRepository', () => {
         ? { ...item, maxReadInterval: 3600, readDelay: 200, startTimeOffset: 100, endTimeOffset: null, recoveryStrategy: null }
         : item
     );
+    const beforeItem = repository.findItemById(connector.id, connector.items[0].id);
     repository.saveSouth(connector);
 
     const updatedConnector = repository.findSouthById(connector.id)!;
@@ -99,6 +133,22 @@ describe('SouthConnectorRepository', () => {
     assert.strictEqual(updatedItem.maxReadInterval, 3600);
     assert.strictEqual(updatedItem.readDelay, 200);
     assert.strictEqual(updatedItem.startTimeOffset, 100);
+
+    const recordMock = auditService.record as unknown as ReturnType<typeof mock.fn>;
+    const itemUpdateCalls = recordMock.mock.calls.filter(
+      call => call.arguments[0] === 'south_item' && call.arguments[1] === connector.items[0].id && call.arguments[2] === 'UPDATE'
+    );
+    assert.strictEqual(itemUpdateCalls.length, 1);
+    assert.deepStrictEqual(itemUpdateCalls[0].arguments[3], beforeItem);
+
+    // A second save of the same unchanged connector must not re-audit the untouched item
+    recordMock.mock.resetCalls();
+    const resaved: SouthConnectorEntity<SouthSettings, SouthItemSettings> = JSON.parse(JSON.stringify(updatedConnector));
+    repository.saveSouth(resaved);
+    const secondItemCalls = recordMock.mock.calls.filter(
+      call => call.arguments[0] === 'south_item' && call.arguments[1] === connector.items[0].id
+    );
+    assert.strictEqual(secondItemCalls.length, 0);
   });
 
   it('should delete a south connector', () => {
@@ -110,8 +160,89 @@ describe('SouthConnectorRepository', () => {
     repository.saveSouth(newSouthConnector);
 
     assert.ok(repository.findSouthById(newSouthConnector.id));
-    repository.deleteSouth(newSouthConnector.id);
+    const before = repository.findSouthById(newSouthConnector.id);
+    repository.deleteSouth(newSouthConnector.id, 'deleteUser');
     assert.strictEqual(repository.findSouthById(newSouthConnector.id), null);
+
+    const recordMock = auditService.record as unknown as ReturnType<typeof mock.fn>;
+    const deleteCall = recordMock.mock.calls.find(
+      call => call.arguments[0] === 'south_connector' && call.arguments[1] === newSouthConnector.id && call.arguments[2] === 'DELETE'
+    );
+    assert.ok(deleteCall);
+    assert.deepStrictEqual(deleteCall!.arguments, ['south_connector', newSouthConnector.id, 'DELETE', before, null, 'deleteUser']);
+  });
+
+  it('should audit deleted items and groups when deleting a south connector', () => {
+    // First save a bare connector to get a real generated id
+    const newSouthConnector: SouthConnectorEntity<SouthSettings, SouthItemSettings> = JSON.parse(JSON.stringify(testData.south.list[0]));
+    newSouthConnector.id = '';
+    newSouthConnector.name = 'to be deleted with items and groups';
+    newSouthConnector.groups = [];
+    newSouthConnector.items = [];
+    repository.saveSouth(newSouthConnector);
+
+    // Attach a temp group (created with the correct southId as part of the save) and an item using it
+    const tempGroup: SouthItemGroupEntityLight = {
+      id: 'temp_deleteSouthAudit',
+      name: 'Group For Delete South Audit',
+      scanMode: testData.scanMode.list[0],
+      startTimeOffset: null,
+      endTimeOffset: null,
+      recoveryStrategy: null,
+      maxReadInterval: null,
+      readDelay: 0,
+      createdBy: '',
+      updatedBy: '',
+      createdAt: '',
+      updatedAt: ''
+    };
+    newSouthConnector.groups = [tempGroup];
+    newSouthConnector.items = [
+      {
+        id: '',
+        name: 'item to delete with south',
+        enabled: true,
+        scanMode: testData.scanMode.list[0],
+        settings: {} as SouthItemSettings,
+        group: { ...tempGroup },
+        syncWithGroup: false,
+        maxReadInterval: null,
+        readDelay: null,
+        startTimeOffset: null,
+        endTimeOffset: null,
+        recoveryStrategy: null,
+        createdBy: '',
+        updatedBy: '',
+        createdAt: '',
+        updatedAt: ''
+      }
+    ];
+    repository.saveSouth(newSouthConnector);
+    const before = repository.findSouthById(newSouthConnector.id)!;
+    assert.strictEqual(before.items.length, 1);
+    assert.strictEqual(before.groups.length, 1);
+
+    const recordMock = auditService.record as unknown as ReturnType<typeof mock.fn>;
+    recordMock.mock.resetCalls();
+
+    repository.deleteSouth(newSouthConnector.id, 'deleteUser');
+
+    const itemDeleteCall = recordMock.mock.calls.find(
+      call => call.arguments[0] === 'south_item' && call.arguments[1] === before.items[0].id && call.arguments[2] === 'DELETE'
+    );
+    assert.ok(itemDeleteCall);
+    assert.strictEqual(itemDeleteCall!.arguments[5], 'deleteUser');
+
+    const groupDeleteCall = recordMock.mock.calls.find(
+      call => call.arguments[0] === 'south_item_group' && call.arguments[1] === before.groups[0].id && call.arguments[2] === 'DELETE'
+    );
+    assert.ok(groupDeleteCall);
+    assert.strictEqual(groupDeleteCall!.arguments[5], 'deleteUser');
+
+    const connectorDeleteCall = recordMock.mock.calls.find(
+      call => call.arguments[0] === 'south_connector' && call.arguments[1] === newSouthConnector.id && call.arguments[2] === 'DELETE'
+    );
+    assert.ok(connectorDeleteCall);
   });
 
   it('should stop south connector', () => {
@@ -170,14 +301,37 @@ describe('SouthConnectorRepository', () => {
   });
 
   it('should delete item', () => {
-    repository.deleteItem(testData.south.list[1].id, testData.south.list[1].items[0].id);
-    repository.deleteItem(testData.south.list[1].id, testData.south.list[1].items[1].id);
+    const before0 = repository.findItemById(testData.south.list[1].id, testData.south.list[1].items[0].id);
+    repository.deleteItem(testData.south.list[1].id, testData.south.list[1].items[0].id, 'deleteUser');
+    repository.deleteItem(testData.south.list[1].id, testData.south.list[1].items[1].id, 'deleteUser');
     assert.strictEqual(repository.findItemById(testData.south.list[1].id, testData.south.list[1].items[0].id), null);
+
+    const recordMock = auditService.record as unknown as ReturnType<typeof mock.fn>;
+    assert.deepStrictEqual(recordMock.mock.calls[0].arguments, [
+      'south_item',
+      testData.south.list[1].items[0].id,
+      'DELETE',
+      before0,
+      null,
+      'deleteUser'
+    ]);
   });
 
   it('should delete all item by south', () => {
-    repository.deleteAllItemsBySouth(testData.south.list[1].id);
+    const beforeItems = repository.findAllItemsForSouth(testData.south.list[1].id);
+    repository.deleteAllItemsBySouth(testData.south.list[1].id, 'deleteUser');
     assert.strictEqual(repository.findAllItemsForSouth(testData.south.list[1].id).length, 0);
+
+    const recordMock = auditService.record as unknown as ReturnType<typeof mock.fn>;
+    const deleteCalls = recordMock.mock.calls.filter(call => call.arguments[0] === 'south_item' && call.arguments[2] === 'DELETE');
+    assert.strictEqual(deleteCalls.length, beforeItems.length);
+    for (const item of beforeItems) {
+      assert.ok(
+        deleteCalls.some(
+          call => call.arguments[1] === item.id && call.arguments[3] !== null && call.arguments[5] === 'deleteUser'
+        )
+      );
+    }
   });
 
   it('should disable and enable item', () => {
@@ -210,7 +364,7 @@ describe('SouthConnectorRepository', () => {
     itemsToSave.push(newItem);
     itemsToSave[0].name = 'updated name';
 
-    repository.saveAllItems(testData.south.list[0].id, itemsToSave, false);
+    repository.saveAllItems(testData.south.list[0].id, itemsToSave, false, 'userTest');
 
     const results = repository.findAllItemsForSouth(testData.south.list[0].id);
     assert.strictEqual(results.length, 3);
@@ -245,7 +399,7 @@ describe('SouthConnectorRepository', () => {
     };
     itemsToSave.push(newItem);
 
-    repository.saveAllItems(testData.south.list[0].id, itemsToSave, true);
+    repository.saveAllItems(testData.south.list[0].id, itemsToSave, true, 'userTest');
 
     const results = repository.findAllItemsForSouth(testData.south.list[0].id);
     assert.strictEqual(results.length, itemsToSave.length);
@@ -257,7 +411,7 @@ describe('SouthConnectorRepository', () => {
   });
 
   it('should save south connector with items that have groups', () => {
-    const groupRepository = new SouthItemGroupRepository(database);
+    const groupRepository = new SouthItemGroupRepository(database, createAuditServiceMock());
 
     const group = groupRepository.create(
       {
@@ -305,7 +459,7 @@ describe('SouthConnectorRepository', () => {
   });
 
   it('should save item with groups', () => {
-    const groupRepository = new SouthItemGroupRepository(database);
+    const groupRepository = new SouthItemGroupRepository(database, createAuditServiceMock());
 
     const group = groupRepository.create(
       {
@@ -347,6 +501,55 @@ describe('SouthConnectorRepository', () => {
     const savedItem = repository.findItemById(testData.south.list[0].id, itemWithGroup.id);
     assert.ok(savedItem);
     assert.strictEqual(savedItem.group!.id, group.id);
+
+    const recordMock = auditService.record as unknown as ReturnType<typeof mock.fn>;
+    const createCall = recordMock.mock.calls.find(
+      call => call.arguments[0] === 'south_item' && call.arguments[1] === itemWithGroup.id && call.arguments[2] === 'CREATE'
+    );
+    assert.ok(createCall);
+    assert.strictEqual(createCall!.arguments[3], null);
+  });
+
+  it('should audit an update via saveItem', () => {
+    const item: SouthConnectorItemEntity<SouthItemSettings> = {
+      id: '',
+      name: 'save-item-update-audit',
+      enabled: true,
+      scanMode: testData.scanMode.list[0],
+      settings: {} as SouthItemSettings,
+      group: null,
+      syncWithGroup: false,
+      maxReadInterval: null,
+      readDelay: null,
+      startTimeOffset: null,
+      endTimeOffset: null,
+      recoveryStrategy: null,
+      createdBy: '',
+      updatedBy: 'creatorUser',
+      createdAt: '',
+      updatedAt: ''
+    };
+    repository.saveItem(testData.south.list[0].id, item);
+    assert.ok(item.id);
+    const beforeUpdate = repository.findItemById(testData.south.list[0].id, item.id);
+
+    const recordMock = auditService.record as unknown as ReturnType<typeof mock.fn>;
+    recordMock.mock.resetCalls();
+
+    item.name = 'save-item-update-audit-renamed';
+    item.updatedBy = 'updaterUser';
+    repository.saveItem(testData.south.list[0].id, item);
+
+    const afterUpdate = repository.findItemById(testData.south.list[0].id, item.id);
+    assert.strictEqual(recordMock.mock.calls.length, 1);
+    assert.deepStrictEqual(recordMock.mock.calls[0].arguments, [
+      'south_item',
+      item.id,
+      'UPDATE',
+      beforeUpdate,
+      afterUpdate,
+      'updaterUser'
+    ]);
   });
 
   it('should save and find item with historian fields', () => {
@@ -408,7 +611,7 @@ describe('SouthConnectorRepository', () => {
   });
 
   it('should move items to a group', () => {
-    const groupRepository = new SouthItemGroupRepository(database);
+    const groupRepository = new SouthItemGroupRepository(database, createAuditServiceMock());
 
     const group = groupRepository.create(
       {
@@ -438,7 +641,7 @@ describe('SouthConnectorRepository', () => {
   });
 
   it('should remove items from groups when groupId is null', () => {
-    const groupRepository = new SouthItemGroupRepository(database);
+    const groupRepository = new SouthItemGroupRepository(database, createAuditServiceMock());
 
     const group = groupRepository.create(
       {
@@ -526,6 +729,11 @@ describe('SouthConnectorRepository', () => {
     assert.ok(savedItem);
     assert.ok(savedItem.group);
     assert.notStrictEqual(savedItem.group.id, 'temp_newgroup');
+
+    const recordMock = auditService.record as unknown as ReturnType<typeof mock.fn>;
+    const groupCreateCall = recordMock.mock.calls.find(call => call.arguments[0] === 'south_item_group' && call.arguments[2] === 'CREATE');
+    assert.ok(groupCreateCall);
+    assert.strictEqual(groupCreateCall!.arguments[1], savedItem.group!.id);
   });
 
   it('should find scan mode for south', () => {
@@ -537,7 +745,7 @@ describe('SouthConnectorRepository', () => {
   });
 
   it('should find groups by south id', () => {
-    const groupRepository = new SouthItemGroupRepository(database);
+    const groupRepository = new SouthItemGroupRepository(database, createAuditServiceMock());
     groupRepository.create(
       {
         name: 'Test Group For Find',
@@ -561,7 +769,7 @@ describe('SouthConnectorRepository', () => {
   });
 
   it('should update existing group properties when saving the south connector', () => {
-    const groupRepository = new SouthItemGroupRepository(database);
+    const groupRepository = new SouthItemGroupRepository(database, createAuditServiceMock());
 
     // Create a real group with the first scan mode
     const group = groupRepository.create(
@@ -604,10 +812,98 @@ describe('SouthConnectorRepository', () => {
     assert.strictEqual(savedGroup.startTimeOffset, 500);
     assert.strictEqual(savedGroup.maxReadInterval, 3600);
     assert.strictEqual(savedGroup.readDelay, 200);
+
+    const recordMock = auditService.record as unknown as ReturnType<typeof mock.fn>;
+    const groupUpdateCall = recordMock.mock.calls.find(
+      call => call.arguments[0] === 'south_item_group' && call.arguments[1] === group.id && call.arguments[2] === 'UPDATE'
+    );
+    assert.ok(groupUpdateCall);
+    assert.strictEqual(groupUpdateCall!.arguments[5], 'updateUser');
+  });
+
+  it('should audit a removed group when saving the south connector without it', () => {
+    const groupRepository = new SouthItemGroupRepository(database, createAuditServiceMock());
+    const group = groupRepository.create(
+      {
+        name: 'Group To Remove Via Save',
+        southId: testData.south.list[0].id,
+        scanMode: testData.scanMode.list[0],
+        startTimeOffset: null,
+        endTimeOffset: null,
+        recoveryStrategy: null,
+        maxReadInterval: null,
+        readDelay: 0
+      },
+      'userTest'
+    );
+
+    const south: SouthConnectorEntity<SouthSettings, SouthItemSettings> = JSON.parse(JSON.stringify(testData.south.list[0]));
+    south.items = [];
+    south.groups = [group];
+    repository.saveSouth(south);
+
+    const recordMock = auditService.record as unknown as ReturnType<typeof mock.fn>;
+    recordMock.mock.resetCalls();
+
+    const southWithoutGroup: SouthConnectorEntity<SouthSettings, SouthItemSettings> = JSON.parse(JSON.stringify(south));
+    southWithoutGroup.groups = [];
+    southWithoutGroup.updatedBy = 'removeUser';
+    repository.saveSouth(southWithoutGroup);
+
+    assert.strictEqual(groupRepository.findById(group.id), null);
+    const groupDeleteCall = recordMock.mock.calls.find(
+      call => call.arguments[0] === 'south_item_group' && call.arguments[1] === group.id && call.arguments[2] === 'DELETE'
+    );
+    assert.ok(groupDeleteCall);
+    assert.strictEqual(groupDeleteCall!.arguments[5], 'removeUser');
+  });
+
+  it('should audit a removed item when saving the south connector without it', () => {
+    const south: SouthConnectorEntity<SouthSettings, SouthItemSettings> = JSON.parse(JSON.stringify(testData.south.list[0]));
+    south.id = '';
+    south.name = 'connector for item removal audit';
+    south.items = [
+      {
+        id: '',
+        name: 'item to be removed',
+        enabled: true,
+        scanMode: testData.scanMode.list[0],
+        settings: {} as SouthItemSettings,
+        group: null,
+        syncWithGroup: false,
+        maxReadInterval: null,
+        readDelay: null,
+        startTimeOffset: null,
+        endTimeOffset: null,
+        recoveryStrategy: null,
+        createdBy: '',
+        updatedBy: '',
+        createdAt: '',
+        updatedAt: ''
+      }
+    ];
+    repository.saveSouth(south);
+    const itemId = south.items[0].id;
+    const beforeItem = repository.findItemById(south.id, itemId);
+
+    const recordMock = auditService.record as unknown as ReturnType<typeof mock.fn>;
+    recordMock.mock.resetCalls();
+
+    const southWithoutItem: SouthConnectorEntity<SouthSettings, SouthItemSettings> = JSON.parse(JSON.stringify(south));
+    southWithoutItem.items = [];
+    southWithoutItem.updatedBy = 'removeItemUser';
+    repository.saveSouth(southWithoutItem);
+
+    assert.strictEqual(repository.findItemById(south.id, itemId), null);
+    const itemDeleteCall = recordMock.mock.calls.find(
+      call => call.arguments[0] === 'south_item' && call.arguments[1] === itemId && call.arguments[2] === 'DELETE'
+    );
+    assert.ok(itemDeleteCall);
+    assert.deepStrictEqual(itemDeleteCall!.arguments, ['south_item', itemId, 'DELETE', beforeItem, null, 'removeItemUser']);
   });
 
   it('should delete a group and fill empty scan mode and history fields on its items', () => {
-    const groupRepository = new SouthItemGroupRepository(database);
+    const groupRepository = new SouthItemGroupRepository(database, createAuditServiceMock());
     const group = groupRepository.create(
       {
         name: 'Group To Delete With Fallback',
@@ -642,7 +938,7 @@ describe('SouthConnectorRepository', () => {
     };
     repository.saveItem(testData.south.list[0].id, itemWithEmptyFields);
 
-    repository.deleteGroupAndUpdateItems(testData.south.list[0].id, group, true);
+    repository.deleteGroupAndUpdateItems(testData.south.list[0].id, group, true, 'deleteUser');
 
     assert.strictEqual(groupRepository.findById(group.id), null);
     const savedItem = repository.findItemById(testData.south.list[0].id, itemWithEmptyFields.id)!;
@@ -657,7 +953,7 @@ describe('SouthConnectorRepository', () => {
   });
 
   it('should not overwrite an item own scan mode and history fields when deleting its group', () => {
-    const groupRepository = new SouthItemGroupRepository(database);
+    const groupRepository = new SouthItemGroupRepository(database, createAuditServiceMock());
     const group = groupRepository.create(
       {
         name: 'Group To Delete Without Fallback',
@@ -692,7 +988,7 @@ describe('SouthConnectorRepository', () => {
     };
     repository.saveItem(testData.south.list[0].id, itemWithOwnFields);
 
-    repository.deleteGroupAndUpdateItems(testData.south.list[0].id, group, true);
+    repository.deleteGroupAndUpdateItems(testData.south.list[0].id, group, true, 'deleteUser');
 
     const savedItem = repository.findItemById(testData.south.list[0].id, itemWithOwnFields.id)!;
     assert.strictEqual(savedItem.group, null);
@@ -705,7 +1001,7 @@ describe('SouthConnectorRepository', () => {
   });
 
   it('should not fill history fields when the connector does not support history', () => {
-    const groupRepository = new SouthItemGroupRepository(database);
+    const groupRepository = new SouthItemGroupRepository(database, createAuditServiceMock());
     const group = groupRepository.create(
       {
         name: 'Group To Delete No History',
@@ -740,7 +1036,7 @@ describe('SouthConnectorRepository', () => {
     };
     repository.saveItem(testData.south.list[0].id, itemWithEmptyFields);
 
-    repository.deleteGroupAndUpdateItems(testData.south.list[0].id, group, false);
+    repository.deleteGroupAndUpdateItems(testData.south.list[0].id, group, false, 'deleteUser');
 
     const savedItem = repository.findItemById(testData.south.list[0].id, itemWithEmptyFields.id)!;
     assert.strictEqual(savedItem.scanMode!.id, group.scanMode.id);
@@ -898,7 +1194,7 @@ describe('SouthConnectorRepository', () => {
   });
 
   it('should persist a non-null recovery strategy when updating an existing group', () => {
-    const groupRepository = new SouthItemGroupRepository(database);
+    const groupRepository = new SouthItemGroupRepository(database, createAuditServiceMock());
     const group = groupRepository.create(
       {
         name: 'Group With Recovery Strategy',
@@ -924,7 +1220,7 @@ describe('SouthConnectorRepository', () => {
   });
 
   it('should throw when an existing group is saved without a scan mode (NOT NULL constraint)', () => {
-    const groupRepository = new SouthItemGroupRepository(database);
+    const groupRepository = new SouthItemGroupRepository(database, createAuditServiceMock());
     const group = groupRepository.create(
       {
         name: 'Group Missing Scan Mode',

--- a/backend/src/repository/config/south-connector.repository.spec.ts
+++ b/backend/src/repository/config/south-connector.repository.spec.ts
@@ -69,9 +69,14 @@ describe('SouthConnectorRepository', () => {
       newSouthConnector.id,
       'CREATE',
       null,
-      createdConnector,
+      { ...createdConnector, settings: { ...createdConnector.settings, password: '' } },
       newSouthConnector.updatedBy
     ]);
+    // The connector's secret settings field must never be persisted in the audit trail
+    assert.notStrictEqual(
+      (connectorCalls[0].arguments[4] as { settings: { password: string } }).settings.password,
+      (createdConnector.settings as unknown as { password: string }).password
+    );
   });
 
   it('should update a south connector', () => {
@@ -108,10 +113,17 @@ describe('SouthConnectorRepository', () => {
       'south_connector',
       newSouthConnector.id,
       'UPDATE',
-      beforeConnector,
-      updatedConnector,
+      { ...beforeConnector, settings: { ...beforeConnector!.settings, password: '' } },
+      { ...updatedConnector, settings: { ...updatedConnector.settings, password: '' } },
       newSouthConnector.updatedBy
     ]);
+    // The connector's secret settings field must never be persisted in the audit trail, before or after
+    assert.strictEqual((connectorCalls[0].arguments[3] as { settings: { password: string } }).settings.password, '');
+    assert.strictEqual((connectorCalls[0].arguments[4] as { settings: { password: string } }).settings.password, '');
+    assert.notStrictEqual(
+      (connectorCalls[0].arguments[4] as { settings: { password: string } }).settings.password,
+      (updatedConnector.settings as unknown as { password: string }).password
+    );
 
     const itemCreateCalls = recordMock.mock.calls.filter(call => call.arguments[0] === 'south_item' && call.arguments[2] === 'CREATE');
     assert.strictEqual(itemCreateCalls.length, 1);
@@ -169,7 +181,14 @@ describe('SouthConnectorRepository', () => {
       call => call.arguments[0] === 'south_connector' && call.arguments[1] === newSouthConnector.id && call.arguments[2] === 'DELETE'
     );
     assert.ok(deleteCall);
-    assert.deepStrictEqual(deleteCall!.arguments, ['south_connector', newSouthConnector.id, 'DELETE', before, null, 'deleteUser']);
+    assert.deepStrictEqual(deleteCall!.arguments, [
+      'south_connector',
+      newSouthConnector.id,
+      'DELETE',
+      { ...before, settings: { ...before!.settings, password: '' } },
+      null,
+      'deleteUser'
+    ]);
   });
 
   it('should audit deleted items and groups when deleting a south connector', () => {
@@ -327,9 +346,7 @@ describe('SouthConnectorRepository', () => {
     assert.strictEqual(deleteCalls.length, beforeItems.length);
     for (const item of beforeItems) {
       assert.ok(
-        deleteCalls.some(
-          call => call.arguments[1] === item.id && call.arguments[3] !== null && call.arguments[5] === 'deleteUser'
-        )
+        deleteCalls.some(call => call.arguments[1] === item.id && call.arguments[3] !== null && call.arguments[5] === 'deleteUser')
       );
     }
   });
@@ -542,14 +559,7 @@ describe('SouthConnectorRepository', () => {
 
     const afterUpdate = repository.findItemById(testData.south.list[0].id, item.id);
     assert.strictEqual(recordMock.mock.calls.length, 1);
-    assert.deepStrictEqual(recordMock.mock.calls[0].arguments, [
-      'south_item',
-      item.id,
-      'UPDATE',
-      beforeUpdate,
-      afterUpdate,
-      'updaterUser'
-    ]);
+    assert.deepStrictEqual(recordMock.mock.calls[0].arguments, ['south_item', item.id, 'UPDATE', beforeUpdate, afterUpdate, 'updaterUser']);
   });
 
   it('should save and find item with historian fields', () => {

--- a/backend/src/repository/config/south-connector.repository.ts
+++ b/backend/src/repository/config/south-connector.repository.ts
@@ -10,10 +10,13 @@ import {
 import { SouthItemSettings, SouthSettings } from '../../../shared/model/south-settings.model';
 import { OIBusSouthType, SouthConnectorItemSearchParam, SouthHistoryRecoveryStrategy } from '../../../shared/model/south-connector.model';
 import { Page } from '../../../shared/model/types';
+import { OIBusObjectAttribute } from '../../../shared/model/form.model';
 import { ScanMode } from '../../model/scan-mode.model';
 import { scanModeAliasedColumns, scanModeColumns, toScanMode, toScanModeFromPrefixedRow } from './scan-mode.repository';
 import SouthItemGroupRepository from './south-item-group.repository';
 import AuditService from '../../service/audit.service';
+import { encryptionService } from '../../service/encryption.service';
+import { southManifestList } from '../../service/south-manifests';
 
 const SOUTH_CONNECTORS_TABLE = 'south_connectors';
 const SOUTH_ITEMS_TABLE = 'south_items';
@@ -179,7 +182,7 @@ export default class SouthConnectorRepository {
               'south_item',
               removedItemId,
               'DELETE',
-              removedItem as unknown as Record<string, unknown>,
+              this.redactItem(removedItem, south.type),
               null,
               south.updatedBy
             );
@@ -238,7 +241,7 @@ export default class SouthConnectorRepository {
               item.updatedBy
             );
             const created = this.findItemById(south.id, item.id);
-            this.auditService.record('south_item', item.id, 'CREATE', null, created as unknown as Record<string, unknown>, item.updatedBy);
+            this.auditService.record('south_item', item.id, 'CREATE', null, this.redactItem(created, south.type), item.updatedBy);
           } else {
             const existing = existingItemsById.get(item.id);
             const hasChanged =
@@ -273,8 +276,8 @@ export default class SouthConnectorRepository {
                 'south_item',
                 item.id,
                 'UPDATE',
-                (beforeItemsById.get(item.id) ?? null) as unknown as Record<string, unknown> | null,
-                after as unknown as Record<string, unknown>,
+                this.redactItem(beforeItemsById.get(item.id) ?? null, south.type),
+                this.redactItem(after, south.type),
                 item.updatedBy
               );
             }
@@ -296,14 +299,7 @@ export default class SouthConnectorRepository {
           .run(south.id);
         this.database.prepare(`DELETE FROM ${SOUTH_ITEMS_TABLE} WHERE connector_id = ?;`).run(south.id);
         for (const [removedItemId, removedItem] of beforeItemsById) {
-          this.auditService.record(
-            'south_item',
-            removedItemId,
-            'DELETE',
-            removedItem as unknown as Record<string, unknown>,
-            null,
-            south.updatedBy
-          );
+          this.auditService.record('south_item', removedItemId, 'DELETE', this.redactItem(removedItem, south.type), null, south.updatedBy);
         }
       }
 
@@ -325,8 +321,8 @@ export default class SouthConnectorRepository {
         'south_connector',
         south.id,
         isNewConnector ? 'CREATE' : 'UPDATE',
-        beforeConnector as unknown as Record<string, unknown> | null,
-        afterConnector as unknown as Record<string, unknown>,
+        this.redactConnector(beforeConnector),
+        this.redactConnector(afterConnector),
         south.updatedBy
       );
     });
@@ -351,12 +347,12 @@ export default class SouthConnectorRepository {
       this.database.prepare(`DELETE FROM ${SOUTH_CONNECTORS_TABLE} WHERE id = ?;`).run(id);
       if (before) {
         for (const item of before.items) {
-          this.auditService.record('south_item', item.id, 'DELETE', item as unknown as Record<string, unknown>, null, deletedBy);
+          this.auditService.record('south_item', item.id, 'DELETE', this.redactItem(item, before.type), null, deletedBy);
         }
         for (const group of before.groups) {
           this.auditService.record('south_item_group', group.id, 'DELETE', group as unknown as Record<string, unknown>, null, deletedBy);
         }
-        this.auditService.record('south_connector', id, 'DELETE', before as unknown as Record<string, unknown>, null, deletedBy);
+        this.auditService.record('south_connector', id, 'DELETE', this.redactConnector(before), null, deletedBy);
       }
     });
     transaction();
@@ -488,6 +484,7 @@ export default class SouthConnectorRepository {
   saveItem(southConnectorId: string, southItem: SouthConnectorItemEntity<SouthItemSettings>): void {
     const wasNew = !southItem.id;
     const before = wasNew ? null : this.findItemById(southConnectorId, southItem.id);
+    const southType = this.findSouthById(southConnectorId)?.type;
     if (!southItem.id) {
       southItem.id = generateRandomId(6);
       const insertQuery =
@@ -542,8 +539,8 @@ export default class SouthConnectorRepository {
       'south_item',
       southItem.id,
       wasNew ? 'CREATE' : 'UPDATE',
-      before as unknown as Record<string, unknown> | null,
-      after as unknown as Record<string, unknown>,
+      southType ? this.redactItem(before, southType) : (before as unknown as Record<string, unknown> | null),
+      southType ? this.redactItem(after, southType) : (after as unknown as Record<string, unknown>),
       southItem.updatedBy
     );
   }
@@ -567,6 +564,7 @@ export default class SouthConnectorRepository {
 
   deleteItem(southId: string, id: string, deletedBy: string): void {
     const before = this.findItemById(southId, id);
+    const southType = this.findSouthById(southId)?.type;
     const transaction = this.database.transaction(() => {
       this.database
         .prepare(
@@ -578,7 +576,14 @@ export default class SouthConnectorRepository {
         .run(southId, id);
       this.database.prepare(`DELETE FROM ${SOUTH_ITEMS_TABLE} WHERE connector_id = ? AND id = ?;`).run(southId, id);
       if (before) {
-        this.auditService.record('south_item', id, 'DELETE', before as unknown as Record<string, unknown>, null, deletedBy);
+        this.auditService.record(
+          'south_item',
+          id,
+          'DELETE',
+          southType ? this.redactItem(before, southType) : (before as unknown as Record<string, unknown>),
+          null,
+          deletedBy
+        );
       }
     });
     transaction();
@@ -586,6 +591,7 @@ export default class SouthConnectorRepository {
 
   deleteAllItemsBySouth(southId: string, deletedBy: string): void {
     const beforeItems = this.findAllItemsForSouth(southId);
+    const southType = this.findSouthById(southId)?.type;
     const transaction = this.database.transaction(() => {
       this.database
         .prepare(
@@ -597,7 +603,14 @@ export default class SouthConnectorRepository {
         .run(southId);
       this.database.prepare(`DELETE FROM ${SOUTH_ITEMS_TABLE} WHERE connector_id = ?;`).run(southId);
       for (const item of beforeItems) {
-        this.auditService.record('south_item', item.id, 'DELETE', item as unknown as Record<string, unknown>, null, deletedBy);
+        this.auditService.record(
+          'south_item',
+          item.id,
+          'DELETE',
+          southType ? this.redactItem(item, southType) : (item as unknown as Record<string, unknown>),
+          null,
+          deletedBy
+        );
       }
     });
     transaction();
@@ -650,6 +663,33 @@ export default class SouthConnectorRepository {
       .prepare<[string], Record<string, string | number>>(query)
       .all(southId)
       .map(result => toSouthItemGroupLight(result));
+  }
+
+  /**
+   * Returns a shallow copy of the south connector with its settings' secret fields redacted, using the
+   * same manifest-driven filtering applied before exposing the connector to the frontend (see
+   * toSouthConnectorDTO in south-connector-dto.utils.ts), so real secrets never end up persisted in the
+   * audit trail.
+   */
+  private redactConnector(entity: SouthConnectorEntity<SouthSettings, SouthItemSettings> | null): Record<string, unknown> | null {
+    if (!entity) return null;
+    const manifest = southManifestList.find(element => element.id === entity.type);
+    if (!manifest) return entity as unknown as Record<string, unknown>;
+    return { ...entity, settings: encryptionService.filterSecrets(entity.settings, manifest.settings) };
+  }
+
+  /**
+   * Returns a shallow copy of the south item with its settings' secret fields redacted, using the
+   * same item-level manifest lookup as toSouthConnectorItemDTO in south-connector-dto.utils.ts.
+   */
+  private redactItem(entity: SouthConnectorItemEntity<SouthItemSettings> | null, southType: string): Record<string, unknown> | null {
+    if (!entity) return null;
+    const manifest = southManifestList.find(element => element.id === southType);
+    if (!manifest) return entity as unknown as Record<string, unknown>;
+    const itemSettingsManifest = manifest.items.rootAttribute.attributes.find(attribute => attribute.key === 'settings') as
+      OIBusObjectAttribute | undefined;
+    if (!itemSettingsManifest) return entity as unknown as Record<string, unknown>;
+    return { ...entity, settings: encryptionService.filterSecrets(entity.settings, itemSettingsManifest) };
   }
 
   private toSouthConnector(result: Record<string, string | number>): SouthConnectorEntity<SouthSettings, SouthItemSettings> {

--- a/backend/src/repository/config/south-connector.repository.ts
+++ b/backend/src/repository/config/south-connector.repository.ts
@@ -13,6 +13,7 @@ import { Page } from '../../../shared/model/types';
 import { ScanMode } from '../../model/scan-mode.model';
 import { scanModeAliasedColumns, scanModeColumns, toScanMode, toScanModeFromPrefixedRow } from './scan-mode.repository';
 import SouthItemGroupRepository from './south-item-group.repository';
+import AuditService from '../../service/audit.service';
 
 const SOUTH_CONNECTORS_TABLE = 'south_connectors';
 const SOUTH_ITEMS_TABLE = 'south_items';
@@ -46,8 +47,11 @@ const ITEM_JOIN_FROM =
 export default class SouthConnectorRepository {
   private groupRepository: SouthItemGroupRepository;
 
-  constructor(private readonly database: Database) {
-    this.groupRepository = new SouthItemGroupRepository(database);
+  constructor(
+    private readonly database: Database,
+    private readonly auditService: AuditService
+  ) {
+    this.groupRepository = new SouthItemGroupRepository(database, auditService);
   }
 
   findAllSouth(): Array<SouthConnectorEntityLight> {
@@ -72,6 +76,11 @@ export default class SouthConnectorRepository {
   }
 
   saveSouth(south: SouthConnectorEntity<SouthSettings, SouthItemSettings>): void {
+    const isNewConnector = !south.id;
+    const beforeConnector = south.id ? this.findSouthById(south.id) : null;
+    const beforeItemsById = south.id
+      ? new Map(this.findAllItemsForSouth(south.id).map(i => [i.id, i]))
+      : new Map<string, SouthConnectorItemEntity<SouthItemSettings>>();
     const transaction = this.database.transaction(() => {
       if (!south.id) {
         south.id = generateRandomId(6);
@@ -119,20 +128,19 @@ export default class SouthConnectorRepository {
       }
 
       // Update existing groups (name, scan mode, history settings may have changed via the connector edit form)
-      const updateGroupStmt = this.database.prepare(
-        `UPDATE ${SOUTH_ITEM_GROUPS_TABLE} SET name = ?, scan_mode_id = ?, start_time_offset = ?, end_time_offset = ?, max_read_interval = ?, read_delay = ?, recovery_strategy = ?, updated_by = ?, updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now') WHERE id = ?;`
-      );
       for (const group of south.groups.filter(g => g.id && !g.id.startsWith('temp_'))) {
-        updateGroupStmt.run(
-          group.name,
-          group.scanMode?.id ?? null,
-          group.startTimeOffset ?? null,
-          group.endTimeOffset ?? null,
-          group.maxReadInterval ?? null,
-          group.readDelay ?? null,
-          group.recoveryStrategy ?? null,
-          south.updatedBy,
-          group.id
+        this.groupRepository.update(
+          group.id,
+          {
+            name: group.name,
+            scanMode: group.scanMode,
+            startTimeOffset: group.startTimeOffset,
+            endTimeOffset: group.endTimeOffset,
+            maxReadInterval: group.maxReadInterval,
+            readDelay: group.readDelay,
+            recoveryStrategy: group.recoveryStrategy
+          },
+          south.updatedBy
         );
       }
 
@@ -163,6 +171,21 @@ export default class SouthConnectorRepository {
             south.id,
             south.items.filter(item => item.id).map(item => item.id)
           );
+
+        const incomingItemIds = new Set(south.items.filter(item => item.id).map(item => item.id));
+        for (const [removedItemId, removedItem] of beforeItemsById) {
+          if (!incomingItemIds.has(removedItemId)) {
+            this.auditService.record(
+              'south_item',
+              removedItemId,
+              'DELETE',
+              removedItem as unknown as Record<string, unknown>,
+              null,
+              south.updatedBy
+            );
+          }
+        }
+
         const insert = this.database.prepare(
           `INSERT INTO ${SOUTH_ITEMS_TABLE} (id, name, enabled, connector_id, scan_mode_id, settings, sync_with_group, max_read_interval, read_delay, start_time_offset, end_time_offset, recovery_strategy, created_by, updated_by, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, strftime('%Y-%m-%dT%H:%M:%SZ', 'now'), strftime('%Y-%m-%dT%H:%M:%SZ', 'now'));`
         );
@@ -214,6 +237,8 @@ export default class SouthConnectorRepository {
               item.createdBy,
               item.updatedBy
             );
+            const created = this.findItemById(south.id, item.id);
+            this.auditService.record('south_item', item.id, 'CREATE', null, created as unknown as Record<string, unknown>, item.updatedBy);
           } else {
             const existing = existingItemsById.get(item.id);
             const hasChanged =
@@ -243,6 +268,15 @@ export default class SouthConnectorRepository {
                 item.updatedBy,
                 item.id
               );
+              const after = this.findItemById(south.id, item.id);
+              this.auditService.record(
+                'south_item',
+                item.id,
+                'UPDATE',
+                (beforeItemsById.get(item.id) ?? null) as unknown as Record<string, unknown> | null,
+                after as unknown as Record<string, unknown>,
+                item.updatedBy
+              );
             }
           }
           // Update groups
@@ -261,22 +295,40 @@ export default class SouthConnectorRepository {
           )
           .run(south.id);
         this.database.prepare(`DELETE FROM ${SOUTH_ITEMS_TABLE} WHERE connector_id = ?;`).run(south.id);
-      }
-      if (south.groups.length > 0) {
-        this.database
-          .prepare(
-            `DELETE FROM ${SOUTH_ITEM_GROUPS_TABLE} WHERE south_id = ? AND id NOT IN (${south.groups
-              .filter(group => group.id)
-              .map(() => '?')
-              .join(', ')});`
-          )
-          .run(
-            south.id,
-            south.groups.filter(group => group.id).map(group => group.id)
+        for (const [removedItemId, removedItem] of beforeItemsById) {
+          this.auditService.record(
+            'south_item',
+            removedItemId,
+            'DELETE',
+            removedItem as unknown as Record<string, unknown>,
+            null,
+            south.updatedBy
           );
-      } else {
-        this.database.prepare(`DELETE FROM ${SOUTH_ITEM_GROUPS_TABLE} WHERE south_id = ?;`).run(south.id);
+        }
       }
+
+      const existingGroups = this.findGroupBySouthId(south.id);
+      if (south.groups.length > 0) {
+        const incomingGroupIds = new Set(south.groups.filter(group => group.id).map(group => group.id));
+        const removedGroupIds = existingGroups.filter(group => !incomingGroupIds.has(group.id)).map(group => group.id);
+        for (const removedGroupId of removedGroupIds) {
+          this.groupRepository.delete(removedGroupId, south.updatedBy);
+        }
+      } else {
+        for (const existingGroup of existingGroups) {
+          this.groupRepository.delete(existingGroup.id, south.updatedBy);
+        }
+      }
+
+      const afterConnector = this.findSouthById(south.id);
+      this.auditService.record(
+        'south_connector',
+        south.id,
+        isNewConnector ? 'CREATE' : 'UPDATE',
+        beforeConnector as unknown as Record<string, unknown> | null,
+        afterConnector as unknown as Record<string, unknown>,
+        south.updatedBy
+      );
     });
     transaction();
   }
@@ -291,11 +343,21 @@ export default class SouthConnectorRepository {
     this.database.prepare(query).run(0, id);
   }
 
-  deleteSouth(id: string): void {
+  deleteSouth(id: string, deletedBy: string): void {
+    const before = this.findSouthById(id);
     const transaction = this.database.transaction(() => {
       this.database.prepare(`DELETE FROM ${SOUTH_ITEMS_TABLE} WHERE connector_id = ?;`).run(id);
       this.database.prepare(`DELETE FROM ${NORTH_TRANSFORMERS_TABLE} WHERE source_south_south_id = ?;`).run(id);
       this.database.prepare(`DELETE FROM ${SOUTH_CONNECTORS_TABLE} WHERE id = ?;`).run(id);
+      if (before) {
+        for (const item of before.items) {
+          this.auditService.record('south_item', item.id, 'DELETE', item as unknown as Record<string, unknown>, null, deletedBy);
+        }
+        for (const group of before.groups) {
+          this.auditService.record('south_item_group', group.id, 'DELETE', group as unknown as Record<string, unknown>, null, deletedBy);
+        }
+        this.auditService.record('south_connector', id, 'DELETE', before as unknown as Record<string, unknown>, null, deletedBy);
+      }
     });
     transaction();
   }
@@ -305,7 +367,7 @@ export default class SouthConnectorRepository {
    * scan mode / history settings (overlap, max read interval, read delay) left empty is filled in with
    * the value the item was inheriting from the group.
    */
-  deleteGroupAndUpdateItems(southId: string, group: SouthItemGroupEntity, applyHistorySettings: boolean): void {
+  deleteGroupAndUpdateItems(southId: string, group: SouthItemGroupEntity, applyHistorySettings: boolean, deletedBy: string): void {
     const items = this.findAllItemsForSouth(southId).filter(item => item.group?.id === group.id);
     const transaction = this.database.transaction(() => {
       for (const item of items) {
@@ -333,7 +395,7 @@ export default class SouthConnectorRepository {
         item.group = null;
         this.saveItem(southId, item);
       }
-      this.groupRepository.delete(group.id);
+      this.groupRepository.delete(group.id, deletedBy);
     });
     transaction();
   }
@@ -424,6 +486,8 @@ export default class SouthConnectorRepository {
   }
 
   saveItem(southConnectorId: string, southItem: SouthConnectorItemEntity<SouthItemSettings>): void {
+    const wasNew = !southItem.id;
+    const before = wasNew ? null : this.findItemById(southConnectorId, southItem.id);
     if (!southItem.id) {
       southItem.id = generateRandomId(6);
       const insertQuery =
@@ -472,16 +536,27 @@ export default class SouthConnectorRepository {
       const insertGroup = this.database.prepare(`INSERT INTO ${GROUP_ITEMS_TABLE} (group_id, item_id) VALUES (?, ?);`);
       insertGroup.run(southItem.group.id, southItem.id);
     }
+
+    const after = this.findItemById(southConnectorId, southItem.id);
+    this.auditService.record(
+      'south_item',
+      southItem.id,
+      wasNew ? 'CREATE' : 'UPDATE',
+      before as unknown as Record<string, unknown> | null,
+      after as unknown as Record<string, unknown>,
+      southItem.updatedBy
+    );
   }
 
   saveAllItems(
     southConnectorId: string,
     southItems: Array<SouthConnectorItemEntity<SouthItemSettings>>,
-    deleteItemsNotPresent: boolean
+    deleteItemsNotPresent: boolean,
+    deletedBy: string
   ): void {
     const transaction = this.database.transaction(() => {
       if (deleteItemsNotPresent) {
-        this.deleteAllItemsBySouth(southConnectorId);
+        this.deleteAllItemsBySouth(southConnectorId, deletedBy);
       }
       for (const item of southItems) {
         this.saveItem(southConnectorId, item);
@@ -490,7 +565,8 @@ export default class SouthConnectorRepository {
     transaction();
   }
 
-  deleteItem(southId: string, id: string): void {
+  deleteItem(southId: string, id: string, deletedBy: string): void {
+    const before = this.findItemById(southId, id);
     const transaction = this.database.transaction(() => {
       this.database
         .prepare(
@@ -501,11 +577,15 @@ export default class SouthConnectorRepository {
         )
         .run(southId, id);
       this.database.prepare(`DELETE FROM ${SOUTH_ITEMS_TABLE} WHERE connector_id = ? AND id = ?;`).run(southId, id);
+      if (before) {
+        this.auditService.record('south_item', id, 'DELETE', before as unknown as Record<string, unknown>, null, deletedBy);
+      }
     });
     transaction();
   }
 
-  deleteAllItemsBySouth(southId: string): void {
+  deleteAllItemsBySouth(southId: string, deletedBy: string): void {
+    const beforeItems = this.findAllItemsForSouth(southId);
     const transaction = this.database.transaction(() => {
       this.database
         .prepare(
@@ -516,6 +596,9 @@ export default class SouthConnectorRepository {
         )
         .run(southId);
       this.database.prepare(`DELETE FROM ${SOUTH_ITEMS_TABLE} WHERE connector_id = ?;`).run(southId);
+      for (const item of beforeItems) {
+        this.auditService.record('south_item', item.id, 'DELETE', item as unknown as Record<string, unknown>, null, deletedBy);
+      }
     });
     transaction();
   }

--- a/backend/src/repository/config/south-item-group.repository.spec.ts
+++ b/backend/src/repository/config/south-item-group.repository.spec.ts
@@ -3,9 +3,10 @@ import assert from 'node:assert/strict';
 import { mock } from 'node:test';
 import { Database } from 'better-sqlite3';
 import SouthItemGroupRepository, { toSouthItemGroup } from './south-item-group.repository';
-import { emptyDatabase, initDatabase } from '../../tests/utils/test-utils';
+import { createAuditServiceMock, emptyDatabase, initDatabase } from '../../tests/utils/test-utils';
 import testData from '../../tests/utils/test-data';
 import { SouthItemGroupCommand } from '../../model/south-connector.model';
+import AuditService from '../../service/audit.service';
 
 const TEST_DB_PATH = 'src/tests/test-config-south-item-group.db';
 
@@ -22,9 +23,11 @@ describe('South Item Group Repository', () => {
 
   describe('South item group operations', () => {
     let repository: SouthItemGroupRepository;
+    let auditService: AuditService;
 
     beforeEach(() => {
-      repository = new SouthItemGroupRepository(database);
+      auditService = createAuditServiceMock();
+      repository = new SouthItemGroupRepository(database, auditService);
     });
 
     it('should find a group by id', () => {
@@ -145,6 +148,10 @@ describe('South Item Group Repository', () => {
       assert.strictEqual(created.southId, testData.south.list[0].id);
       assert.strictEqual(created.scanMode.id, testData.scanMode.list[0].id);
       assert.strictEqual(created.startTimeOffset, 5);
+
+      const recordMock = auditService.record as unknown as ReturnType<typeof mock.fn>;
+      assert.strictEqual(recordMock.mock.calls.length, 1);
+      assert.deepStrictEqual(recordMock.mock.calls[0].arguments, ['south_item_group', created.id, 'CREATE', null, created, 'userTest']);
     });
 
     it('should create a group with custom id', () => {
@@ -211,6 +218,7 @@ describe('South Item Group Repository', () => {
         readDelay: 0
       };
 
+      const before = repository.findById(created.id);
       repository.update(created.id, updateCommand, 'userTest');
 
       const updated = repository.findById(created.id);
@@ -219,6 +227,10 @@ describe('South Item Group Repository', () => {
       assert.strictEqual(updated.scanMode.id, testData.scanMode.list[1].id);
       assert.strictEqual(updated.startTimeOffset, 15);
       assert.strictEqual(updated.southId, testData.south.list[0].id);
+
+      const recordMock = auditService.record as unknown as ReturnType<typeof mock.fn>;
+      assert.strictEqual(recordMock.mock.calls.length, 2); // create + update
+      assert.deepStrictEqual(recordMock.mock.calls[1].arguments, ['south_item_group', created.id, 'UPDATE', before, updated, 'userTest']);
     });
 
     it('should update a group with null startTimeOffset', () => {
@@ -264,8 +276,12 @@ describe('South Item Group Repository', () => {
       const created = repository.create(groupToCreate, 'userTest');
       assert.ok(repository.findById(created.id));
 
-      repository.delete(created.id);
+      repository.delete(created.id, 'userTest');
       assert.strictEqual(repository.findById(created.id), null);
+
+      const recordMock = auditService.record as unknown as ReturnType<typeof mock.fn>;
+      assert.strictEqual(recordMock.mock.calls.length, 2); // create + delete
+      assert.deepStrictEqual(recordMock.mock.calls[1].arguments, ['south_item_group', created.id, 'DELETE', created, null, 'userTest']);
     });
 
     it('should convert database result to SouthItemGroupEntity', () => {

--- a/backend/src/repository/config/south-item-group.repository.ts
+++ b/backend/src/repository/config/south-item-group.repository.ts
@@ -4,6 +4,7 @@ import { SouthItemGroupCommand, SouthItemGroupEntity } from '../../model/south-c
 import { ScanMode } from '../../model/scan-mode.model';
 import { SouthHistoryRecoveryStrategy } from '../../../shared/model/south-connector.model';
 import { scanModeAliasedColumns, toScanModeFromPrefixedRow } from './scan-mode.repository';
+import AuditService from '../../service/audit.service';
 
 const SOUTH_ITEM_GROUPS_TABLE = 'south_item_groups';
 const SOUTH_ITEMS_TABLE = 'south_items';
@@ -14,7 +15,10 @@ const SCAN_MODE_TABLE = 'scan_modes';
  * Repository used for south item groups
  */
 export default class SouthItemGroupRepository {
-  constructor(private readonly database: Database) {}
+  constructor(
+    private readonly database: Database,
+    private readonly auditService: AuditService
+  ) {}
 
   findById(id: string): SouthItemGroupEntity | null {
     const query =
@@ -69,10 +73,12 @@ export default class SouthItemGroupRepository {
     if (!created) {
       throw new Error(`Failed to create south item group with id ${id}`);
     }
+    this.auditService.record('south_item_group', created.id, 'CREATE', null, created as unknown as Record<string, unknown>, createdBy);
     return created;
   }
 
   update(id: string, command: Omit<SouthItemGroupCommand, 'southId'>, updatedBy: string): void {
+    const before = this.findById(id);
     const query = `UPDATE ${SOUTH_ITEM_GROUPS_TABLE}
       SET name = ?, scan_mode_id = ?, start_time_offset = ?, end_time_offset = ?, max_read_interval = ?, read_delay = ?, recovery_strategy = ?, updated_by = ?, updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
       WHERE id = ?;`;
@@ -89,11 +95,24 @@ export default class SouthItemGroupRepository {
         updatedBy,
         id
       );
+    const after = this.findById(id);
+    this.auditService.record(
+      'south_item_group',
+      id,
+      'UPDATE',
+      before as unknown as Record<string, unknown> | null,
+      after as unknown as Record<string, unknown>,
+      updatedBy
+    );
   }
 
-  delete(id: string): void {
+  delete(id: string, deletedBy: string): void {
+    const before = this.findById(id);
     // Delete the group (cascade in group_items is handled by foreign key)
     this.database.prepare(`DELETE FROM ${SOUTH_ITEM_GROUPS_TABLE} WHERE id = ?;`).run(id);
+    if (before) {
+      this.auditService.record('south_item_group', id, 'DELETE', before as unknown as Record<string, unknown>, null, deletedBy);
+    }
   }
 
   findAllItemsForGroup(groupId: string): Array<Record<string, string>> {

--- a/backend/src/repository/config/transformer.repository.spec.ts
+++ b/backend/src/repository/config/transformer.repository.spec.ts
@@ -1,7 +1,9 @@
 import { before, after, beforeEach, describe, it } from 'node:test';
 import assert from 'node:assert/strict';
+import { mock } from 'node:test';
 import { Database } from 'better-sqlite3';
-import { emptyDatabase, initDatabase, stripAuditFields } from '../../tests/utils/test-utils';
+import AuditService from '../../service/audit.service';
+import { createAuditServiceMock, emptyDatabase, initDatabase, stripAuditFields } from '../../tests/utils/test-utils';
 import testData from '../../tests/utils/test-data';
 import TransformerRepository from './transformer.repository';
 import { CustomTransformer, StandardTransformer } from '../../model/transformer.model';
@@ -111,10 +113,12 @@ describe('TransformerRepository', () => {
   });
 
   let repository: TransformerRepository;
+  let auditService: AuditService;
   let createdTransformerId: string;
 
   beforeEach(() => {
-    repository = new TransformerRepository(database);
+    auditService = createAuditServiceMock();
+    repository = new TransformerRepository(database, auditService);
   });
 
   it('should properly find all transformers', () => {
@@ -150,10 +154,21 @@ describe('TransformerRepository', () => {
     createdTransformerId = createTransformer.id;
     assert.ok(createdTransformerId);
 
-    const found = stripAuditFields(repository.findById(createdTransformerId));
+    const found = repository.findById(createdTransformerId);
     assert.ok(found);
     assert.strictEqual(found.inputType, createTransformer.inputType);
     assert.strictEqual(found.outputType, createTransformer.outputType);
+
+    const recordMock = auditService.record as unknown as ReturnType<typeof mock.fn>;
+    assert.strictEqual(recordMock.mock.calls.length, 1);
+    assert.deepStrictEqual(recordMock.mock.calls[0].arguments, [
+      'transformer',
+      createdTransformerId,
+      'CREATE',
+      null,
+      found,
+      (found as CustomTransformer).createdBy
+    ]);
   });
 
   it('should update a transformer', () => {
@@ -168,11 +183,27 @@ describe('TransformerRepository', () => {
     const result = repository.findById(updateTransformer.id)!;
     assert.strictEqual((result as CustomTransformer).name, 'new name updated');
     assert.strictEqual((result as CustomTransformer).description, 'new description updated');
+
+    const recordMock = auditService.record as unknown as ReturnType<typeof mock.fn>;
+    assert.strictEqual(recordMock.mock.calls.length, 1);
+    assert.deepStrictEqual(recordMock.mock.calls[0].arguments, [
+      'transformer',
+      updateTransformer.id,
+      'UPDATE',
+      existing,
+      result,
+      updateTransformer.updatedBy
+    ]);
   });
 
   it('should delete transformer', () => {
-    repository.delete(createdTransformerId);
+    const before = repository.findById(createdTransformerId);
+    repository.delete(createdTransformerId, 'userTest');
     assert.strictEqual(repository.findById(createdTransformerId), null);
+
+    const recordMock = auditService.record as unknown as ReturnType<typeof mock.fn>;
+    assert.strictEqual(recordMock.mock.calls.length, 1);
+    assert.deepStrictEqual(recordMock.mock.calls[0].arguments, ['transformer', createdTransformerId, 'DELETE', before, null, 'userTest']);
   });
 
   it('should properly search transformers with search params and page them', () => {
@@ -216,7 +247,7 @@ describe('TransformerRepository', () => {
   });
 
   it('should skip creating standard transformers that already exist', () => {
-    const secondRepo = new TransformerRepository(database);
+    const secondRepo = new TransformerRepository(database, createAuditServiceMock());
     const all = secondRepo.list().filter(t => t.type === 'standard');
     assert.strictEqual(all.length, 16);
     // Explicitly pin the last standard transformer registered by createStandardTransformers()
@@ -230,7 +261,7 @@ describe('TransformerRepository', () => {
   it('should create all standard transformers when none exist', () => {
     // Remove all standard transformers to force createStandardTransformers() to insert them all
     database.prepare("DELETE FROM transformers WHERE type = 'standard'").run();
-    const freshRepo = new TransformerRepository(database);
+    const freshRepo = new TransformerRepository(database, createAuditServiceMock());
     const standardTransformers = freshRepo.list().filter(t => t.type === 'standard');
     assert.strictEqual(standardTransformers.length, 16);
     // Explicitly pin the last standard transformer registered by createStandardTransformers()
@@ -246,12 +277,12 @@ describe('TransformerRepository', () => {
     // And re-constructing once more against the now fully-populated table should skip it again,
     // covering the false branch of that same last if-check without disturbing other tests' state.
     database.prepare('DELETE FROM transformers WHERE function_name = ?').run(OIBusSetpointToOPCUATransformer.transformerName);
-    const repoMissingLastOne = new TransformerRepository(database);
+    const repoMissingLastOne = new TransformerRepository(database, createAuditServiceMock());
     const recreated = repoMissingLastOne
       .list()
       .filter(t => t.type === 'standard' && (t as StandardTransformer).functionName === OIBusSetpointToOPCUATransformer.transformerName);
     assert.strictEqual(recreated.length, 1);
-    const repoWithAllPresent = new TransformerRepository(database);
+    const repoWithAllPresent = new TransformerRepository(database, createAuditServiceMock());
     const stillOne = repoWithAllPresent
       .list()
       .filter(t => t.type === 'standard' && (t as StandardTransformer).functionName === OIBusSetpointToOPCUATransformer.transformerName);

--- a/backend/src/repository/config/transformer.repository.ts
+++ b/backend/src/repository/config/transformer.repository.ts
@@ -20,12 +20,16 @@ import RecordListToCsvTransformer from '../../transformers/any/record-list-to-cs
 import JSONToOIAnalyticsTransformer from '../../transformers/any/json-to-oianalytics/json-to-oianalytics-transformer';
 import CSVToMQTTTransformer from '../../transformers/any/csv-to-mqtt/csv-to-mqtt-transformer';
 import CSVToTimeValuesTransformer from '../../transformers/any/csv-to-time-values/csv-to-time-values-transformer';
+import AuditService from '../../service/audit.service';
 
 const TRANSFORMERS_TABLE = 'transformers';
 const PAGE_SIZE = 10;
 
 export default class TransformerRepository {
-  constructor(private readonly database: Database) {
+  constructor(
+    private readonly database: Database,
+    private readonly auditService: AuditService
+  ) {
     this.createStandardTransformers();
   }
 
@@ -56,7 +60,17 @@ export default class TransformerRepository {
           transformer.createdBy,
           transformer.updatedBy
         );
+      const created = this.findById(transformer.id);
+      this.auditService.record(
+        'transformer',
+        transformer.id,
+        'CREATE',
+        null,
+        created as unknown as Record<string, unknown>,
+        transformer.createdBy
+      );
     } else {
+      const before = this.findById(transformer.id);
       this.database
         .prepare(
           `UPDATE ${TRANSFORMERS_TABLE} SET name = ?, description = ?, custom_manifest = ?, custom_code = ?, language = ?, timeout = ?, updated_by = ?, updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now') WHERE id = ?`
@@ -71,11 +85,24 @@ export default class TransformerRepository {
           transformer.updatedBy,
           transformer.id
         );
+      const after = this.findById(transformer.id);
+      this.auditService.record(
+        'transformer',
+        transformer.id,
+        'UPDATE',
+        before as unknown as Record<string, unknown>,
+        after as unknown as Record<string, unknown>,
+        transformer.updatedBy
+      );
     }
   }
 
-  delete(id: string): void {
+  delete(id: string, deletedBy: string): void {
+    const before = this.findById(id);
     this.database.prepare(`DELETE FROM ${TRANSFORMERS_TABLE} WHERE id = ?`).run(id);
+    if (before) {
+      this.auditService.record('transformer', id, 'DELETE', before as unknown as Record<string, unknown>, null, deletedBy);
+    }
   }
 
   findById(id: string): Transformer | null {

--- a/backend/src/repository/config/user.repository.spec.ts
+++ b/backend/src/repository/config/user.repository.spec.ts
@@ -2,12 +2,13 @@ import { before, after, beforeEach, afterEach, describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { mock } from 'node:test';
 import { Database } from 'better-sqlite3';
-import { emptyDatabase, flushPromises, initDatabase, stripAuditFields } from '../../tests/utils/test-utils';
+import { createAuditServiceMock, emptyDatabase, flushPromises, initDatabase, stripAuditFields } from '../../tests/utils/test-utils';
 import testData from '../../tests/utils/test-data';
 import UserRepository from './user.repository';
 import { createPageFromArray } from '../../../shared/model/types';
 import { UserCommandDTO } from '../../../shared/model/user.model';
 import argon2 from 'argon2';
+import AuditService from '../../service/audit.service';
 
 const TEST_DB_PATH = 'src/tests/test-config-user.db';
 
@@ -23,11 +24,13 @@ describe('UserRepository', () => {
   });
 
   let repository: UserRepository;
+  let auditService: AuditService;
   let createdId: string;
 
   beforeEach(() => {
     mock.method(argon2, 'hash', async (password: string) => password);
-    repository = new UserRepository(database);
+    auditService = createAuditServiceMock();
+    repository = new UserRepository(database, auditService);
   });
 
   afterEach(() => {
@@ -68,16 +71,25 @@ describe('UserRepository', () => {
     createdId = result.id;
     assert.ok(createdId);
     assert.deepStrictEqual(stripAuditFields(result), stripAuditFields({ ...testData.users.command, id: createdId }));
+
+    const recordMock = auditService.record as unknown as ReturnType<typeof mock.fn>;
+    assert.strictEqual(recordMock.mock.calls.length, 1);
+    assert.deepStrictEqual(recordMock.mock.calls[0].arguments, ['user', result.id, 'CREATE', null, result, testData.users.list[0].id]);
   });
 
   it('should update a user', async () => {
     const newCommand: UserCommandDTO = JSON.parse(JSON.stringify(testData.users.command));
     newCommand.login = 'new login';
     newCommand.timezone = 'UTC';
-    repository.update(createdId, newCommand);
+    const before = repository.findById(createdId);
+    repository.update(createdId, newCommand, 'updaterUser');
     const result = repository.findById(createdId)!;
     assert.strictEqual(result.login, newCommand.login);
     assert.strictEqual(result.timezone, newCommand.timezone);
+
+    const recordMock = auditService.record as unknown as ReturnType<typeof mock.fn>;
+    assert.strictEqual(recordMock.mock.calls.length, 1);
+    assert.deepStrictEqual(recordMock.mock.calls[0].arguments, ['user', createdId, 'UPDATE', before, result, 'updaterUser']);
 
     await repository.updatePassword(createdId, 'new password');
 
@@ -86,8 +98,13 @@ describe('UserRepository', () => {
   });
 
   it('should delete a user', () => {
-    repository.delete(testData.users.list[1].id);
+    const before = repository.findById(testData.users.list[1].id);
+    repository.delete(testData.users.list[1].id, 'deleterUser');
     assert.strictEqual(repository.findById(testData.users.list[1].id), null);
+
+    const recordMock = auditService.record as unknown as ReturnType<typeof mock.fn>;
+    assert.strictEqual(recordMock.mock.calls.length, 1);
+    assert.deepStrictEqual(recordMock.mock.calls[0].arguments, ['user', testData.users.list[1].id, 'DELETE', before, null, 'deleterUser']);
   });
 });
 
@@ -111,7 +128,7 @@ describe('UserRepository with custom default credentials', () => {
   it('should create a default user with custom login and password', async () => {
     mock.method(argon2, 'hash', async (password: string) => password);
 
-    const repository = new UserRepository(db, 'customuser', 'custompass');
+    const repository = new UserRepository(db, createAuditServiceMock(), 'customuser', 'custompass');
     await flushPromises();
 
     const users = repository.list();
@@ -123,7 +140,7 @@ describe('UserRepository with custom default credentials', () => {
   it('should not recreate the user when the same login already exists', async () => {
     mock.method(argon2, 'hash', async (password: string) => password);
 
-    new UserRepository(db, 'customuser', 'anotherpass');
+    new UserRepository(db, createAuditServiceMock(), 'customuser', 'anotherpass');
     await flushPromises();
 
     // Still only one user; createDefault is a no-op when the same login is already present

--- a/backend/src/repository/config/user.repository.ts
+++ b/backend/src/repository/config/user.repository.ts
@@ -5,6 +5,7 @@ import { generateRandomId } from '../../service/utils';
 import { Language, Page } from '../../../shared/model/types';
 import { User } from '../../model/user.model';
 import { UserCommandDTO, UserSearchParam } from '../../../shared/model/user.model';
+import AuditService from '../../service/audit.service';
 
 const USERS_TABLE = 'users';
 const PAGE_SIZE = 50;
@@ -22,6 +23,7 @@ const DEFAULT_PASSWORD = 'pass';
 export default class UserRepository {
   constructor(
     private readonly database: Database,
+    private readonly auditService: AuditService,
     defaultLogin = DEFAULT_USER.login,
     defaultPassword = DEFAULT_PASSWORD
   ) {
@@ -115,7 +117,9 @@ export default class UserRepository {
       );
 
     const query = `SELECT id, login, first_name, last_name, email, language, timezone, created_by, updated_by, created_at, updated_at FROM ${USERS_TABLE} WHERE ROWID = ?;`;
-    return this.toUser(this.database.prepare(query).get(insertResult.lastInsertRowid) as Record<string, string>);
+    const result = this.toUser(this.database.prepare(query).get(insertResult.lastInsertRowid) as Record<string, string>);
+    this.auditService.record('user', result.id, 'CREATE', null, this.toAuditableUser(result), createdBy);
+    return result;
   }
 
   async updatePassword(id: string, password: string): Promise<void> {
@@ -125,16 +129,30 @@ export default class UserRepository {
     this.database.prepare(queryUpdate).run(hash, id);
   }
 
-  update(id: string, command: UserCommandDTO): void {
+  update(id: string, command: UserCommandDTO, updatedBy: string): void {
+    const before = this.findById(id);
     const queryUpdate = `UPDATE ${USERS_TABLE} SET login = ?, first_name = ?, last_name = ?, email = ?, language = ?, timezone = ? WHERE id = ?;`;
     this.database
       .prepare(queryUpdate)
       .run(command.login, command.firstName, command.lastName, command.email, command.language, command.timezone, id);
+    const after = this.findById(id);
+    this.auditService.record(
+      'user',
+      id,
+      'UPDATE',
+      before ? this.toAuditableUser(before) : null,
+      after ? this.toAuditableUser(after) : null,
+      updatedBy
+    );
   }
 
-  delete(id: string): void {
+  delete(id: string, deletedBy: string): void {
+    const before = this.findById(id);
     const query = `DELETE FROM ${USERS_TABLE} WHERE id = ?;`;
     this.database.prepare(query).run(id);
+    if (before) {
+      this.auditService.record('user', id, 'DELETE', this.toAuditableUser(before), null, deletedBy);
+    }
   }
 
   protected createDefault(login: string, password: string): void {
@@ -147,6 +165,14 @@ export default class UserRepository {
     this.create({ ...DEFAULT_USER, login }, password, 'system').catch(err => {
       console.error(err.message);
     });
+  }
+
+  /**
+   * Returns the User object as-is for the audit trail. The password hash is never included here since
+   * `User`/`toUser()` never select or expose the `password` column in the first place.
+   */
+  private toAuditableUser(user: User): Record<string, unknown> {
+    return user as unknown as Record<string, unknown>;
   }
 
   private toUser(result: Record<string, string>): User {

--- a/backend/src/service/audit-cleanup.service.spec.ts
+++ b/backend/src/service/audit-cleanup.service.spec.ts
@@ -1,0 +1,126 @@
+import { describe, it, beforeEach, afterEach, mock } from 'node:test';
+import assert from 'node:assert/strict';
+import { DateTime } from 'luxon';
+import testData from '../tests/utils/test-data';
+import AuditCleanupService from './audit-cleanup.service';
+import AuditRepositoryMock from '../tests/__mocks__/repository/config/audit-repository.mock';
+import EngineRepositoryMock from '../tests/__mocks__/repository/config/engine-repository.mock';
+import { EngineSettings } from '../model/engine.model';
+
+describe('AuditCleanupService', () => {
+  let service: AuditCleanupService;
+  let auditRepository: AuditRepositoryMock;
+  let engineRepository: EngineRepositoryMock;
+
+  beforeEach(() => {
+    auditRepository = new AuditRepositoryMock();
+    engineRepository = new EngineRepositoryMock();
+
+    mock.timers.enable({ apis: ['Date', 'setInterval'], now: new Date(testData.constants.dates.FAKE_NOW).getTime() });
+
+    service = new AuditCleanupService(auditRepository, engineRepository);
+  });
+
+  afterEach(() => {
+    mock.restoreAll();
+    mock.timers.reset();
+  });
+
+  describe('cleanup()', () => {
+    it('should do nothing when engine settings are missing', () => {
+      engineRepository.get.mock.mockImplementationOnce(() => null);
+
+      service.cleanup();
+
+      assert.strictEqual(auditRepository.deleteOlderThan.mock.calls.length, 0);
+    });
+
+    it('should do nothing when auditRetentionDuration is null', () => {
+      engineRepository.get.mock.mockImplementationOnce(
+        () => ({ ...testData.engine.settings, auditRetentionDuration: null }) as EngineSettings
+      );
+
+      service.cleanup();
+
+      assert.strictEqual(auditRepository.deleteOlderThan.mock.calls.length, 0);
+    });
+
+    it('should do nothing when auditRetentionDuration is 0', () => {
+      engineRepository.get.mock.mockImplementationOnce(
+        () => ({ ...testData.engine.settings, auditRetentionDuration: 0 }) as EngineSettings
+      );
+
+      service.cleanup();
+
+      assert.strictEqual(auditRepository.deleteOlderThan.mock.calls.length, 0);
+    });
+
+    it('should do nothing when auditRetentionDuration is negative', () => {
+      engineRepository.get.mock.mockImplementationOnce(
+        () => ({ ...testData.engine.settings, auditRetentionDuration: -1 }) as EngineSettings
+      );
+
+      service.cleanup();
+
+      assert.strictEqual(auditRepository.deleteOlderThan.mock.calls.length, 0);
+    });
+
+    it('should prune audit logs older than the configured retention duration', () => {
+      engineRepository.get.mock.mockImplementationOnce(
+        () => ({ ...testData.engine.settings, auditRetentionDuration: 90 }) as EngineSettings
+      );
+
+      service.cleanup();
+
+      assert.strictEqual(auditRepository.deleteOlderThan.mock.calls.length, 1);
+      const expectedCutoff = DateTime.now().minus({ days: 90 }).toUTC().toISO();
+      assert.strictEqual(auditRepository.deleteOlderThan.mock.calls[0].arguments[0], expectedCutoff);
+    });
+  });
+
+  describe('start()/stop()', () => {
+    it('should run cleanup immediately and on each interval tick', async () => {
+      const cleanupSpy = mock.method(service, 'cleanup', () => undefined);
+      const clearIntervalSpy = mock.method(global, 'clearInterval', mock.fn());
+
+      await service.start();
+      assert.strictEqual(cleanupSpy.mock.calls.length, 1);
+
+      mock.timers.tick(3600 * 1000);
+      assert.strictEqual(cleanupSpy.mock.calls.length, 2);
+
+      mock.timers.tick(3600 * 1000);
+      assert.strictEqual(cleanupSpy.mock.calls.length, 3);
+
+      service.stop();
+      assert.strictEqual(clearIntervalSpy.mock.calls.length, 1);
+    });
+
+    it('should be a no-op when stop() is called twice', async () => {
+      const cleanupSpy = mock.method(service, 'cleanup', () => undefined);
+
+      await service.start();
+      assert.strictEqual(cleanupSpy.mock.calls.length, 1);
+
+      service.stop();
+      service.stop();
+
+      mock.timers.tick(3600 * 1000);
+      // interval was cleared, so cleanup should not run again
+      assert.strictEqual(cleanupSpy.mock.calls.length, 1);
+    });
+
+    it('should restart the interval cleanly when start() is called again', async () => {
+      const cleanupSpy = mock.method(service, 'cleanup', () => undefined);
+
+      await service.start();
+      await service.start();
+
+      mock.timers.tick(3600 * 1000);
+      // Only one interval should be active: 2 immediate runs (one per start()) + 1 tick
+      assert.strictEqual(cleanupSpy.mock.calls.length, 3);
+
+      service.stop();
+    });
+  });
+});

--- a/backend/src/service/audit-cleanup.service.ts
+++ b/backend/src/service/audit-cleanup.service.ts
@@ -1,0 +1,42 @@
+import { DateTime } from 'luxon';
+import AuditRepository from '../repository/config/audit.repository';
+import EngineRepository from '../repository/config/engine.repository';
+
+const CLEAN_UP_INTERVAL = 3600 * 1000; // Every hour, matching CleanupService's cadence
+
+/**
+ * Prunes audit log rows older than the configured retention duration (in days), on an hourly
+ * interval. A `null`/`0`/negative retention duration means "keep forever" and disables pruning.
+ */
+export default class AuditCleanupService {
+  private cleanUpInterval: NodeJS.Timeout | null = null;
+
+  constructor(
+    private readonly auditRepository: AuditRepository,
+    private readonly engineRepository: EngineRepository
+  ) {}
+
+  start(): Promise<void> {
+    this.cleanup();
+    this.stop();
+    this.cleanUpInterval = setInterval(this.cleanup.bind(this), CLEAN_UP_INTERVAL);
+    return Promise.resolve();
+  }
+
+  stop(): void {
+    if (this.cleanUpInterval) {
+      clearInterval(this.cleanUpInterval);
+      this.cleanUpInterval = null;
+    }
+  }
+
+  cleanup(): void {
+    const settings = this.engineRepository.get();
+    const retentionDays = settings?.auditRetentionDuration;
+    if (!retentionDays || retentionDays <= 0) {
+      return;
+    }
+    const cutoff = DateTime.now().minus({ days: retentionDays }).toUTC().toISO()!;
+    this.auditRepository.deleteOlderThan(cutoff);
+  }
+}

--- a/backend/src/service/audit.service.spec.ts
+++ b/backend/src/service/audit.service.spec.ts
@@ -1,0 +1,123 @@
+import { beforeEach, afterEach, describe, it, mock } from 'node:test';
+import assert from 'node:assert/strict';
+import AuditService from './audit.service';
+import AuditRepository from '../repository/config/audit.repository';
+import { AuditLog } from '../model/audit.model';
+
+let auditRepository: { record: ReturnType<typeof mock.fn>; search: ReturnType<typeof mock.fn>; findByEntity: ReturnType<typeof mock.fn> };
+let service: AuditService;
+
+describe('Audit Service', () => {
+  beforeEach(() => {
+    auditRepository = {
+      record: mock.fn(),
+      search: mock.fn(),
+      findByEntity: mock.fn()
+    };
+    service = new AuditService(auditRepository as unknown as AuditRepository);
+  });
+
+  afterEach(() => {
+    mock.restoreAll();
+  });
+
+  it('should record an audit log and strip bookkeeping fields from both entities', () => {
+    const previousEntity = {
+      id: 'id1',
+      createdAt: '2020-01-01T00:00:00.000Z',
+      createdBy: 'user1',
+      updatedAt: '2020-01-02T00:00:00.000Z',
+      updatedBy: 'user1',
+      name: 'old name',
+      port: 502
+    };
+    const newEntity = {
+      id: 'id1',
+      createdAt: '2020-01-01T00:00:00.000Z',
+      createdBy: 'user1',
+      updatedAt: '2020-01-03T00:00:00.000Z',
+      updatedBy: 'user2',
+      name: 'new name',
+      port: 503
+    };
+
+    service.record('south_connector', 'id1', 'UPDATE', previousEntity, newEntity, 'user2');
+
+    assert.strictEqual(auditRepository.record.mock.calls.length, 1);
+    assert.deepStrictEqual(auditRepository.record.mock.calls[0].arguments, [
+      'south_connector',
+      'id1',
+      'UPDATE',
+      { name: 'old name', port: 502 },
+      { name: 'new name', port: 503 },
+      'user2'
+    ]);
+  });
+
+  it('should not call the repository when the userId is "system"', () => {
+    service.record('south_connector', 'id1', 'CREATE', null, { name: 'my south' }, 'system');
+
+    assert.strictEqual(auditRepository.record.mock.calls.length, 0);
+  });
+
+  it('should call the repository when the userId is "oianalytics"', () => {
+    service.record('south_connector', 'id1', 'CREATE', null, { name: 'my south' }, 'oianalytics');
+
+    assert.strictEqual(auditRepository.record.mock.calls.length, 1);
+    assert.deepStrictEqual(auditRepository.record.mock.calls[0].arguments, [
+      'south_connector',
+      'id1',
+      'CREATE',
+      null,
+      { name: 'my south' },
+      'oianalytics'
+    ]);
+  });
+
+  it('should handle a null previous entity (CREATE) without throwing', () => {
+    service.record('south_connector', 'id1', 'CREATE', null, { name: 'my south' }, 'user1');
+
+    assert.deepStrictEqual(auditRepository.record.mock.calls[0].arguments, [
+      'south_connector',
+      'id1',
+      'CREATE',
+      null,
+      { name: 'my south' },
+      'user1'
+    ]);
+  });
+
+  it('should handle a null new entity (DELETE) without throwing', () => {
+    service.record('south_connector', 'id1', 'DELETE', { name: 'my south' }, null, 'user1');
+
+    assert.deepStrictEqual(auditRepository.record.mock.calls[0].arguments, [
+      'south_connector',
+      'id1',
+      'DELETE',
+      { name: 'my south' },
+      null,
+      'user1'
+    ]);
+  });
+
+  it('should pass search through to the repository', () => {
+    const expectedResult = { content: [] as Array<AuditLog>, size: 50, number: 0, totalElements: 0, totalPages: 0 };
+    auditRepository.search.mock.mockImplementationOnce(() => expectedResult);
+
+    const searchParams = { entityType: 'south_connector' as const, page: 0 };
+    const result = service.search(searchParams);
+
+    assert.deepStrictEqual(auditRepository.search.mock.calls[0].arguments, [searchParams]);
+    assert.strictEqual(result, expectedResult);
+  });
+
+  it('should pass findByEntity through to the repository', () => {
+    const expectedResult: Array<AuditLog> = [];
+    auditRepository.findByEntity.mock.mockImplementationOnce(() => expectedResult);
+
+    const result = service.findByEntity('south_connector', 'id1');
+
+    assert.deepStrictEqual(auditRepository.findByEntity.mock.calls[0].arguments, ['south_connector', 'id1']);
+    assert.strictEqual(result, expectedResult);
+  });
+});

--- a/backend/src/service/audit.service.ts
+++ b/backend/src/service/audit.service.ts
@@ -1,0 +1,41 @@
+import AuditRepository from '../repository/config/audit.repository';
+import { AuditAction, AuditEntityType, AuditLog, AuditSearchParam } from '../model/audit.model';
+import { Page } from '../../shared/model/types';
+
+const BOOKKEEPING_FIELDS = ['id', 'createdAt', 'createdBy', 'updatedAt', 'updatedBy'] as const;
+// 'system' is the only non-real-user sentinel used for created_by/updated_by across the codebase
+// (bootstrap/migrations, see user.repository.ts, scan-mode.repository.ts, engine.repository.ts,
+// oianalytics-message.repository.ts, oianalytics-registration.repository.ts). 'oianalytics' is a
+// genuine actor (changes pushed from OIAnalytics) and must remain auditable.
+const NON_AUDITABLE_USER_IDS = new Set(['system']);
+
+function strip(entity: Record<string, unknown> | null): Record<string, unknown> | null {
+  if (!entity) return null;
+  const clone = { ...entity };
+  for (const field of BOOKKEEPING_FIELDS) delete clone[field];
+  return clone;
+}
+
+export default class AuditService {
+  constructor(private readonly auditRepository: AuditRepository) {}
+
+  record(
+    entityType: AuditEntityType,
+    entityId: string,
+    action: AuditAction,
+    previousEntity: Record<string, unknown> | null,
+    newEntity: Record<string, unknown> | null,
+    userId: string
+  ): void {
+    if (NON_AUDITABLE_USER_IDS.has(userId)) return;
+    this.auditRepository.record(entityType, entityId, action, strip(previousEntity), strip(newEntity), userId);
+  }
+
+  search(searchParams: AuditSearchParam): Page<AuditLog> {
+    return this.auditRepository.search(searchParams);
+  }
+
+  findByEntity(entityType: AuditEntityType, entityId: string): Array<AuditLog> {
+    return this.auditRepository.findByEntity(entityType, entityId);
+  }
+}

--- a/backend/src/service/certificate.service.spec.ts
+++ b/backend/src/service/certificate.service.spec.ts
@@ -175,10 +175,10 @@ describe('Certificate Service', () => {
   it('should delete a certificate', async () => {
     certificateRepository.findById.mock.mockImplementationOnce(() => testData.certificates.list[0]);
 
-    await service.delete(testData.certificates.list[0].id);
+    await service.delete(testData.certificates.list[0].id, 'userTest');
 
     assert.deepStrictEqual(certificateRepository.findById.mock.calls[0].arguments, [testData.certificates.list[0].id]);
-    assert.deepStrictEqual(certificateRepository.delete.mock.calls[0].arguments, [testData.certificates.list[0].id]);
+    assert.deepStrictEqual(certificateRepository.delete.mock.calls[0].arguments, [testData.certificates.list[0].id, 'userTest']);
   });
 
   it('should import a certificate without a CA chain', async () => {

--- a/backend/src/service/certificate.service.ts
+++ b/backend/src/service/certificate.service.ts
@@ -163,9 +163,9 @@ export default class CertificateService {
     return content;
   }
 
-  delete(certificateId: string): void {
+  delete(certificateId: string, userId: string): void {
     const certificate = this.findById(certificateId);
-    this.certificateRepository.delete(certificate.id);
+    this.certificateRepository.delete(certificate.id, userId);
     this.oIAnalyticsMessageService.createFullConfigMessageIfNotPending();
   }
 }

--- a/backend/src/service/history-query.service.spec.ts
+++ b/backend/src/service/history-query.service.spec.ts
@@ -408,10 +408,10 @@ describe('History Query service', () => {
   });
 
   it('should delete history query', async () => {
-    await service.delete(testData.historyQueries.list[0].id);
+    await service.delete(testData.historyQueries.list[0].id, 'userTest');
 
     assert.deepStrictEqual(engine.deleteHistoryQuery.mock.calls[0].arguments, [testData.historyQueries.list[0]]);
-    assert.deepStrictEqual(historyQueryRepository.deleteHistory.mock.calls[0].arguments, [testData.historyQueries.list[0].id]);
+    assert.deepStrictEqual(historyQueryRepository.deleteHistory.mock.calls[0].arguments, [testData.historyQueries.list[0].id, 'userTest']);
     assert.deepStrictEqual(historyQueryMetricsRepository.removeMetrics.mock.calls[0].arguments, [testData.historyQueries.list[0].id]);
     assert.strictEqual(oIAnalyticsMessageService.createFullHistoryQueriesMessageIfNotPending.mock.calls.length, 1);
   });
@@ -720,7 +720,7 @@ describe('History Query service', () => {
   });
 
   it('should delete an item', async () => {
-    await service.deleteItem(testData.historyQueries.list[0].id, testData.historyQueries.list[0].items[0].id);
+    await service.deleteItem(testData.historyQueries.list[0].id, testData.historyQueries.list[0].items[0].id, 'userTest');
 
     assert.deepStrictEqual(historyQueryRepository.findItemById.mock.calls[0].arguments, [
       testData.historyQueries.list[0].id,
@@ -728,7 +728,8 @@ describe('History Query service', () => {
     ]);
     assert.deepStrictEqual(historyQueryRepository.deleteItem.mock.calls[0].arguments, [
       testData.historyQueries.list[0].id,
-      testData.historyQueries.list[0].items[0].id
+      testData.historyQueries.list[0].items[0].id,
+      'userTest'
     ]);
     assert.strictEqual(oIAnalyticsMessageService.createFullHistoryQueriesMessageIfNotPending.mock.calls.length, 1);
     assert.deepStrictEqual(engine.reloadHistoryQuery.mock.calls[0].arguments, [testData.historyQueries.list[0], false]);
@@ -745,24 +746,29 @@ describe('History Query service', () => {
       )
     );
 
-    await service.deleteItems(historyQueryId, itemIds);
+    await service.deleteItems(historyQueryId, itemIds, 'userTest');
 
     assert.deepStrictEqual(historyQueryRepository.deleteItem.mock.calls[0].arguments, [
       testData.historyQueries.list[0].id,
-      testData.historyQueries.list[0].items[0].id
+      testData.historyQueries.list[0].items[0].id,
+      'userTest'
     ]);
     assert.deepStrictEqual(historyQueryRepository.deleteItem.mock.calls[1].arguments, [
       testData.historyQueries.list[0].id,
-      testData.historyQueries.list[0].items[1].id
+      testData.historyQueries.list[0].items[1].id,
+      'userTest'
     ]);
     assert.strictEqual(oIAnalyticsMessageService.createFullHistoryQueriesMessageIfNotPending.mock.calls.length, 1);
     assert.deepStrictEqual(engine.reloadHistoryQuery.mock.calls[0].arguments, [testData.historyQueries.list[0], false]);
   });
 
   it('should delete all items', async () => {
-    await service.deleteAllItems(testData.historyQueries.list[0].id);
+    await service.deleteAllItems(testData.historyQueries.list[0].id, 'userTest');
 
-    assert.deepStrictEqual(historyQueryRepository.deleteAllItemsByHistory.mock.calls[0].arguments, [testData.historyQueries.list[0].id]);
+    assert.deepStrictEqual(historyQueryRepository.deleteAllItemsByHistory.mock.calls[0].arguments, [
+      testData.historyQueries.list[0].id,
+      'userTest'
+    ]);
     assert.strictEqual(oIAnalyticsMessageService.createFullHistoryQueriesMessageIfNotPending.mock.calls.length, 1);
     assert.deepStrictEqual(engine.reloadHistoryQuery.mock.calls[0].arguments, [testData.historyQueries.list[0], true]);
   });
@@ -935,21 +941,27 @@ describe('History Query service', () => {
       items: []
     } as HistoryTransformerWithOptions;
 
-    await service.addOrEditTransformer(testData.historyQueries.list[0].id, transformerWithOptions);
+    await service.addOrEditTransformer(testData.historyQueries.list[0].id, transformerWithOptions, 'userTest');
 
     assert.deepStrictEqual(historyQueryRepository.addOrEditTransformer.mock.calls[0].arguments, [
       testData.historyQueries.list[0].id,
-      transformerWithOptions
+      transformerWithOptions,
+      'userTest'
     ]);
     assert.strictEqual(oIAnalyticsMessageService.createFullHistoryQueriesMessageIfNotPending.mock.calls.length, 1);
     assert.deepStrictEqual(engine.stopHistoryQuery.mock.calls[0].arguments, [testData.historyQueries.list[0].id]);
   });
 
   it('should remove transformer', async () => {
-    await service.removeTransformer(testData.historyQueries.list[0].id, testData.historyQueries.list[0].northTransformers[0].id);
+    await service.removeTransformer(
+      testData.historyQueries.list[0].id,
+      testData.historyQueries.list[0].northTransformers[0].id,
+      'userTest'
+    );
 
     assert.deepStrictEqual(historyQueryRepository.removeTransformer.mock.calls[0].arguments, [
-      testData.historyQueries.list[0].northTransformers[0].id
+      testData.historyQueries.list[0].northTransformers[0].id,
+      'userTest'
     ]);
     assert.strictEqual(oIAnalyticsMessageService.createFullHistoryQueriesMessageIfNotPending.mock.calls.length, 1);
     assert.deepStrictEqual(engine.stopHistoryQuery.mock.calls[0].arguments, [testData.historyQueries.list[0].id]);

--- a/backend/src/service/history-query.service.ts
+++ b/backend/src/service/history-query.service.ts
@@ -285,10 +285,10 @@ export default class HistoryQueryService {
     await this.engine.reloadHistoryQuery(historyQuery, resetCache);
   }
 
-  async delete(historyId: string): Promise<void> {
+  async delete(historyId: string, deletedBy: string): Promise<void> {
     const historyQuery = this.findById(historyId);
     await this.engine.deleteHistoryQuery(historyQuery);
-    this.historyQueryRepository.deleteHistory(historyQuery.id);
+    this.historyQueryRepository.deleteHistory(historyQuery.id, deletedBy);
     this.logRepository.deleteLogsByScopeId('history-query', historyQuery.id);
     this.historyQueryMetricsRepository.removeMetrics(historyQuery.id);
     this.oIAnalyticsMessageService.createFullHistoryQueriesMessageIfNotPending();
@@ -516,10 +516,10 @@ export default class HistoryQueryService {
     await this.engine.reloadHistoryQuery(historyQuery, false);
   }
 
-  async deleteItem(historyId: string, itemId: string): Promise<void> {
+  async deleteItem(historyId: string, itemId: string, deletedBy: string): Promise<void> {
     const historyQuery = this.findById(historyId);
     const item = this.findItemById(historyId, itemId);
-    this.historyQueryRepository.deleteItem(historyQuery.id, item.id);
+    this.historyQueryRepository.deleteItem(historyQuery.id, item.id, deletedBy);
     this.oIAnalyticsMessageService.createFullHistoryQueriesMessageIfNotPending();
     await this.engine.reloadHistoryQuery(historyQuery, false);
   }
@@ -534,19 +534,19 @@ export default class HistoryQueryService {
     await this.engine.reloadHistoryQuery(historyQuery, false);
   }
 
-  async deleteItems(historyId: string, itemIds: Array<string>): Promise<void> {
+  async deleteItems(historyId: string, itemIds: Array<string>, deletedBy: string): Promise<void> {
     const historyQuery = this.findById(historyId);
     for (const itemId of itemIds) {
       const item = this.findItemById(historyId, itemId);
-      this.historyQueryRepository.deleteItem(historyQuery.id, item.id);
+      this.historyQueryRepository.deleteItem(historyQuery.id, item.id, deletedBy);
     }
     this.oIAnalyticsMessageService.createFullHistoryQueriesMessageIfNotPending();
     await this.engine.reloadHistoryQuery(historyQuery, false);
   }
 
-  async deleteAllItems(historyId: string): Promise<void> {
+  async deleteAllItems(historyId: string, deletedBy: string): Promise<void> {
     const historyQuery = this.findById(historyId);
-    this.historyQueryRepository.deleteAllItemsByHistory(historyId);
+    this.historyQueryRepository.deleteAllItemsByHistory(historyId, deletedBy);
     this.oIAnalyticsMessageService.createFullHistoryQueriesMessageIfNotPending();
     await this.engine.reloadHistoryQuery(historyQuery, true);
   }
@@ -640,21 +640,21 @@ export default class HistoryQueryService {
       itemsToAdd.push(historyQueryItemEntity);
     }
 
-    this.historyQueryRepository.saveAllItems(historyQuery.id, itemsToAdd, deleteItemsNotPresent);
+    this.historyQueryRepository.saveAllItems(historyQuery.id, itemsToAdd, deleteItemsNotPresent, user);
     this.oIAnalyticsMessageService.createFullHistoryQueriesMessageIfNotPending();
     await this.engine.reloadHistoryQuery(historyQuery, false);
   }
 
-  async addOrEditTransformer(historyId: string, transformerWithOptions: HistoryTransformerWithOptions): Promise<void> {
+  async addOrEditTransformer(historyId: string, transformerWithOptions: HistoryTransformerWithOptions, userId: string): Promise<void> {
     const historyQuery = this.findById(historyId);
-    this.historyQueryRepository.addOrEditTransformer(historyQuery.id, transformerWithOptions);
+    this.historyQueryRepository.addOrEditTransformer(historyQuery.id, transformerWithOptions, userId);
     this.oIAnalyticsMessageService.createFullHistoryQueriesMessageIfNotPending();
     await this.engine.stopHistoryQuery(historyQuery.id);
   }
 
-  async removeTransformer(historyId: string, historyTransformerId: string): Promise<void> {
+  async removeTransformer(historyId: string, historyTransformerId: string, userId: string): Promise<void> {
     const historyQuery = this.findById(historyId);
-    this.historyQueryRepository.removeTransformer(historyTransformerId);
+    this.historyQueryRepository.removeTransformer(historyTransformerId, userId);
     this.oIAnalyticsMessageService.createFullHistoryQueriesMessageIfNotPending();
     await this.engine.stopHistoryQuery(historyQuery.id);
   }

--- a/backend/src/service/ip-filter.service.spec.ts
+++ b/backend/src/service/ip-filter.service.spec.ts
@@ -101,17 +101,17 @@ describe('IP Filter Service', () => {
     ipFilterRepository.findById.mock.mockImplementationOnce(() => testData.ipFilters.list[0]);
     ipFilterRepository.list.mock.mockImplementationOnce(() => testData.ipFilters.list);
 
-    await service.delete(testData.ipFilters.list[0].id);
+    await service.delete(testData.ipFilters.list[0].id, 'userTest');
 
     assert.deepStrictEqual(ipFilterRepository.findById.mock.calls[0].arguments, [testData.ipFilters.list[0].id]);
-    assert.deepStrictEqual(ipFilterRepository.delete.mock.calls[0].arguments, [testData.ipFilters.list[0].id]);
+    assert.deepStrictEqual(ipFilterRepository.delete.mock.calls[0].arguments, [testData.ipFilters.list[0].id, 'userTest']);
     assert.ok(oIAnalyticsMessageService.createFullConfigMessageIfNotPending.mock.calls.length > 0);
   });
 
   it('should not delete if the IP filter is not found', () => {
     ipFilterRepository.findById.mock.mockImplementationOnce(() => null);
 
-    assert.throws(() => service.delete(testData.ipFilters.list[0].id), {
+    assert.throws(() => service.delete(testData.ipFilters.list[0].id, 'userTest'), {
       message: `IP filter "${testData.ipFilters.list[0].id}" not found`
     });
 

--- a/backend/src/service/ip-filter.service.ts
+++ b/backend/src/service/ip-filter.service.ts
@@ -51,9 +51,9 @@ export default class IPFilterService {
     this.oIAnalyticsMessageService.createFullConfigMessageIfNotPending();
   }
 
-  delete(ipFilterId: string): void {
+  delete(ipFilterId: string, userId: string): void {
     const ipFilter = this.findById(ipFilterId);
-    this.ipFilterRepository.delete(ipFilter.id);
+    this.ipFilterRepository.delete(ipFilter.id, userId);
     this.whiteListEvent.emit(
       'update-white-list',
       this.ipFilterRepository.list().map(ip => ip.address)

--- a/backend/src/service/north.service.spec.ts
+++ b/backend/src/service/north.service.spec.ts
@@ -476,10 +476,10 @@ describe('North Service', () => {
   });
 
   it('should delete a north connector', async () => {
-    await service.delete(testData.north.list[0].id);
+    await service.delete(testData.north.list[0].id, 'userTest');
 
     assert.deepStrictEqual(engine.deleteNorth.mock.calls[0].arguments, [testData.north.list[0]]);
-    assert.deepStrictEqual(northConnectorRepository.deleteNorth.mock.calls[0].arguments, [testData.north.list[0].id]);
+    assert.deepStrictEqual(northConnectorRepository.deleteNorth.mock.calls[0].arguments, [testData.north.list[0].id, 'userTest']);
     assert.deepStrictEqual(logRepository.deleteLogsByScopeId.mock.calls[0].arguments, ['north', testData.north.list[0].id]);
     assert.deepStrictEqual(northMetricsRepository.removeMetrics.mock.calls[0].arguments, [testData.north.list[0].id]);
     assert.strictEqual(oIAnalyticsMessageService.createFullConfigMessageIfNotPending.mock.calls.length, 1);
@@ -530,20 +530,24 @@ describe('North Service', () => {
       options: {},
       source: { type: 'oianalytics-setpoint' }
     } as NorthTransformerWithOptions;
-    service.addOrEditTransformer(testData.north.list[0].id, transformerWithOptions);
+    service.addOrEditTransformer(testData.north.list[0].id, transformerWithOptions, 'userTest');
 
     assert.deepStrictEqual(northConnectorRepository.addOrEditTransformer.mock.calls[0].arguments, [
       testData.north.list[0].id,
-      transformerWithOptions
+      transformerWithOptions,
+      'userTest'
     ]);
     assert.strictEqual(oIAnalyticsMessageService.createFullConfigMessageIfNotPending.mock.calls.length, 1);
     assert.deepStrictEqual(engine.updateNorthConfiguration.mock.calls[0].arguments, [testData.north.list[0].id]);
   });
 
   it('should remove transformer', () => {
-    service.removeTransformer(testData.north.list[0].id, testData.north.list[0].transformers[0].id);
+    service.removeTransformer(testData.north.list[0].id, testData.north.list[0].transformers[0].id, 'userTest');
 
-    assert.deepStrictEqual(northConnectorRepository.removeTransformer.mock.calls[0].arguments, [testData.north.list[0].transformers[0].id]);
+    assert.deepStrictEqual(northConnectorRepository.removeTransformer.mock.calls[0].arguments, [
+      testData.north.list[0].transformers[0].id,
+      'userTest'
+    ]);
     assert.strictEqual(oIAnalyticsMessageService.createFullConfigMessageIfNotPending.mock.calls.length, 1);
     assert.deepStrictEqual(engine.updateNorthConfiguration.mock.calls[0].arguments, [testData.north.list[0].id]);
   });

--- a/backend/src/service/north.service.ts
+++ b/backend/src/service/north.service.ts
@@ -163,10 +163,10 @@ export default class NorthService {
     await this.engine.reloadNorth(northEntity);
   }
 
-  async delete(northId: string) {
+  async delete(northId: string, userId: string) {
     const northConnector = this.findById(northId);
     await this.engine.deleteNorth(northConnector);
-    this.northConnectorRepository.deleteNorth(northId);
+    this.northConnectorRepository.deleteNorth(northId, userId);
     this.logRepository.deleteLogsByScopeId('north', northConnector.id);
     this.northMetricsRepository.removeMetrics(northConnector.id);
     this.oIAnalyticsMessageService.createFullConfigMessageIfNotPending();
@@ -260,16 +260,16 @@ export default class NorthService {
     return await north.testConnection();
   }
 
-  addOrEditTransformer(northId: string, transformerWithOptions: NorthTransformerWithOptions): void {
+  addOrEditTransformer(northId: string, transformerWithOptions: NorthTransformerWithOptions, userId: string): void {
     const northConnector = this.findById(northId);
-    this.northConnectorRepository.addOrEditTransformer(northConnector.id, transformerWithOptions);
+    this.northConnectorRepository.addOrEditTransformer(northConnector.id, transformerWithOptions, userId);
     this.oIAnalyticsMessageService.createFullConfigMessageIfNotPending();
     this.engine.updateNorthConfiguration(northConnector.id);
   }
 
-  removeTransformer(northId: string, northTransformerId: string): void {
+  removeTransformer(northId: string, northTransformerId: string, userId: string): void {
     const northConnector = this.findById(northId);
-    this.northConnectorRepository.removeTransformer(northTransformerId);
+    this.northConnectorRepository.removeTransformer(northTransformerId, userId);
     this.oIAnalyticsMessageService.createFullConfigMessageIfNotPending();
     this.engine.updateNorthConfiguration(northConnector.id);
   }

--- a/backend/src/service/oia/oianalytics-command.service.spec.ts
+++ b/backend/src/service/oia/oianalytics-command.service.spec.ts
@@ -1107,7 +1107,8 @@ describe('OIAnalytics Command Service', () => {
     await service.processNextCommand();
 
     assert.deepStrictEqual(scanModeService.delete.mock.calls[0].arguments, [
-      (testData.oIAnalytics.commands.oIBusList[6] as OIBusDeleteScanModeCommand).scanModeId
+      (testData.oIAnalytics.commands.oIBusList[6] as OIBusDeleteScanModeCommand).scanModeId,
+      'oianalytics'
     ]);
     assert.deepStrictEqual(oIAnalyticsCommandRepository.markAsCompleted.mock.calls[1].arguments, [
       testData.oIAnalytics.commands.oIBusList[6].id,
@@ -1122,7 +1123,8 @@ describe('OIAnalytics Command Service', () => {
     await service.processNextCommand();
 
     assert.deepStrictEqual(southService.delete.mock.calls[0].arguments, [
-      (testData.oIAnalytics.commands.oIBusList[7] as OIBusDeleteSouthConnectorCommand).southConnectorId
+      (testData.oIAnalytics.commands.oIBusList[7] as OIBusDeleteSouthConnectorCommand).southConnectorId,
+      'oianalytics'
     ]);
     assert.deepStrictEqual(oIAnalyticsCommandRepository.markAsCompleted.mock.calls[1].arguments, [
       testData.oIAnalytics.commands.oIBusList[7].id,
@@ -1137,7 +1139,8 @@ describe('OIAnalytics Command Service', () => {
     await service.processNextCommand();
 
     assert.deepStrictEqual(northService.delete.mock.calls[0].arguments, [
-      (testData.oIAnalytics.commands.oIBusList[8] as OIBusDeleteNorthConnectorCommand).northConnectorId
+      (testData.oIAnalytics.commands.oIBusList[8] as OIBusDeleteNorthConnectorCommand).northConnectorId,
+      'oianalytics'
     ]);
     assert.deepStrictEqual(oIAnalyticsCommandRepository.markAsCompleted.mock.calls[1].arguments, [
       testData.oIAnalytics.commands.oIBusList[8].id,
@@ -1625,7 +1628,7 @@ describe('OIAnalytics Command Service', () => {
 
     await service.processNextCommand();
 
-    assert.deepStrictEqual(oIAnalyticsRegistrationService.updateKeys.mock.calls[0].arguments, ['private key', 'public key']);
+    assert.deepStrictEqual(oIAnalyticsRegistrationService.updateKeys.mock.calls[0].arguments, ['private key', 'public key', 'oianalytics']);
     assert.strictEqual(oIAnalyticsMessageService.createFullConfigMessageIfNotPending.mock.calls.length, 1);
     assert.deepStrictEqual(oIAnalyticsCommandRepository.markAsCompleted.mock.calls[1].arguments, [
       testData.oIAnalytics.commands.oIBusList[12].id,
@@ -1684,7 +1687,7 @@ describe('OIAnalytics Command Service', () => {
 
     await service.processNextCommand();
 
-    assert.deepStrictEqual(ipFilterService.delete.mock.calls[0].arguments, [command.ipFilterId]);
+    assert.deepStrictEqual(ipFilterService.delete.mock.calls[0].arguments, [command.ipFilterId, 'oianalytics']);
     assert.deepStrictEqual(oIAnalyticsCommandRepository.markAsCompleted.mock.calls[1].arguments, [
       command.id,
       testData.constants.dates.FAKE_NOW,
@@ -1746,7 +1749,7 @@ describe('OIAnalytics Command Service', () => {
 
     await service.processNextCommand();
 
-    assert.deepStrictEqual(certificateService.delete.mock.calls[0].arguments, [command.certificateId]);
+    assert.deepStrictEqual(certificateService.delete.mock.calls[0].arguments, [command.certificateId, 'oianalytics']);
     assert.deepStrictEqual(oIAnalyticsCommandRepository.markAsCompleted.mock.calls[1].arguments, [
       command.id,
       testData.constants.dates.FAKE_NOW,
@@ -1929,7 +1932,7 @@ describe('OIAnalytics Command Service', () => {
 
     await service.processNextCommand();
 
-    assert.deepStrictEqual(transformerService.delete.mock.calls[0].arguments, ['transformerId1']);
+    assert.deepStrictEqual(transformerService.delete.mock.calls[0].arguments, ['transformerId1', 'oianalytics']);
     assert.deepStrictEqual(oIAnalyticsCommandRepository.markAsCompleted.mock.calls[1].arguments, [
       command.id,
       testData.constants.dates.FAKE_NOW,
@@ -2301,7 +2304,7 @@ describe('OIAnalytics Command Service', () => {
 
     await service.processNextCommand();
 
-    assert.deepStrictEqual(historyQueryService.delete.mock.calls[0].arguments, [command.historyQueryId]);
+    assert.deepStrictEqual(historyQueryService.delete.mock.calls[0].arguments, [command.historyQueryId, 'oianalytics']);
     assert.deepStrictEqual(oIAnalyticsCommandRepository.markAsCompleted.mock.calls[1].arguments, [
       command.id,
       testData.constants.dates.FAKE_NOW,

--- a/backend/src/service/oia/oianalytics-command.service.ts
+++ b/backend/src/service/oia/oianalytics-command.service.ts
@@ -109,19 +109,19 @@ import { delay, getOIBusInfo, unzip, getErrorMessage } from '../utils';
 interface ICertificateService {
   create(command: CertificateCommandDTO, createdBy: string): Promise<unknown>;
   update(certificateId: string, command: CertificateCommandDTO, updatedBy: string): Promise<void>;
-  delete(certificateId: string): void;
+  delete(certificateId: string, userId: string): void;
 }
 
 interface IIPFilterService {
   create(command: IPFilterCommandDTO, createdBy: string): Promise<IPFilter>;
   update(ipFilterId: string, command: IPFilterCommandDTO, updatedBy: string): Promise<void>;
-  delete(ipFilterId: string): void;
+  delete(ipFilterId: string, userId: string): void;
 }
 
 interface IScanModeService {
   create(command: ScanModeCommandDTO, createdBy: string): Promise<ScanMode>;
   update(scanModeId: string, command: ScanModeCommandDTO, updatedBy: string): Promise<void>;
-  delete(scanModeId: string): void;
+  delete(scanModeId: string, userId: string): void;
 }
 
 interface IOIBusService {
@@ -142,7 +142,7 @@ interface ICommandSouthService {
   findById(southId: string): SouthConnectorEntity<SouthSettings, SouthItemSettings> | null;
   create(command: SouthConnectorCommandDTO, retrieveSecretsFromSouth: string | null, createdBy: string): Promise<unknown>;
   update(southId: string, command: SouthConnectorCommandDTO, updatedBy: string): Promise<void>;
-  delete(southId: string): Promise<void>;
+  delete(southId: string, userId: string): Promise<void>;
   checkImportItems(
     southType: string,
     fileContent: string,
@@ -165,7 +165,7 @@ interface ICommandNorthService {
   listManifest(): Array<NorthConnectorManifest>;
   create(command: NorthConnectorCommandDTO, retrieveSecretsFromNorth: string | null, createdBy: string): Promise<unknown>;
   update(northId: string, command: NorthConnectorCommandDTO, updatedBy: string): Promise<void>;
-  delete(northId: string): Promise<void>;
+  delete(northId: string, userId: string): Promise<void>;
   testNorth(northId: string, northType: OIBusNorthType, settingsToTest: NorthSettings): Promise<OIBusConnectionTestResult>;
   executeSetpoint(
     northConnectorId: string,
@@ -184,7 +184,7 @@ interface ICommandHistoryQueryService {
     createdBy: string
   ): Promise<unknown>;
   update(historyId: string, command: HistoryQueryCommandDTO, resetCache: boolean, updatedBy: string): Promise<void>;
-  delete(historyId: string): Promise<void>;
+  delete(historyId: string, deletedBy: string): Promise<void>;
   checkImportItems(
     southType: string,
     fileContent: string,
@@ -220,7 +220,7 @@ interface ICommandHistoryQueryService {
 interface ICommandTransformerService {
   create(command: CustomTransformerCommandDTO, createdBy: string): Promise<unknown>;
   update(transformerId: string, command: CustomTransformerCommandDTO, updatedBy: string): Promise<void>;
-  delete(transformerId: string): Promise<void>;
+  delete(transformerId: string, userId: string): Promise<void>;
   test(command: CustomTransformerCommandDTO, testRequest: TransformerTestRequest): Promise<TransformerTestResponse>;
   testTransformer(transformerId: string, options: Record<string, unknown>, inputData: string): Promise<SouthConnectorItemTestResult>;
 }
@@ -802,7 +802,7 @@ export default class OIAnalyticsCommandService {
         format: 'pem' // Output format for the key
       }
     });
-    await this.oIAnalyticsRegistrationService.updateKeys(privateKey, publicKey);
+    await this.oIAnalyticsRegistrationService.updateKeys(privateKey, publicKey, 'oianalytics');
     this.oIAnalyticsMessageService.createFullConfigMessageIfNotPending();
     this.oIAnalyticsCommandRepository.markAsCompleted(command.id, DateTime.now().toUTC().toISO(), 'OIAnalytics keys reloaded');
   }
@@ -1033,7 +1033,7 @@ export default class OIAnalyticsCommandService {
   }
 
   private async executeDeleteScanModeCommand(command: OIBusDeleteScanModeCommand) {
-    await this.scanModeService.delete(command.scanModeId);
+    await this.scanModeService.delete(command.scanModeId, 'oianalytics');
     this.oIAnalyticsCommandRepository.markAsCompleted(command.id, DateTime.now().toUTC().toISO(), 'Scan mode deleted successfully');
   }
 
@@ -1048,7 +1048,7 @@ export default class OIAnalyticsCommandService {
   }
 
   private async executeDeleteIPFilterCommand(command: OIBusDeleteIPFilterCommand) {
-    await this.ipFilterService.delete(command.ipFilterId);
+    await this.ipFilterService.delete(command.ipFilterId, 'oianalytics');
     this.oIAnalyticsCommandRepository.markAsCompleted(command.id, DateTime.now().toUTC().toISO(), 'IP Filter deleted successfully');
   }
 
@@ -1063,7 +1063,7 @@ export default class OIAnalyticsCommandService {
   }
 
   private async executeDeleteCertificateCommand(command: OIBusDeleteCertificateCommand) {
-    await this.certificateService.delete(command.certificateId);
+    await this.certificateService.delete(command.certificateId, 'oianalytics');
     this.oIAnalyticsCommandRepository.markAsCompleted(command.id, DateTime.now().toUTC().toISO(), 'Certificate deleted successfully');
   }
 
@@ -1131,7 +1131,7 @@ export default class OIAnalyticsCommandService {
   }
 
   private async executeDeleteSouthCommand(command: OIBusDeleteSouthConnectorCommand) {
-    await this.southService.delete(command.southConnectorId);
+    await this.southService.delete(command.southConnectorId, 'oianalytics');
     this.oIAnalyticsCommandRepository.markAsCompleted(command.id, DateTime.now().toUTC().toISO(), 'South connector deleted successfully');
   }
 
@@ -1227,7 +1227,7 @@ export default class OIAnalyticsCommandService {
   }
 
   private async executeDeleteNorthCommand(command: OIBusDeleteNorthConnectorCommand) {
-    await this.northService.delete(command.northConnectorId);
+    await this.northService.delete(command.northConnectorId, 'oianalytics');
     this.oIAnalyticsCommandRepository.markAsCompleted(command.id, DateTime.now().toUTC().toISO(), 'North connector deleted successfully');
   }
 
@@ -1301,7 +1301,7 @@ export default class OIAnalyticsCommandService {
   }
 
   private async executeDeleteHistoryQueryCommand(command: OIBusDeleteHistoryQueryCommand) {
-    await this.historyQueryService.delete(command.historyQueryId);
+    await this.historyQueryService.delete(command.historyQueryId, 'oianalytics');
     this.oIAnalyticsCommandRepository.markAsCompleted(command.id, DateTime.now().toUTC().toISO(), 'History query deleted successfully');
   }
 
@@ -1411,7 +1411,7 @@ export default class OIAnalyticsCommandService {
   }
 
   private async executeDeleteCustomTransformerCommand(command: OIBusDeleteCustomTransformerCommand) {
-    await this.transformerService.delete(command.transformerId);
+    await this.transformerService.delete(command.transformerId, 'oianalytics');
     this.oIAnalyticsCommandRepository.markAsCompleted(command.id, DateTime.now().toUTC().toISO(), 'Transformer deleted successfully');
   }
 

--- a/backend/src/service/oia/oianalytics-message.service.ts
+++ b/backend/src/service/oia/oianalytics-message.service.ts
@@ -386,6 +386,7 @@ export default class OIAnalyticsMessageService {
           }
         },
         logger: {
+          auditRetentionDuration: engine.auditRetentionDuration,
           console: {
             level: engine.logger.console.level
           },

--- a/backend/src/service/oia/oianalytics-message.service.ts
+++ b/backend/src/service/oia/oianalytics-message.service.ts
@@ -365,6 +365,7 @@ export default class OIAnalyticsMessageService {
       ignoreIpFilters: info.ignoreIpFilters,
       ignoreRemoteUpdate: info.ignoreRemoteUpdate,
       settings: {
+        auditRetentionDuration: engine.auditRetentionDuration,
         general: {
           name: engine.general.name
         },

--- a/backend/src/service/oia/oianalytics-registration.service.spec.ts
+++ b/backend/src/service/oia/oianalytics-registration.service.spec.ts
@@ -317,11 +317,15 @@ describe('OIAnalytics Registration Service', () => {
   });
 
   it('should update keys', async () => {
-    await service.updateKeys('private key', 'public key');
+    await service.updateKeys('private key', 'public key', testData.users.list[0].id);
 
     assert.strictEqual(mockEncryptionService.encryptionService.encryptText.mock.calls.length, 1);
     assert.deepStrictEqual(mockEncryptionService.encryptionService.encryptText.mock.calls[0].arguments, ['private key']);
-    assert.deepStrictEqual(oIAnalyticsRegistrationRepository.updateKeys.mock.calls[0].arguments, ['private key', 'public key']);
+    assert.deepStrictEqual(oIAnalyticsRegistrationRepository.updateKeys.mock.calls[0].arguments, [
+      'private key',
+      'public key',
+      testData.users.list[0].id
+    ]);
   });
 
   it('should edit registration with proxy', async () => {

--- a/backend/src/service/oia/oianalytics-registration.service.ts
+++ b/backend/src/service/oia/oianalytics-registration.service.ts
@@ -153,8 +153,8 @@ export default class OIAnalyticsRegistrationService {
     this.registrationEvent.emit('updated');
   }
 
-  async updateKeys(privateKey: string, publicKey: string): Promise<void> {
-    this.oIAnalyticsRegistrationRepository.updateKeys(await encryptionService.encryptText(privateKey), publicKey);
+  async updateKeys(privateKey: string, publicKey: string, updatedBy: string): Promise<void> {
+    this.oIAnalyticsRegistrationRepository.updateKeys(await encryptionService.encryptText(privateKey), publicKey, updatedBy);
   }
 
   async testConnection(command: RegistrationSettingsCommandDTO): Promise<void> {

--- a/backend/src/service/oibus.service.spec.ts
+++ b/backend/src/service/oibus.service.spec.ts
@@ -730,6 +730,7 @@ describe('OIBus Service', () => {
         updatedAt: engineSettings.updatedAt,
         version: engineSettings.version,
         launcherVersion: engineSettings.launcherVersion,
+        auditRetentionDuration: engineSettings.auditRetentionDuration,
         general: {
           name: engineSettings.general.name
         },

--- a/backend/src/service/oibus.service.ts
+++ b/backend/src/service/oibus.service.ts
@@ -416,6 +416,7 @@ export const toEngineSettingsDTO = (engineSettings: EngineSettings, getUserInfo:
     updatedAt: engineSettings.updatedAt,
     version: engineSettings.version,
     launcherVersion: engineSettings.launcherVersion,
+    auditRetentionDuration: engineSettings.auditRetentionDuration,
     general: {
       name: engineSettings.general.name
     },

--- a/backend/src/service/repository.service.ts
+++ b/backend/src/service/repository.service.ts
@@ -97,12 +97,7 @@ export default class RepositoryService {
     this._southConnectorRepository = new SouthConnectorRepository(this.oibusDatabase, this._auditService);
     this._southItemGroupRepository = new SouthItemGroupRepository(this.oibusDatabase, this._auditService);
     this._historyQueryRepository = new HistoryQueryRepository(this.oibusDatabase, this._auditService);
-    this._userRepository = new UserRepository(
-      this.oibusDatabase,
-      this._auditService,
-      initConfig.adminUsername,
-      initConfig.adminPassword
-    );
+    this._userRepository = new UserRepository(this.oibusDatabase, this._auditService, initConfig.adminUsername, initConfig.adminPassword);
     this._oianalyticsRegistrationRepository = new OIAnalyticsRegistrationRepository(this.oibusDatabase, this._auditService);
     this._oianalyticsCommandRepository = new OIAnalyticsCommandRepository(this.oibusDatabase);
     this._oianalyticsMessageRepository = new OIAnalyticsMessageRepository(this.oibusDatabase);

--- a/backend/src/service/repository.service.ts
+++ b/backend/src/service/repository.service.ts
@@ -21,6 +21,8 @@ import OIAnalyticsCommandRepository from '../repository/config/oianalytics-comma
 import OIAnalyticsMessageRepository from '../repository/config/oianalytics-message.repository';
 import HistoryQueryMetricsRepository from '../repository/metrics/history-query-metrics.repository';
 import TransformerRepository from '../repository/config/transformer.repository';
+import AuditRepository from '../repository/config/audit.repository';
+import AuditService from './audit.service';
 
 export default class RepositoryService {
   private readonly oibusDatabase;
@@ -29,6 +31,8 @@ export default class RepositoryService {
   private readonly cryptoDatabase;
   private readonly cacheDatabase;
 
+  private readonly _auditRepository: AuditRepository;
+  private readonly _auditService: AuditService;
   private readonly _engineRepository: EngineRepository;
   private readonly _cryptoRepository: CryptoRepository;
   private readonly _ipFilterRepository: IpFilterRepository;
@@ -76,19 +80,33 @@ export default class RepositoryService {
     this.metricsDatabase.pragma('journal_mode = WAL');
     this.metricsDatabase.pragma('synchronous = NORMAL');
 
-    this._ipFilterRepository = new IpFilterRepository(this.oibusDatabase);
-    this._scanModeRepository = new ScanModeRepository(this.oibusDatabase);
-    this._certificateRepository = new CertificateRepository(this.oibusDatabase);
-    this._engineRepository = new EngineRepository(this.oibusDatabase, launcherVersion, initConfig.port, initConfig.engineName);
-    this._northConnectorRepository = new NorthConnectorRepository(this.oibusDatabase);
-    this._southConnectorRepository = new SouthConnectorRepository(this.oibusDatabase);
-    this._southItemGroupRepository = new SouthItemGroupRepository(this.oibusDatabase);
-    this._historyQueryRepository = new HistoryQueryRepository(this.oibusDatabase);
-    this._userRepository = new UserRepository(this.oibusDatabase, initConfig.adminUsername, initConfig.adminPassword);
-    this._oianalyticsRegistrationRepository = new OIAnalyticsRegistrationRepository(this.oibusDatabase);
+    this._auditRepository = new AuditRepository(this.oibusDatabase);
+    this._auditService = new AuditService(this._auditRepository);
+
+    this._ipFilterRepository = new IpFilterRepository(this.oibusDatabase, this._auditService);
+    this._scanModeRepository = new ScanModeRepository(this.oibusDatabase, this._auditService);
+    this._certificateRepository = new CertificateRepository(this.oibusDatabase, this._auditService);
+    this._engineRepository = new EngineRepository(
+      this.oibusDatabase,
+      this._auditService,
+      launcherVersion,
+      initConfig.port,
+      initConfig.engineName
+    );
+    this._northConnectorRepository = new NorthConnectorRepository(this.oibusDatabase, this._auditService);
+    this._southConnectorRepository = new SouthConnectorRepository(this.oibusDatabase, this._auditService);
+    this._southItemGroupRepository = new SouthItemGroupRepository(this.oibusDatabase, this._auditService);
+    this._historyQueryRepository = new HistoryQueryRepository(this.oibusDatabase, this._auditService);
+    this._userRepository = new UserRepository(
+      this.oibusDatabase,
+      this._auditService,
+      initConfig.adminUsername,
+      initConfig.adminPassword
+    );
+    this._oianalyticsRegistrationRepository = new OIAnalyticsRegistrationRepository(this.oibusDatabase, this._auditService);
     this._oianalyticsCommandRepository = new OIAnalyticsCommandRepository(this.oibusDatabase);
     this._oianalyticsMessageRepository = new OIAnalyticsMessageRepository(this.oibusDatabase);
-    this._transformerRepository = new TransformerRepository(this.oibusDatabase);
+    this._transformerRepository = new TransformerRepository(this.oibusDatabase, this._auditService);
 
     this._cryptoRepository = new CryptoRepository(this.cryptoDatabase);
 
@@ -100,6 +118,14 @@ export default class RepositoryService {
     this._southMetricsRepository = new SouthConnectorMetricsRepository(this.metricsDatabase);
     this._northMetricsRepository = new NorthConnectorMetricsRepository(this.metricsDatabase);
     this._historyQueryMetricsRepository = new HistoryQueryMetricsRepository(this.metricsDatabase);
+  }
+
+  get auditRepository(): AuditRepository {
+    return this._auditRepository;
+  }
+
+  get auditService(): AuditService {
+    return this._auditService;
   }
 
   get cryptoRepository(): CryptoRepository {

--- a/backend/src/service/scan-mode.service.spec.ts
+++ b/backend/src/service/scan-mode.service.spec.ts
@@ -203,10 +203,10 @@ describe('Scan Mode Service', () => {
     };
     southConnectorRepository.findAllItemsForSouth.mock.mockImplementation(() => [mockItem]);
 
-    await service.delete(testData.scanMode.list[0].id);
+    await service.delete(testData.scanMode.list[0].id, 'userTest');
 
     assert.deepStrictEqual(scanModeRepository.findById.mock.calls[0].arguments, [testData.scanMode.list[0].id]);
-    assert.deepStrictEqual(scanModeRepository.delete.mock.calls[0].arguments, [testData.scanMode.list[0].id]);
+    assert.deepStrictEqual(scanModeRepository.delete.mock.calls[0].arguments, [testData.scanMode.list[0].id, 'userTest']);
     assert.ok(oIAnalyticsMessageService.createFullConfigMessageIfNotPending.mock.calls.length > 0);
     // The engine tears down the scan mode's shared cron
     assert.deepStrictEqual(dataStreamEngine.deleteScanMode.mock.calls[0].arguments, [testData.scanMode.list[0].id]);
@@ -215,7 +215,7 @@ describe('Scan Mode Service', () => {
   it('delete() should not delete if the scan mode is not found', () => {
     scanModeRepository.findById.mock.mockImplementationOnce(() => null);
 
-    assert.throws(() => service.delete(testData.scanMode.list[0].id), {
+    assert.throws(() => service.delete(testData.scanMode.list[0].id, 'userTest'), {
       message: `Scan mode "${testData.scanMode.list[0].id}" not found`
     });
 

--- a/backend/src/service/scan-mode.service.ts
+++ b/backend/src/service/scan-mode.service.ts
@@ -69,9 +69,9 @@ export default class ScanModeService {
     this.oIAnalyticsMessageService.createFullConfigMessageIfNotPending();
   }
 
-  delete(scanModeId: string): void {
+  delete(scanModeId: string, userId: string): void {
     const scanMode = this.findById(scanModeId);
-    this.scanModeRepository.delete(scanMode.id);
+    this.scanModeRepository.delete(scanMode.id, userId);
     this.dataStreamEngine.deleteScanMode(scanMode.id);
     this.oIAnalyticsMessageService.createFullConfigMessageIfNotPending();
   }

--- a/backend/src/service/south.service.spec.ts
+++ b/backend/src/service/south.service.spec.ts
@@ -435,10 +435,10 @@ describe('South Service', () => {
   });
 
   it('should delete a south connector', async () => {
-    await service.delete(testData.south.list[0].id);
+    await service.delete(testData.south.list[0].id, 'userTest');
 
     assert.deepStrictEqual(engine.deleteSouth.mock.calls[0].arguments, [testData.south.list[0]]);
-    assert.deepStrictEqual(southConnectorRepository.deleteSouth.mock.calls[0].arguments, [testData.south.list[0].id]);
+    assert.deepStrictEqual(southConnectorRepository.deleteSouth.mock.calls[0].arguments, [testData.south.list[0].id, 'userTest']);
     assert.deepStrictEqual(logRepository.deleteLogsByScopeId.mock.calls[0].arguments, ['south', testData.south.list[0].id]);
     assert.deepStrictEqual(southMetricsRepository.removeMetrics.mock.calls[0].arguments, [testData.south.list[0].id]);
     assert.strictEqual(oIAnalyticsMessageService.createFullConfigMessageIfNotPending.mock.calls.length, 1);
@@ -1261,7 +1261,7 @@ describe('South Service', () => {
   });
 
   it('should delete an item', async () => {
-    await service.deleteItem(testData.south.list[0].id, testData.south.list[0].items[0].id);
+    await service.deleteItem(testData.south.list[0].id, testData.south.list[0].items[0].id, 'userTest');
 
     assert.deepStrictEqual(southConnectorRepository.findItemById.mock.calls[0].arguments, [
       testData.south.list[0].id,
@@ -1269,7 +1269,8 @@ describe('South Service', () => {
     ]);
     assert.deepStrictEqual(southConnectorRepository.deleteItem.mock.calls[0].arguments, [
       testData.south.list[0].id,
-      testData.south.list[0].items[0].id
+      testData.south.list[0].items[0].id,
+      'userTest'
     ]);
     assert.strictEqual(oIAnalyticsMessageService.createFullConfigMessageIfNotPending.mock.calls.length, 1);
     assert.deepStrictEqual(engine.reloadSouthItems.mock.calls[0].arguments, [testData.south.list[0]]);
@@ -1286,24 +1287,29 @@ describe('South Service', () => {
       )
     );
 
-    await service.deleteItems(southConnectorId, itemIds);
+    await service.deleteItems(southConnectorId, itemIds, 'userTest');
 
     assert.deepStrictEqual(southConnectorRepository.deleteItem.mock.calls[0].arguments, [
       testData.south.list[0].id,
-      testData.south.list[0].items[0].id
+      testData.south.list[0].items[0].id,
+      'userTest'
     ]);
     assert.deepStrictEqual(southConnectorRepository.deleteItem.mock.calls[1].arguments, [
       testData.south.list[0].id,
-      testData.south.list[0].items[1].id
+      testData.south.list[0].items[1].id,
+      'userTest'
     ]);
     assert.strictEqual(oIAnalyticsMessageService.createFullConfigMessageIfNotPending.mock.calls.length, 1);
     assert.deepStrictEqual(engine.reloadSouthItems.mock.calls[0].arguments, [testData.south.list[0]]);
   });
 
   it('should delete all items', async () => {
-    await service.deleteAllItems(testData.south.list[0].id);
+    await service.deleteAllItems(testData.south.list[0].id, 'userTest');
 
-    assert.deepStrictEqual(southConnectorRepository.deleteAllItemsBySouth.mock.calls[0].arguments, [testData.south.list[0].id]);
+    assert.deepStrictEqual(southConnectorRepository.deleteAllItemsBySouth.mock.calls[0].arguments, [
+      testData.south.list[0].id,
+      'userTest'
+    ]);
     assert.deepStrictEqual(southCacheRepository.deleteItemsBySouth.mock.calls[0].arguments, [testData.south.list[0].id]);
     assert.strictEqual(oIAnalyticsMessageService.createFullConfigMessageIfNotPending.mock.calls.length, 1);
     assert.deepStrictEqual(engine.reloadSouthItems.mock.calls[0].arguments, [testData.south.list[0]]);
@@ -2653,11 +2659,12 @@ describe('South Service', () => {
       southItemGroupRepository.findById.mock.mockImplementation(() => groupToDelete);
       engine.reloadSouthItems.mock.mockImplementation(async () => undefined);
 
-      await service.deleteGroup(testData.south.list[0].id, 'groupToDelete');
+      await service.deleteGroup(testData.south.list[0].id, 'groupToDelete', 'userTest');
       assert.deepStrictEqual(southConnectorRepository.deleteGroupAndUpdateItems.mock.calls[0].arguments, [
         testData.south.list[0].id,
         groupToDelete,
-        false
+        false,
+        'userTest'
       ]);
       assert.deepStrictEqual(engine.reloadSouthItems.mock.calls[0].arguments, [testData.south.list[0]]);
     });
@@ -2700,7 +2707,7 @@ describe('South Service', () => {
       };
       southCacheRepository.getGroupLastValue.mock.mockImplementation(() => groupCache);
 
-      await service.deleteGroup(southConnector.id, 'groupToDelete');
+      await service.deleteGroup(southConnector.id, 'groupToDelete', 'userTest');
 
       assert.deepStrictEqual(southCacheRepository.getGroupLastValue.mock.calls[0].arguments, [southConnector.id, groupToDelete.id]);
       assert.strictEqual(southCacheRepository.saveItemLastValue.mock.calls.length, 1);
@@ -2720,7 +2727,7 @@ describe('South Service', () => {
       southItemGroupRepository.findById.mock.mockImplementation(() => null);
 
       await assert.rejects(
-        async () => service.deleteGroup(testData.south.list[0].id, 'nonExistentGroup'),
+        async () => service.deleteGroup(testData.south.list[0].id, 'nonExistentGroup', 'userTest'),
         new NotFoundError('South item group "nonExistentGroup" not found')
       );
     });
@@ -2746,7 +2753,7 @@ describe('South Service', () => {
       southItemGroupRepository.findById.mock.mockImplementation(() => groupFromDifferentSouth);
 
       await assert.rejects(
-        async () => service.deleteGroup(testData.south.list[0].id, 'groupFromOtherSouth'),
+        async () => service.deleteGroup(testData.south.list[0].id, 'groupFromOtherSouth', 'userTest'),
         new NotFoundError(`South item group "groupFromOtherSouth" does not belong to south connector "${testData.south.list[0].id}"`)
       );
     });

--- a/backend/src/service/south.service.spec.ts
+++ b/backend/src/service/south.service.spec.ts
@@ -1306,10 +1306,7 @@ describe('South Service', () => {
   it('should delete all items', async () => {
     await service.deleteAllItems(testData.south.list[0].id, 'userTest');
 
-    assert.deepStrictEqual(southConnectorRepository.deleteAllItemsBySouth.mock.calls[0].arguments, [
-      testData.south.list[0].id,
-      'userTest'
-    ]);
+    assert.deepStrictEqual(southConnectorRepository.deleteAllItemsBySouth.mock.calls[0].arguments, [testData.south.list[0].id, 'userTest']);
     assert.deepStrictEqual(southCacheRepository.deleteItemsBySouth.mock.calls[0].arguments, [testData.south.list[0].id]);
     assert.strictEqual(oIAnalyticsMessageService.createFullConfigMessageIfNotPending.mock.calls.length, 1);
     assert.deepStrictEqual(engine.reloadSouthItems.mock.calls[0].arguments, [testData.south.list[0]]);

--- a/backend/src/service/south.service.ts
+++ b/backend/src/service/south.service.ts
@@ -197,10 +197,10 @@ export default class SouthService {
     await this.engine.reloadSouth(southEntity);
   }
 
-  async delete(southId: string): Promise<void> {
+  async delete(southId: string, userId: string): Promise<void> {
     const southConnector = this.findById(southId);
     await this.engine.deleteSouth(southConnector);
-    this.southConnectorRepository.deleteSouth(southConnector.id);
+    this.southConnectorRepository.deleteSouth(southConnector.id, userId);
     this.logRepository.deleteLogsByScopeId('south', southConnector.id);
     this.southMetricsRepository.removeMetrics(southConnector.id);
     this.southCacheRepository.deleteItemsBySouth(southConnector.id);
@@ -617,10 +617,10 @@ export default class SouthService {
     await this.engine.reloadSouthItems(southConnector);
   }
 
-  async deleteItem(southId: string, itemId: string): Promise<void> {
+  async deleteItem(southId: string, itemId: string, userId: string): Promise<void> {
     const southConnector = this.findById(southId)!;
     const southItem = this.findItemById(southId, itemId);
-    this.southConnectorRepository.deleteItem(southConnector.id, southItem.id);
+    this.southConnectorRepository.deleteItem(southConnector.id, southItem.id, userId);
     this.oIAnalyticsMessageService.createFullConfigMessageIfNotPending();
     await this.engine.reloadSouthItems(southConnector);
   }
@@ -636,19 +636,19 @@ export default class SouthService {
     await this.engine.reloadSouthItems(southConnector);
   }
 
-  async deleteItems(southId: string, itemIds: Array<string>): Promise<void> {
+  async deleteItems(southId: string, itemIds: Array<string>, userId: string): Promise<void> {
     const southConnector = this.findById(southId);
     for (const itemId of itemIds) {
       const southItem = this.findItemById(southId, itemId);
-      this.southConnectorRepository.deleteItem(southConnector.id, southItem.id);
+      this.southConnectorRepository.deleteItem(southConnector.id, southItem.id, userId);
     }
     this.oIAnalyticsMessageService.createFullConfigMessageIfNotPending();
     await this.engine.reloadSouthItems(southConnector);
   }
 
-  async deleteAllItems(southId: string): Promise<void> {
+  async deleteAllItems(southId: string, userId: string): Promise<void> {
     const southConnector = this.findById(southId)!;
-    this.southConnectorRepository.deleteAllItemsBySouth(southId);
+    this.southConnectorRepository.deleteAllItemsBySouth(southId, userId);
     this.southCacheRepository.deleteItemsBySouth(southId);
     this.oIAnalyticsMessageService.createFullConfigMessageIfNotPending();
     await this.engine.reloadSouthItems(southConnector);
@@ -829,7 +829,7 @@ export default class SouthService {
       itemsToAdd.push(southItemEntity);
     }
 
-    this.southConnectorRepository.saveAllItems(southConnector.id, itemsToAdd, deleteItemsNotPresent);
+    this.southConnectorRepository.saveAllItems(southConnector.id, itemsToAdd, deleteItemsNotPresent, user);
     this.oIAnalyticsMessageService.createFullConfigMessageIfNotPending();
     await this.engine.reloadSouthItems(southConnector);
   }
@@ -920,7 +920,7 @@ export default class SouthService {
     return updated;
   }
 
-  async deleteGroup(southId: string, groupId: string): Promise<void> {
+  async deleteGroup(southId: string, groupId: string, userId: string): Promise<void> {
     const southConnector = this.findById(southId);
     const group = this.southItemGroupRepository.findById(groupId);
     if (!group) {
@@ -933,7 +933,7 @@ export default class SouthService {
     // Fetched before deleteGroupAndUpdateItems() clears item.group / item.syncWithGroup, so we still
     // know which items were synced with this group when seeding their per-item cache below.
     const affectedItems = this.southConnectorRepository.findAllItemsForSouth(southId).filter(item => item.group?.id === groupId);
-    this.southConnectorRepository.deleteGroupAndUpdateItems(southId, group, manifest.modes.history);
+    this.southConnectorRepository.deleteGroupAndUpdateItems(southId, group, manifest.modes.history, userId);
     this.carryOverGroupTrackedInstant(
       southConnector,
       affectedItems.map(item => ({ before: item, afterGroupId: null, afterSyncWithGroup: false }))

--- a/backend/src/service/transformer.service.spec.ts
+++ b/backend/src/service/transformer.service.spec.ts
@@ -344,7 +344,7 @@ describe('Transformer Service', () => {
 
     assert.strictEqual(transformerRepository.save.mock.calls.length, 1);
     assert.strictEqual(engine.removeAndReloadTransformer.mock.calls.length, 1);
-    assert.deepStrictEqual(engine.removeAndReloadTransformer.mock.calls[0].arguments, [testData.transformers.list[0].id]);
+    assert.deepStrictEqual(engine.removeAndReloadTransformer.mock.calls[0].arguments, [testData.transformers.list[0].id, 'userTest']);
     assert.strictEqual(engine.reloadTransformer.mock.calls.length, 0);
   });
 
@@ -364,21 +364,21 @@ describe('Transformer Service', () => {
   it('should delete a transformer', async () => {
     transformerRepository.findById.mock.mockImplementation(() => testData.transformers.list[0]);
 
-    await service.delete(testData.transformers.list[0].id);
+    await service.delete(testData.transformers.list[0].id, 'userTest');
 
     assert.strictEqual(transformerRepository.findById.mock.calls.length, 1);
     assert.deepStrictEqual(transformerRepository.findById.mock.calls[0].arguments, [testData.transformers.list[0].id]);
     assert.strictEqual(engine.removeAndReloadTransformer.mock.calls.length, 1);
-    assert.deepStrictEqual(engine.removeAndReloadTransformer.mock.calls[0].arguments, [testData.transformers.list[0].id]);
+    assert.deepStrictEqual(engine.removeAndReloadTransformer.mock.calls[0].arguments, [testData.transformers.list[0].id, 'userTest']);
     assert.strictEqual(transformerRepository.delete.mock.calls.length, 1);
-    assert.deepStrictEqual(transformerRepository.delete.mock.calls[0].arguments, [testData.transformers.list[0].id]);
+    assert.deepStrictEqual(transformerRepository.delete.mock.calls[0].arguments, [testData.transformers.list[0].id, 'userTest']);
   });
 
   it('should not delete if the transformer is not found', async () => {
     transformerRepository.findById.mock.mockImplementation(() => null);
 
     await assert.rejects(
-      () => service.delete(testData.transformers.list[0].id),
+      () => service.delete(testData.transformers.list[0].id, 'userTest'),
       new Error(`Transformer "${testData.transformers.list[0].id}" not found`)
     );
 
@@ -395,7 +395,7 @@ describe('Transformer Service', () => {
     transformerRepository.findById.mock.mockImplementation(() => standardTransformer);
 
     await assert.rejects(
-      () => service.delete(standardTransformer.id),
+      () => service.delete(standardTransformer.id, 'userTest'),
       new Error(`Cannot delete standard transformer "${standardTransformer.id}"`)
     );
 

--- a/backend/src/service/transformer.service.ts
+++ b/backend/src/service/transformer.service.ts
@@ -68,7 +68,7 @@ import type { ILogger } from '../model/logger.model';
 
 interface TransformerReloadEngine {
   reloadTransformer(transformerId: string): Promise<void>;
-  removeAndReloadTransformer(transformerId: string): Promise<void>;
+  removeAndReloadTransformer(transformerId: string, updatedBy: string): Promise<void>;
   logger: ILogger;
 }
 
@@ -201,19 +201,19 @@ export default class TransformerService {
     this.oIAnalyticsMessageService.createFullConfigMessageIfNotPending();
 
     if (manifestChanged) {
-      await this.engine.removeAndReloadTransformer(transformerId);
+      await this.engine.removeAndReloadTransformer(transformerId, updatedBy);
     } else if (codeChanged) {
       await this.engine.reloadTransformer(transformerId);
     }
   }
 
-  async delete(transformerId: string): Promise<void> {
+  async delete(transformerId: string, userId: string): Promise<void> {
     const transformer = this.findById(transformerId);
     if (transformer.type === 'standard') {
       throw new OIBusValidationError(`Cannot delete standard transformer "${transformerId}"`);
     }
-    await this.engine.removeAndReloadTransformer(transformerId);
-    this.transformerRepository.delete(transformerId);
+    await this.engine.removeAndReloadTransformer(transformerId, userId);
+    this.transformerRepository.delete(transformerId, userId);
     this.oIAnalyticsMessageService.createFullConfigMessageIfNotPending();
   }
 

--- a/backend/src/service/user.service.spec.ts
+++ b/backend/src/service/user.service.spec.ts
@@ -104,17 +104,21 @@ describe('User Service', () => {
   it('should update a user', async () => {
     userRepository.findById.mock.mockImplementationOnce(() => testData.users.list[0]);
 
-    await service.update(testData.users.list[0].id, testData.users.command);
+    await service.update(testData.users.list[0].id, testData.users.command, 'updaterUser');
 
     assert.deepStrictEqual(validator.validate.mock.calls[0].arguments, [userSchema, testData.users.command]);
     assert.deepStrictEqual(userRepository.findById.mock.calls[0].arguments, [testData.users.list[0].id]);
-    assert.deepStrictEqual(userRepository.update.mock.calls[0].arguments, [testData.users.list[0].id, testData.users.command]);
+    assert.deepStrictEqual(userRepository.update.mock.calls[0].arguments, [
+      testData.users.list[0].id,
+      testData.users.command,
+      'updaterUser'
+    ]);
   });
 
   it('should not update if the user is not found', async () => {
     userRepository.findById.mock.mockImplementationOnce(() => null);
 
-    await assert.rejects(() => service.update(testData.users.list[0].id, testData.users.command), {
+    await assert.rejects(() => service.update(testData.users.list[0].id, testData.users.command, 'updaterUser'), {
       message: `User "${testData.users.list[0].id}" (id) not found`
     });
 
@@ -153,16 +157,16 @@ describe('User Service', () => {
   it('should delete a user', async () => {
     userRepository.findById.mock.mockImplementationOnce(() => testData.users.list[0]);
 
-    await service.delete(testData.users.list[0].id);
+    await service.delete(testData.users.list[0].id, 'deleterUser');
 
     assert.deepStrictEqual(userRepository.findById.mock.calls[0].arguments, [testData.users.list[0].id]);
-    assert.deepStrictEqual(userRepository.delete.mock.calls[0].arguments, [testData.users.list[0].id]);
+    assert.deepStrictEqual(userRepository.delete.mock.calls[0].arguments, [testData.users.list[0].id, 'deleterUser']);
   });
 
   it('should not delete if the user is not found', () => {
     userRepository.findById.mock.mockImplementationOnce(() => null);
 
-    assert.throws(() => service.delete(testData.users.list[0].id), {
+    assert.throws(() => service.delete(testData.users.list[0].id, 'deleterUser'), {
       message: `User "${testData.users.list[0].id}" (id) not found`
     });
 

--- a/backend/src/service/user.service.ts
+++ b/backend/src/service/user.service.ts
@@ -48,10 +48,10 @@ export default class UserService {
     return await this.userRepository.create(command, password, createdBy);
   }
 
-  async update(userId: string, command: UserCommandDTO): Promise<void> {
+  async update(userId: string, command: UserCommandDTO, updatedBy: string): Promise<void> {
     const user = this.findById(userId);
     await this.validator.validate(userSchema, command);
-    this.userRepository.update(user.id, command);
+    this.userRepository.update(user.id, command, updatedBy);
   }
 
   async updatePassword(userId: string, newPassword: string | undefined): Promise<void> {
@@ -62,9 +62,9 @@ export default class UserService {
     await this.userRepository.updatePassword(user.id, newPassword);
   }
 
-  delete(userId: string): void {
+  delete(userId: string, deletedBy: string): void {
     const user = this.findById(userId);
-    this.userRepository.delete(user.id);
+    this.userRepository.delete(user.id, deletedBy);
   }
 
   getUserInfo(userId: string): UserInfo {

--- a/backend/src/tests/__mocks__/data-stream-engine.mock.ts
+++ b/backend/src/tests/__mocks__/data-stream-engine.mock.ts
@@ -93,5 +93,5 @@ export default class DataStreamEngineMock {
   updateNorthTransformerBySouth = mock.fn((_southId: string): void => undefined);
   updateNorthConfiguration = mock.fn((_northId: string): void => undefined);
   reloadTransformer = mock.fn(async (_transformerId: string): Promise<void> => undefined);
-  removeAndReloadTransformer = mock.fn(async (_transformerId: string): Promise<void> => undefined);
+  removeAndReloadTransformer = mock.fn(async (_transformerId: string, _updatedBy: string): Promise<void> => undefined);
 }

--- a/backend/src/tests/__mocks__/repository/config/audit-repository.mock.ts
+++ b/backend/src/tests/__mocks__/repository/config/audit-repository.mock.ts
@@ -1,0 +1,30 @@
+import { mock } from 'node:test';
+import type { Database } from 'better-sqlite3';
+import { AuditAction, AuditEntityType, AuditLog, AuditSearchParam } from '../../../../model/audit.model';
+import { Page } from '../../../../../shared/model/types';
+import AuditRepository from '../../../../repository/config/audit.repository';
+
+const EMPTY_PAGE: Page<AuditLog> = { content: [], size: 50, number: 0, totalElements: 0, totalPages: 0 };
+
+/**
+ * Create a mock object for Audit repository
+ */
+export default class AuditRepositoryMock extends AuditRepository {
+  constructor() {
+    super({} as Database);
+  }
+  override record = mock.fn(
+    (
+      _entityType: AuditEntityType,
+      _entityId: string,
+      _action: AuditAction,
+      _previousState: Record<string, unknown> | null,
+      _newState: Record<string, unknown> | null,
+      _userId: string,
+      _id?: string
+    ): void => undefined
+  );
+  override search = mock.fn((_searchParams: AuditSearchParam): Page<AuditLog> => EMPTY_PAGE);
+  override findByEntity = mock.fn((_entityType: AuditEntityType, _entityId: string): Array<AuditLog> => []);
+  override deleteOlderThan = mock.fn((_cutoffIso: string): void => undefined);
+}

--- a/backend/src/tests/__mocks__/repository/config/certificate-repository.mock.ts
+++ b/backend/src/tests/__mocks__/repository/config/certificate-repository.mock.ts
@@ -1,5 +1,6 @@
 import { mock } from 'node:test';
 import type { Database } from 'better-sqlite3';
+import { createAuditServiceMock } from '../../../utils/test-utils';
 import { Certificate } from '../../../../model/certificate.model';
 import CertificateRepository from '../../../../repository/config/certificate.repository';
 
@@ -8,7 +9,7 @@ import CertificateRepository from '../../../../repository/config/certificate.rep
  */
 export default class CertificateRepositoryMock extends CertificateRepository {
   constructor() {
-    super({} as Database);
+    super({} as Database, createAuditServiceMock());
   }
   override list = mock.fn((): Array<Certificate> => []);
   override findById = mock.fn((_id: string): Certificate | null => null);
@@ -17,5 +18,5 @@ export default class CertificateRepositoryMock extends CertificateRepository {
   override updateNameAndDescription = mock.fn(
     (_certificateId: string, _newName: string, _newDescription: string, _updatedBy: string): void => undefined
   );
-  override delete = mock.fn((_id: string): void => undefined);
+  override delete = mock.fn((_id: string, _deletedBy: string): void => undefined);
 }

--- a/backend/src/tests/__mocks__/repository/config/engine-repository.mock.ts
+++ b/backend/src/tests/__mocks__/repository/config/engine-repository.mock.ts
@@ -8,13 +8,14 @@ import {
   EngineWebServerCommandDTO
 } from '../../../../../shared/model/engine.model';
 import EngineRepository from '../../../../repository/config/engine.repository';
+import { createAuditServiceMock } from '../../../utils/test-utils';
 
 /**
  * Create a mock object for Engine repository
  */
 export default class EngineRepositoryMock extends EngineRepository {
   constructor() {
-    super({} as Database, '');
+    super({} as Database, createAuditServiceMock(), '');
   }
   protected override createDefault(): void {
     return;

--- a/backend/src/tests/__mocks__/repository/config/history-query-repository.mock.ts
+++ b/backend/src/tests/__mocks__/repository/config/history-query-repository.mock.ts
@@ -1,5 +1,6 @@
 import { mock } from 'node:test';
 import type { Database } from 'better-sqlite3';
+import { createAuditServiceMock } from '../../../utils/test-utils';
 import { HistoryQueryEntity, HistoryQueryEntityLight, HistoryQueryItemEntity } from '../../../../model/histor-query.model';
 import { SouthItemSettings, SouthSettings } from '../../../../../shared/model/south-settings.model';
 import { NorthSettings } from '../../../../../shared/model/north-settings.model';
@@ -13,17 +14,19 @@ import HistoryQueryRepository from '../../../../repository/config/history-query.
  */
 export default class HistoryQueryRepositoryMock extends HistoryQueryRepository {
   constructor() {
-    super({} as Database);
+    super({} as Database, createAuditServiceMock());
   }
   override findAllHistoriesLight = mock.fn((): Array<HistoryQueryEntityLight> => []);
   override findAllHistoriesFull = mock.fn((): Array<HistoryQueryEntity<SouthSettings, NorthSettings, SouthItemSettings>> => []);
   override findHistoryById = mock.fn((_id: string): HistoryQueryEntity<SouthSettings, NorthSettings, SouthItemSettings> | null => null);
   override saveHistory = mock.fn((_history: HistoryQueryEntity<SouthSettings, NorthSettings, SouthItemSettings>): void => undefined);
   override updateHistoryStatus = mock.fn((_id: string, _status: HistoryQueryStatus): void => undefined);
-  override deleteHistory = mock.fn((_id: string): void => undefined);
-  override addOrEditTransformer = mock.fn((_historyId: string, _transformerWithOptions: HistoryTransformerWithOptions): void => undefined);
-  override removeTransformer = mock.fn((_id: string): void => undefined);
-  override removeTransformersByTransformerId = mock.fn((_transformerId: string): void => undefined);
+  override deleteHistory = mock.fn((_id: string, _deletedBy: string): void => undefined);
+  override addOrEditTransformer = mock.fn(
+    (_historyId: string, _transformerWithOptions: HistoryTransformerWithOptions, _updatedBy: string): void => undefined
+  );
+  override removeTransformer = mock.fn((_id: string, _deletedBy: string): void => undefined);
+  override removeTransformersByTransformerId = mock.fn((_transformerId: string, _deletedBy: string): void => undefined);
   override searchItems = mock.fn(
     (_historyId: string, _searchParams: HistoryQueryItemSearchParam): Page<HistoryQueryItemEntity<SouthItemSettings>> => ({
       content: [],
@@ -40,10 +43,15 @@ export default class HistoryQueryRepositoryMock extends HistoryQueryRepository {
   override findItemById = mock.fn((_historyId: string, _itemId: string): HistoryQueryItemEntity<SouthItemSettings> | null => null);
   override saveItem = mock.fn((_historyId: string, _item: HistoryQueryItemEntity<SouthItemSettings>): void => undefined);
   override saveAllItems = mock.fn(
-    (_historyId: string, _items: Array<HistoryQueryItemEntity<SouthItemSettings>>, _deleteItemsNotPresent: boolean): void => undefined
+    (
+      _historyId: string,
+      _items: Array<HistoryQueryItemEntity<SouthItemSettings>>,
+      _deleteItemsNotPresent: boolean,
+      _deletedBy: string
+    ): void => undefined
   );
-  override deleteItem = mock.fn((_historyId: string, _itemId: string): void => undefined);
-  override deleteAllItemsByHistory = mock.fn((_historyId: string): void => undefined);
+  override deleteItem = mock.fn((_historyId: string, _itemId: string, _deletedBy: string): void => undefined);
+  override deleteAllItemsByHistory = mock.fn((_historyId: string, _deletedBy: string): void => undefined);
   override enableItem = mock.fn((_id: string): void => undefined);
   override disableItem = mock.fn((_id: string): void => undefined);
 }

--- a/backend/src/tests/__mocks__/repository/config/ip-filter-repository.mock.ts
+++ b/backend/src/tests/__mocks__/repository/config/ip-filter-repository.mock.ts
@@ -1,5 +1,6 @@
 import { mock } from 'node:test';
 import type { Database } from 'better-sqlite3';
+import { createAuditServiceMock } from '../../../utils/test-utils';
 import { IPFilter } from '../../../../model/ip-filter.model';
 import IpFilterRepository from '../../../../repository/config/ip-filter.repository';
 
@@ -8,7 +9,7 @@ import IpFilterRepository from '../../../../repository/config/ip-filter.reposito
  */
 export default class IpFilterRepositoryMock extends IpFilterRepository {
   constructor() {
-    super({} as Database);
+    super({} as Database, createAuditServiceMock());
   }
   override list = mock.fn((): Array<IPFilter> => []);
   override findById = mock.fn((_id: string): IPFilter | null => null);
@@ -20,5 +21,5 @@ export default class IpFilterRepositoryMock extends IpFilterRepository {
     (_id: string, _command: Omit<IPFilter, 'id' | 'createdBy' | 'updatedBy' | 'createdAt' | 'updatedAt'>, _updatedBy: string): void =>
       undefined
   );
-  override delete = mock.fn((_id: string): void => undefined);
+  override delete = mock.fn((_id: string, _deletedBy: string): void => undefined);
 }

--- a/backend/src/tests/__mocks__/repository/config/north-connector-repository.mock.ts
+++ b/backend/src/tests/__mocks__/repository/config/north-connector-repository.mock.ts
@@ -1,5 +1,6 @@
 import { mock } from 'node:test';
 import type { Database } from 'better-sqlite3';
+import { createAuditServiceMock } from '../../../utils/test-utils';
 import { NorthConnectorEntity, NorthConnectorEntityLight } from '../../../../model/north-connector.model';
 import { NorthSettings } from '../../../../../shared/model/north-settings.model';
 import { NorthTransformerWithOptions } from '../../../../model/transformer.model';
@@ -10,7 +11,7 @@ import NorthConnectorRepository from '../../../../repository/config/north-connec
  */
 export default class NorthConnectorRepositoryMock extends NorthConnectorRepository {
   constructor() {
-    super({} as Database);
+    super({} as Database, createAuditServiceMock());
   }
   override findAllNorth = mock.fn((): Array<NorthConnectorEntityLight> => []);
   override findAllNorthFull = mock.fn((): Array<NorthConnectorEntity<NorthSettings>> => []);
@@ -18,8 +19,10 @@ export default class NorthConnectorRepositoryMock extends NorthConnectorReposito
   override saveNorth = mock.fn((_north: NorthConnectorEntity<NorthSettings>): void => undefined);
   override startNorth = mock.fn((_id: string): void => undefined);
   override stopNorth = mock.fn((_id: string): void => undefined);
-  override deleteNorth = mock.fn((_id: string): void => undefined);
-  override addOrEditTransformer = mock.fn((_northId: string, _transformerWithOptions: NorthTransformerWithOptions): void => undefined);
-  override removeTransformer = mock.fn((_id: string): void => undefined);
-  override removeTransformersByTransformerId = mock.fn((_transformerId: string): void => undefined);
+  override deleteNorth = mock.fn((_id: string, _deletedBy: string): void => undefined);
+  override addOrEditTransformer = mock.fn(
+    (_northId: string, _transformerWithOptions: NorthTransformerWithOptions, _updatedBy: string): void => undefined
+  );
+  override removeTransformer = mock.fn((_id: string, _deletedBy: string): void => undefined);
+  override removeTransformersByTransformerId = mock.fn((_transformerId: string, _deletedBy: string): void => undefined);
 }

--- a/backend/src/tests/__mocks__/repository/config/oianalytics-registration-repository.mock.ts
+++ b/backend/src/tests/__mocks__/repository/config/oianalytics-registration-repository.mock.ts
@@ -1,5 +1,6 @@
 import { mock } from 'node:test';
 import type { Database } from 'better-sqlite3';
+import { createAuditServiceMock } from '../../../utils/test-utils';
 import { OIAnalyticsRegistration, OIAnalyticsRegistrationEditCommand } from '../../../../model/oianalytics-registration.model';
 import { Instant } from '../../../../../shared/model/types';
 import OIAnalyticsRegistrationRepository from '../../../../repository/config/oianalytics-registration.repository';
@@ -9,7 +10,7 @@ import OIAnalyticsRegistrationRepository from '../../../../repository/config/oia
  */
 export default class OianalyticsRegistrationRepositoryMock extends OIAnalyticsRegistrationRepository {
   constructor() {
-    super({} as Database);
+    super({} as Database, createAuditServiceMock());
   }
   protected override createDefault(): void {
     return;
@@ -27,7 +28,7 @@ export default class OianalyticsRegistrationRepositoryMock extends OIAnalyticsRe
     ): void => undefined
   );
   override update = mock.fn((_command: Omit<OIAnalyticsRegistrationEditCommand, 'host'>, _updatedBy: string): void => undefined);
-  override updateKeys = mock.fn((_privateKey: string, _publicKey: string): void => undefined);
+  override updateKeys = mock.fn((_privateKey: string, _publicKey: string, _updatedBy: string): void => undefined);
   override activate = mock.fn((_activationDate: Instant, _token: string): void => undefined);
   override unregister = mock.fn((): void => undefined);
 }

--- a/backend/src/tests/__mocks__/repository/config/scan-mode-repository.mock.ts
+++ b/backend/src/tests/__mocks__/repository/config/scan-mode-repository.mock.ts
@@ -1,5 +1,6 @@
 import { mock } from 'node:test';
 import type { Database } from 'better-sqlite3';
+import { createAuditServiceMock } from '../../../utils/test-utils';
 import { ScanMode } from '../../../../model/scan-mode.model';
 import ScanModeRepository from '../../../../repository/config/scan-mode.repository';
 
@@ -8,7 +9,7 @@ import ScanModeRepository from '../../../../repository/config/scan-mode.reposito
  */
 export default class ScanModeRepositoryMock extends ScanModeRepository {
   constructor() {
-    super({} as Database);
+    super({} as Database, createAuditServiceMock());
   }
   protected override createDefault(): void {
     return;
@@ -23,5 +24,5 @@ export default class ScanModeRepositoryMock extends ScanModeRepository {
     (_id: string, _command: Omit<ScanMode, 'id' | 'createdBy' | 'updatedBy' | 'createdAt' | 'updatedAt'>, _updatedBy: string): void =>
       undefined
   );
-  override delete = mock.fn((_id: string): void => undefined);
+  override delete = mock.fn((_id: string, _deletedBy: string): void => undefined);
 }

--- a/backend/src/tests/__mocks__/repository/config/south-connector-repository.mock.ts
+++ b/backend/src/tests/__mocks__/repository/config/south-connector-repository.mock.ts
@@ -1,5 +1,6 @@
 import { mock } from 'node:test';
 import type { Database } from 'better-sqlite3';
+import { createAuditServiceMock } from '../../../utils/test-utils';
 import {
   SouthConnectorEntity,
   SouthConnectorEntityLight,
@@ -18,14 +19,14 @@ import SouthConnectorRepository from '../../../../repository/config/south-connec
  */
 export default class SouthConnectorRepositoryMock extends SouthConnectorRepository {
   constructor() {
-    super({} as Database);
+    super({} as Database, createAuditServiceMock());
   }
   override findAllSouth = mock.fn((): Array<SouthConnectorEntityLight> => []);
   override findSouthById = mock.fn((_id: string): SouthConnectorEntity<SouthSettings, SouthItemSettings> | null => null);
   override saveSouth = mock.fn((_south: SouthConnectorEntity<SouthSettings, SouthItemSettings>): void => undefined);
   override start = mock.fn((_id: string): void => undefined);
   override stop = mock.fn((_id: string): void => undefined);
-  override deleteSouth = mock.fn((_id: string): void => undefined);
+  override deleteSouth = mock.fn((_id: string, _deletedBy: string): void => undefined);
   override listItems = mock.fn(
     (_southId: string, _searchParams: Omit<SouthConnectorItemSearchParam, 'page'>): Array<SouthConnectorItemEntity<SouthItemSettings>> => []
   );
@@ -42,16 +43,20 @@ export default class SouthConnectorRepositoryMock extends SouthConnectorReposito
   override findItemById = mock.fn((_southConnectorId: string, _itemId: string): SouthConnectorItemEntity<SouthItemSettings> | null => null);
   override saveItem = mock.fn((_southConnectorId: string, _southItem: SouthConnectorItemEntity<SouthItemSettings>): void => undefined);
   override saveAllItems = mock.fn(
-    (_southConnectorId: string, _southItems: Array<SouthConnectorItemEntity<SouthItemSettings>>, _deleteItemsNotPresent: boolean): void =>
-      undefined
+    (
+      _southConnectorId: string,
+      _southItems: Array<SouthConnectorItemEntity<SouthItemSettings>>,
+      _deleteItemsNotPresent: boolean,
+      _deletedBy: string
+    ): void => undefined
   );
-  override deleteItem = mock.fn((_southId: string, _id: string): void => undefined);
-  override deleteAllItemsBySouth = mock.fn((_southId: string): void => undefined);
+  override deleteItem = mock.fn((_southId: string, _id: string, _deletedBy: string): void => undefined);
+  override deleteAllItemsBySouth = mock.fn((_southId: string, _deletedBy: string): void => undefined);
   override enableItem = mock.fn((_id: string): void => undefined);
   override disableItem = mock.fn((_id: string): void => undefined);
   override moveItemsToGroup = mock.fn((_itemIds: Array<string>, _groupId: string | null): void => undefined);
   override deleteGroupAndUpdateItems = mock.fn(
-    (_southId: string, _group: SouthItemGroupEntity, _applyHistorySettings: boolean): void => undefined
+    (_southId: string, _group: SouthItemGroupEntity, _applyHistorySettings: boolean, _deletedBy: string): void => undefined
   );
   override findScanModeForSouth = mock.fn((_scanModeId: string): ScanMode => ({}) as ScanMode);
   override findGroupBySouthId = mock.fn((_southId: string): Array<SouthItemGroupEntityLight> => []);

--- a/backend/src/tests/__mocks__/repository/config/south-item-group-repository.mock.ts
+++ b/backend/src/tests/__mocks__/repository/config/south-item-group-repository.mock.ts
@@ -10,5 +10,5 @@ export default class SouthItemGroupRepositoryMock {
   findByNameAndSouthId = mock.fn((_name: string, _southId: string): SouthItemGroupEntity | null => null);
   create = mock.fn((_command: SouthItemGroupCommand, _createdBy: string): SouthItemGroupEntity => ({}) as SouthItemGroupEntity);
   update = mock.fn((_id: string, _command: Omit<SouthItemGroupCommand, 'southId'>, _updatedBy: string): void => undefined);
-  delete = mock.fn((_id: string): void => undefined);
+  delete = mock.fn((_id: string, _deletedBy: string): void => undefined);
 }

--- a/backend/src/tests/__mocks__/repository/config/transformer-repository.mock.ts
+++ b/backend/src/tests/__mocks__/repository/config/transformer-repository.mock.ts
@@ -1,5 +1,6 @@
 import { mock } from 'node:test';
 import type { Database } from 'better-sqlite3';
+import { createAuditServiceMock } from '../../../utils/test-utils';
 import { CustomTransformer, Transformer } from '../../../../model/transformer.model';
 import { TransformerSearchParam } from '../../../../../shared/model/transformer.model';
 import { Page } from '../../../../../shared/model/types';
@@ -10,7 +11,7 @@ import TransformerRepository from '../../../../repository/config/transformer.rep
  */
 export default class TransformerRepositoryMock extends TransformerRepository {
   constructor() {
-    super({} as Database);
+    super({} as Database, createAuditServiceMock());
   }
   protected override createStandardTransformers(): void {
     return;
@@ -25,5 +26,5 @@ export default class TransformerRepositoryMock extends TransformerRepository {
   }));
   override save = mock.fn((_transformer: CustomTransformer): void => undefined);
   override findById = mock.fn((_id: string): Transformer | null => null);
-  override delete = mock.fn((_id: string): void => undefined);
+  override delete = mock.fn((_id: string, _deletedBy: string): void => undefined);
 }

--- a/backend/src/tests/__mocks__/repository/config/user-repository.mock.ts
+++ b/backend/src/tests/__mocks__/repository/config/user-repository.mock.ts
@@ -4,13 +4,14 @@ import { User } from '../../../../model/user.model';
 import { UserCommandDTO, UserSearchParam } from '../../../../../shared/model/user.model';
 import { Page } from '../../../../../shared/model/types';
 import UserRepository from '../../../../repository/config/user.repository';
+import { createAuditServiceMock } from '../../../utils/test-utils';
 
 /**
  * Create a mock object for User repository
  */
 export default class UserRepositoryMock extends UserRepository {
   constructor() {
-    super({} as Database);
+    super({} as Database, createAuditServiceMock());
   }
   protected override createDefault(): void {
     return;
@@ -33,7 +34,7 @@ export default class UserRepositoryMock extends UserRepository {
       _createdBy: string
     ): Promise<User> => ({}) as User
   );
-  override update = mock.fn((_id: string, _command: UserCommandDTO): void => undefined);
+  override update = mock.fn((_id: string, _command: UserCommandDTO, _updatedBy: string): void => undefined);
   override updatePassword = mock.fn(async (_id: string, _password: string): Promise<void> => undefined);
-  override delete = mock.fn((_id: string): void => undefined);
+  override delete = mock.fn((_id: string, _deletedBy: string): void => undefined);
 }

--- a/backend/src/tests/__mocks__/service/audit-service.mock.ts
+++ b/backend/src/tests/__mocks__/service/audit-service.mock.ts
@@ -1,0 +1,23 @@
+import { mock } from 'node:test';
+import { AuditAction, AuditEntityType, AuditLog, AuditSearchParam } from '../../../model/audit.model';
+import { Page } from '../../../../shared/model/types';
+
+const EMPTY_PAGE: Page<AuditLog> = { content: [], size: 50, number: 0, totalElements: 0, totalPages: 0 };
+
+/**
+ * Create a mock object for Audit Service
+ */
+export default class AuditServiceMock {
+  record = mock.fn(
+    (
+      _entityType: AuditEntityType,
+      _entityId: string,
+      _action: AuditAction,
+      _previousEntity: Record<string, unknown> | null,
+      _newEntity: Record<string, unknown> | null,
+      _userId: string
+    ): void => undefined
+  );
+  search = mock.fn((_searchParams: AuditSearchParam): Page<AuditLog> => EMPTY_PAGE);
+  findByEntity = mock.fn((_entityType: AuditEntityType, _entityId: string): Array<AuditLog> => []);
+}

--- a/backend/src/tests/__mocks__/service/certificate-service.mock.ts
+++ b/backend/src/tests/__mocks__/service/certificate-service.mock.ts
@@ -22,5 +22,5 @@ export default class CertificateServiceMock {
     })
   );
   exportPrivateKey = mock.fn(async (_certificateId: string, _passphrase: string, _requestedBy: string): Promise<string> => '');
-  delete = mock.fn(async (_certificateId: string): Promise<void> => undefined);
+  delete = mock.fn(async (_certificateId: string, _userId: string): Promise<void> => undefined);
 }

--- a/backend/src/tests/__mocks__/service/history-query-service.mock.ts
+++ b/backend/src/tests/__mocks__/service/history-query-service.mock.ts
@@ -31,7 +31,7 @@ export default class HistoryQueryServiceMock {
   update = mock.fn(
     async (_historyId: string, _command: HistoryQueryCommandDTO, _resetCache: boolean, _updatedBy: string): Promise<void> => undefined
   );
-  delete = mock.fn(async (_historyId: string): Promise<void> => undefined);
+  delete = mock.fn(async (_historyId: string, _deletedBy: string): Promise<void> => undefined);
   start = mock.fn(async (_historyId: string): Promise<void> => undefined);
   pause = mock.fn(async (_historyId: string): Promise<void> => undefined);
   getHistoryDataStream = mock.fn((_historyId: string): PassThrough | null => null);
@@ -68,9 +68,9 @@ export default class HistoryQueryServiceMock {
   disableItem = mock.fn(async (_historyId: string, _itemId: string): Promise<void> => undefined);
   enableItems = mock.fn(async (_historyId: string, _itemIds: Array<string>): Promise<void> => undefined);
   disableItems = mock.fn(async (_historyId: string, _itemIds: Array<string>): Promise<void> => undefined);
-  deleteItem = mock.fn(async (_historyId: string, _itemId: string): Promise<void> => undefined);
-  deleteItems = mock.fn(async (_historyId: string, _itemIds: Array<string>): Promise<void> => undefined);
-  deleteAllItems = mock.fn(async (_historyId: string): Promise<void> => undefined);
+  deleteItem = mock.fn(async (_historyId: string, _itemId: string, _deletedBy: string): Promise<void> => undefined);
+  deleteItems = mock.fn(async (_historyId: string, _itemIds: Array<string>, _deletedBy: string): Promise<void> => undefined);
+  deleteAllItems = mock.fn(async (_historyId: string, _deletedBy: string): Promise<void> => undefined);
   checkImportItems = mock.fn(
     async (
       _southType: string,
@@ -84,8 +84,8 @@ export default class HistoryQueryServiceMock {
   );
   importItems = mock.fn(async (): Promise<void> => undefined);
   addOrEditTransformer = mock.fn(
-    async (_historyId: string, _transformerWithOptions: HistoryTransformerWithOptions): Promise<void> => undefined
+    async (_historyId: string, _transformerWithOptions: HistoryTransformerWithOptions, _userId: string): Promise<void> => undefined
   );
-  removeTransformer = mock.fn(async (_historyId: string, _historyTransformerId: string): Promise<void> => undefined);
+  removeTransformer = mock.fn(async (_historyId: string, _historyTransformerId: string, _userId: string): Promise<void> => undefined);
   retrieveSecrets = mock.fn((): HistoryQueryEntity<SouthSettings, NorthSettings, SouthItemSettings> | null => null);
 }

--- a/backend/src/tests/__mocks__/service/ip-filter-service.mock.ts
+++ b/backend/src/tests/__mocks__/service/ip-filter-service.mock.ts
@@ -11,6 +11,6 @@ export default class IpFilterServiceMock {
   findById = mock.fn((_ipFilterId: string): IPFilter => ({}) as IPFilter);
   create = mock.fn(async (_command: IPFilterCommandDTO, _createdBy: string): Promise<IPFilter> => ({}) as IPFilter);
   update = mock.fn(async (_ipFilterId: string, _command: IPFilterCommandDTO, _updatedBy: string): Promise<void> => undefined);
-  delete = mock.fn(async (_ipFilterId: string): Promise<void> => undefined);
+  delete = mock.fn(async (_ipFilterId: string, _userId: string): Promise<void> => undefined);
   whiteListEvent = new EventEmitter();
 }

--- a/backend/src/tests/__mocks__/service/north-service.mock.ts
+++ b/backend/src/tests/__mocks__/service/north-service.mock.ts
@@ -24,7 +24,7 @@ export default class NorthServiceMock {
     ): Promise<NorthConnectorEntity<NorthSettings>> => ({}) as NorthConnectorEntity<NorthSettings>
   );
   update = mock.fn(async (_northId: string, _command: NorthConnectorCommandDTO, _updatedBy: string): Promise<void> => undefined);
-  delete = mock.fn(async (_northId: string): Promise<void> => undefined);
+  delete = mock.fn(async (_northId: string, _userId: string): Promise<void> => undefined);
   start = mock.fn(async (_northId: string): Promise<void> => undefined);
   stop = mock.fn(async (_northId: string): Promise<void> => undefined);
   getNorthDataStream = mock.fn((_northId: string): PassThrough | null => null);
@@ -33,8 +33,10 @@ export default class NorthServiceMock {
     async (_northId: string, _northType: OIBusNorthType, _settingsToTest: NorthSettings): Promise<OIBusConnectionTestResult> =>
       ({ items: [] }) as unknown as OIBusConnectionTestResult
   );
-  addOrEditTransformer = mock.fn((_northId: string, _transformerWithOptions: NorthTransformerWithOptions): void => undefined);
-  removeTransformer = mock.fn((_northId: string, _northTransformerId: string): void => undefined);
+  addOrEditTransformer = mock.fn(
+    (_northId: string, _transformerWithOptions: NorthTransformerWithOptions, _userId: string): void => undefined
+  );
+  removeTransformer = mock.fn((_northId: string, _northTransformerId: string, _userId: string): void => undefined);
   checkSubscription = mock.fn((): boolean => false);
   subscribeToSouth = mock.fn((): void => undefined);
   unsubscribeFromSouth = mock.fn((): void => undefined);

--- a/backend/src/tests/__mocks__/service/oia/oianalytics-registration-service.mock.ts
+++ b/backend/src/tests/__mocks__/service/oia/oianalytics-registration-service.mock.ts
@@ -18,7 +18,7 @@ export default class OIAnalyticsRegistrationServiceMock extends OIAnalyticsRegis
   override editRegistrationSettings = mock.fn(
     async (_command: RegistrationSettingsCommandDTO, _updatedBy: string): Promise<void> => undefined
   );
-  override updateKeys = mock.fn(async (_privateKey: string, _publicKey: string): Promise<void> => undefined);
+  override updateKeys = mock.fn(async (_privateKey: string, _publicKey: string, _updatedBy: string): Promise<void> => undefined);
   override testConnection = mock.fn(async (_command: RegistrationSettingsCommandDTO): Promise<void> => undefined);
   override unregister = mock.fn((): void => undefined);
   override stop = mock.fn((): void => undefined);

--- a/backend/src/tests/__mocks__/service/scan-mode-service.mock.ts
+++ b/backend/src/tests/__mocks__/service/scan-mode-service.mock.ts
@@ -10,6 +10,6 @@ export default class ScanModeServiceMock {
   findById = mock.fn((_scanModeId: string): ScanMode => ({}) as ScanMode);
   create = mock.fn(async (_command: ScanModeCommandDTO, _createdBy: string): Promise<ScanMode> => ({}) as ScanMode);
   update = mock.fn(async (_scanModeId: string, _command: ScanModeCommandDTO, _updatedBy: string): Promise<void> => undefined);
-  delete = mock.fn(async (_scanModeId: string): Promise<void> => undefined);
+  delete = mock.fn(async (_scanModeId: string, _userId: string): Promise<void> => undefined);
   verifyCron = mock.fn(async (_command: { cron: string }): Promise<ValidatedCronExpression> => ({}) as ValidatedCronExpression);
 }

--- a/backend/src/tests/__mocks__/service/south-service.mock.ts
+++ b/backend/src/tests/__mocks__/service/south-service.mock.ts
@@ -40,7 +40,7 @@ export default class SouthServiceMock {
     ): Promise<SouthConnectorEntity<SouthSettings, SouthItemSettings>> => ({}) as SouthConnectorEntity<SouthSettings, SouthItemSettings>
   );
   update = mock.fn(async (): Promise<void> => undefined);
-  delete = mock.fn(async (_southId: string): Promise<void> => undefined);
+  delete = mock.fn(async (_southId: string, _userId: string): Promise<void> => undefined);
   start = mock.fn(async (_southId: string): Promise<void> => undefined);
   stop = mock.fn(async (_southId: string): Promise<void> => undefined);
   getSouthDataStream = mock.fn((_southId: string): PassThrough | null => null);
@@ -88,9 +88,9 @@ export default class SouthServiceMock {
   disableItem = mock.fn(async (_southId: string, _itemId: string): Promise<void> => undefined);
   enableItems = mock.fn(async (_southId: string, _itemIds: Array<string>): Promise<void> => undefined);
   disableItems = mock.fn(async (_southId: string, _itemIds: Array<string>): Promise<void> => undefined);
-  deleteItem = mock.fn(async (_southId: string, _itemId: string): Promise<void> => undefined);
-  deleteItems = mock.fn(async (_southId: string, _itemIds: Array<string>): Promise<void> => undefined);
-  deleteAllItems = mock.fn(async (_southId: string): Promise<void> => undefined);
+  deleteItem = mock.fn(async (_southId: string, _itemId: string, _userId: string): Promise<void> => undefined);
+  deleteItems = mock.fn(async (_southId: string, _itemIds: Array<string>, _userId: string): Promise<void> => undefined);
+  deleteAllItems = mock.fn(async (_southId: string, _userId: string): Promise<void> => undefined);
   getItemLastValue = mock.fn((_southId: string, _itemId: string): SouthItemLastValue => ({}) as SouthItemLastValue);
   checkImportItems = mock.fn(
     async (
@@ -119,6 +119,6 @@ export default class SouthServiceMock {
     (_southId: string, _groupId: string, _user: string, _command: SouthItemGroupCommandDTO): SouthItemGroupEntity =>
       ({}) as SouthItemGroupEntity
   );
-  deleteGroup = mock.fn(async (_southId: string, _groupId: string): Promise<void> => undefined);
+  deleteGroup = mock.fn(async (_southId: string, _groupId: string, _userId: string): Promise<void> => undefined);
   moveItemsToGroup = mock.fn(async (_southId: string, _itemIds: Array<string>, _groupId: string | null): Promise<void> => undefined);
 }

--- a/backend/src/tests/__mocks__/service/transformer-service.mock.ts
+++ b/backend/src/tests/__mocks__/service/transformer-service.mock.ts
@@ -31,7 +31,7 @@ export default class TransformerServiceMock {
     async (_command: CustomTransformerCommandDTO, _createdBy: string): Promise<CustomTransformer> => ({}) as CustomTransformer
   );
   update = mock.fn(async (_transformerId: string, _command: CustomTransformerCommandDTO, _updatedBy: string): Promise<void> => undefined);
-  delete = mock.fn(async (_transformerId: string): Promise<void> => undefined);
+  delete = mock.fn(async (_transformerId: string, _userId: string): Promise<void> => undefined);
   test = mock.fn(
     async (_command: CustomTransformerCommandDTO, _testRequest: TransformerTestRequest): Promise<TransformerTestResponse> =>
       ({}) as TransformerTestResponse

--- a/backend/src/tests/__mocks__/service/user-service.mock.ts
+++ b/backend/src/tests/__mocks__/service/user-service.mock.ts
@@ -21,7 +21,7 @@ export default class UserServiceMock {
     totalPages: 0
   }));
   create = mock.fn(async (_command: UserCommandDTO, _password: string | undefined, _createdBy: string): Promise<User> => ({}) as User);
-  update = mock.fn(async (_userId: string, _command: UserCommandDTO): Promise<void> => undefined);
+  update = mock.fn(async (_userId: string, _command: UserCommandDTO, _updatedBy: string): Promise<void> => undefined);
   updatePassword = mock.fn(async (_userId: string, _newPassword: string | undefined): Promise<void> => undefined);
-  delete = mock.fn((_userId: string): void => undefined);
+  delete = mock.fn((_userId: string, _deletedBy: string): void => undefined);
 }

--- a/backend/src/tests/utils/test-data.ts
+++ b/backend/src/tests/utils/test-data.ts
@@ -1459,6 +1459,7 @@ const engineProxyCommand: EngineProxyCommandDTO = {
   password: null
 };
 const engineLoggerCommand: EngineLoggerCommandDTO = {
+  auditRetentionDuration: 90,
   console: {
     level: 'silent'
   },

--- a/backend/src/tests/utils/test-data.ts
+++ b/backend/src/tests/utils/test-data.ts
@@ -1383,6 +1383,7 @@ const engineSettings: EngineSettings = {
   id: 'oibusId1',
   version: '3.4.9',
   launcherVersion: '3.4.9',
+  auditRetentionDuration: null,
   general: {
     name: 'OIBus'
   },
@@ -1490,6 +1491,7 @@ const engineLoggerCommand: EngineLoggerCommandDTO = {
 };
 const engineSettingsCommand: EngineSettingsCommandDTO = {
   general: { name: 'updated OIBus' },
+  auditRetentionDuration: null,
   webServer: { port: 2223, authTokenDuration: '7d' },
   proxyServer: {
     enabled: true,

--- a/backend/src/tests/utils/test-utils.ts
+++ b/backend/src/tests/utils/test-utils.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { mock } from 'node:test';
 import Database from 'better-sqlite3';
 import type { CustomExpressRequest } from '../../web-server/express';
 import CertificateServiceMock from '../__mocks__/service/certificate-service.mock';
@@ -50,6 +51,7 @@ import { BaseFolders } from '../../model/types';
 import { Transformer, TransformerSource } from '../../model/transformer.model';
 import { OIBusNorthType } from '../../../shared/model/north-connector.model';
 import { OIBusSouthType } from '../../../shared/model/south-connector.model';
+import AuditService from '../../service/audit.service';
 
 const CONFIG_TEST_DATABASE = path.resolve('src', 'tests', 'test-config.db');
 const CRYPTO_TEST_DATABASE = path.resolve('src', 'tests', 'test-crypto.db');
@@ -77,6 +79,19 @@ export function createMockServices(overrides: Record<string, unknown> = {}): Cus
     userService: new UserServiceMock() as unknown as CustomExpressRequest['services']['userService'],
     ...overrides
   } as CustomExpressRequest['services'];
+}
+
+/**
+ * Create a lightweight stub AuditService for repositories that require one as a constructor
+ * dependency but are not under test themselves. Each call returns a fresh instance so
+ * mock.fn() call assertions on `record` stay isolated between tests.
+ */
+export function createAuditServiceMock(): AuditService {
+  return {
+    record: mock.fn(),
+    search: mock.fn(),
+    findByEntity: mock.fn()
+  } as unknown as AuditService;
 }
 
 /**

--- a/backend/src/tests/utils/test-utils.ts
+++ b/backend/src/tests/utils/test-utils.ts
@@ -52,6 +52,7 @@ import { Transformer, TransformerSource } from '../../model/transformer.model';
 import { OIBusNorthType } from '../../../shared/model/north-connector.model';
 import { OIBusSouthType } from '../../../shared/model/south-connector.model';
 import AuditService from '../../service/audit.service';
+import AuditServiceMock from '../__mocks__/service/audit-service.mock';
 
 const CONFIG_TEST_DATABASE = path.resolve('src', 'tests', 'test-config.db');
 const CRYPTO_TEST_DATABASE = path.resolve('src', 'tests', 'test-crypto.db');
@@ -63,6 +64,7 @@ export const flushPromises = () => new Promise(setImmediate);
 
 export function createMockServices(overrides: Record<string, unknown> = {}): CustomExpressRequest['services'] {
   return {
+    auditService: new AuditServiceMock() as unknown as CustomExpressRequest['services']['auditService'],
     certificateService: new CertificateServiceMock() as unknown as CustomExpressRequest['services']['certificateService'],
     historyQueryService: new HistoryQueryServiceMock() as unknown as CustomExpressRequest['services']['historyQueryService'],
     ipFilterService: new IPFilterServiceMock() as unknown as CustomExpressRequest['services']['ipFilterService'],

--- a/backend/src/web-server/controllers/audit.controller.spec.ts
+++ b/backend/src/web-server/controllers/audit.controller.spec.ts
@@ -1,0 +1,119 @@
+import { describe, it, before, beforeEach, mock } from 'node:test';
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+import { CustomExpressRequest } from '../express';
+import { createMockServices, fixTsoaModuleResolution, reloadModule } from '../../tests/utils/test-utils';
+import AuditServiceMock from '../../tests/__mocks__/service/audit-service.mock';
+import { AuditSearchParam } from '../../model/audit.model';
+import { createPageFromArray } from '../../../shared/model/types';
+import type { AuditController as AuditControllerShape } from './audit.controller';
+
+const nodeRequire = createRequire(import.meta.url);
+
+let AuditController: typeof AuditControllerShape;
+
+before(() => {
+  fixTsoaModuleResolution(nodeRequire);
+  const mod = reloadModule<{ AuditController: typeof AuditControllerShape }>(nodeRequire, './audit.controller');
+  AuditController = mod.AuditController;
+});
+
+const auditLog1 = {
+  id: 'audit1',
+  entityType: 'south_connector' as const,
+  entityId: 'south1',
+  action: 'CREATE' as const,
+  previousState: null,
+  newState: { name: 'south1' },
+  userId: 'user1',
+  createdAt: '2020-01-01T00:00:00.000Z'
+};
+const auditLog2 = {
+  id: 'audit2',
+  entityType: 'south_connector' as const,
+  entityId: 'south1',
+  action: 'UPDATE' as const,
+  previousState: { name: 'south1' },
+  newState: { name: 'south1-renamed' },
+  userId: 'user1',
+  createdAt: '2020-01-02T00:00:00.000Z'
+};
+
+describe('AuditController', () => {
+  let controller: AuditControllerShape;
+  let auditService: AuditServiceMock;
+  let mockRequest: Partial<CustomExpressRequest>;
+
+  beforeEach(() => {
+    auditService = new AuditServiceMock();
+    mockRequest = {
+      services: createMockServices({ auditService })
+    } as Partial<CustomExpressRequest>;
+    controller = new AuditController();
+  });
+
+  describe('search()', () => {
+    it('should pass parsed query params through to auditService.search() and map results', () => {
+      const expectedResult = createPageFromArray([auditLog1, auditLog2], 50, 0);
+      auditService.search = mock.fn(() => expectedResult);
+
+      const result = controller.search(
+        mockRequest as CustomExpressRequest,
+        'south_connector',
+        'south1',
+        'CREATE',
+        '2020-01-01',
+        '2020-02-01',
+        1
+      );
+
+      assert.strictEqual(auditService.search.mock.calls.length, 1);
+      const searchParams: AuditSearchParam = {
+        entityType: 'south_connector',
+        entityId: 'south1',
+        action: 'CREATE',
+        start: '2020-01-01',
+        end: '2020-02-01',
+        page: 1
+      };
+      assert.deepStrictEqual(auditService.search.mock.calls[0].arguments[0], searchParams);
+      assert.deepStrictEqual(result, {
+        content: [auditLog1, auditLog2],
+        totalElements: expectedResult.totalElements,
+        size: expectedResult.size,
+        number: expectedResult.number,
+        totalPages: expectedResult.totalPages
+      });
+    });
+
+    it('should default page to 0 and forward undefined filters when none are provided', () => {
+      const expectedResult = createPageFromArray([], 50, 0);
+      auditService.search = mock.fn(() => expectedResult);
+
+      const result = controller.search(mockRequest as CustomExpressRequest);
+
+      const searchParams: AuditSearchParam = {
+        entityType: undefined,
+        entityId: undefined,
+        action: undefined,
+        start: undefined,
+        end: undefined,
+        page: 0
+      };
+      assert.deepStrictEqual(auditService.search.mock.calls[0].arguments[0], searchParams);
+      assert.deepStrictEqual(result.content, []);
+    });
+  });
+
+  describe('history()', () => {
+    it('should pass entityType/entityId through to auditService.findByEntity() and map results', () => {
+      auditService.findByEntity = mock.fn(() => [auditLog2, auditLog1]);
+
+      const result = controller.history(mockRequest as CustomExpressRequest, 'south_connector', 'south1');
+
+      assert.strictEqual(auditService.findByEntity.mock.calls.length, 1);
+      assert.deepStrictEqual(auditService.findByEntity.mock.calls[0].arguments, ['south_connector', 'south1']);
+      assert.deepStrictEqual(result, [auditLog2, auditLog1]);
+    });
+  });
+});

--- a/backend/src/web-server/controllers/audit.controller.ts
+++ b/backend/src/web-server/controllers/audit.controller.ts
@@ -1,0 +1,83 @@
+import { Controller, Get, Path, Query, Request, Route, Tags } from 'tsoa';
+import { Page } from '../../../shared/model/types';
+import { AuditLogDTO } from '../../../shared/model/audit.model';
+import { AuditAction, AuditEntityType, AuditLog, AuditSearchParam } from '../../model/audit.model';
+import { CustomExpressRequest } from '../express';
+
+/**
+ * Maps an internal AuditLog to its DTO representation.
+ */
+export function toAuditLogDTO(auditLog: AuditLog): AuditLogDTO {
+  return {
+    id: auditLog.id,
+    entityType: auditLog.entityType,
+    entityId: auditLog.entityId,
+    action: auditLog.action,
+    previousState: auditLog.previousState,
+    newState: auditLog.newState,
+    userId: auditLog.userId,
+    createdAt: auditLog.createdAt
+  };
+}
+
+@Route('/api/audit')
+@Tags('Audit')
+/**
+ * Audit Trail API
+ * @description Endpoints for searching and consulting the audit trail recorded against configuration changes
+ */
+export class AuditController extends Controller {
+  /**
+   * Searches audit log entries with optional filtering by entity type, entity id, action, and time range.
+   * @summary Search audit log entries
+   * @param entityType Filter by entity type (e.g. `south_connector`).
+   * @param entityId Filter by the identifier of the audited entity.
+   * @param action Filter by the kind of change performed. Valid values: `CREATE`, `UPDATE`, `DELETE`.
+   * @param start ISO 8601 start of the time range.
+   * @param end ISO 8601 end of the time range.
+   * @returns {Page<AuditLogDTO>} Paginated list of audit log entries
+   */
+  @Get('/')
+  search(
+    @Request() request: CustomExpressRequest,
+    @Query() entityType?: string,
+    @Query() entityId?: string,
+    @Query() action?: string,
+    @Query() start?: string,
+    @Query() end?: string,
+    @Query() page = 0
+  ): Page<AuditLogDTO> {
+    const searchParams: AuditSearchParam = {
+      entityType: entityType as AuditEntityType | undefined,
+      entityId,
+      action: action as AuditAction | undefined,
+      start,
+      end,
+      page: page ? parseInt(page.toString(), 10) : 0
+    };
+
+    const auditService = request.services.auditService;
+    const pageResult = auditService.search(searchParams);
+
+    return {
+      content: pageResult.content.map(auditLog => toAuditLogDTO(auditLog)),
+      totalElements: pageResult.totalElements,
+      size: pageResult.size,
+      number: pageResult.number,
+      totalPages: pageResult.totalPages
+    };
+  }
+
+  /**
+   * Retrieves the full audit history recorded for a single entity, most recent first.
+   * @summary Get audit history for an entity
+   * @param entityType The type of the audited entity (e.g. `south_connector`).
+   * @param entityId The identifier of the audited entity.
+   * @returns {Array<AuditLogDTO>} Array of audit log entries for the entity
+   */
+  @Get('/{entityType}/{entityId}')
+  history(@Request() request: CustomExpressRequest, @Path() entityType: string, @Path() entityId: string): Array<AuditLogDTO> {
+    const auditService = request.services.auditService;
+    return auditService.findByEntity(entityType as AuditEntityType, entityId).map(auditLog => toAuditLogDTO(auditLog));
+  }
+}

--- a/backend/src/web-server/controllers/certificate.controller.spec.ts
+++ b/backend/src/web-server/controllers/certificate.controller.spec.ts
@@ -118,7 +118,7 @@ describe('CertificateController', () => {
     await controller.delete(certificateId, mockRequest as CustomExpressRequest);
 
     assert.strictEqual(certificateService.delete.mock.calls.length, 1);
-    assert.deepStrictEqual(certificateService.delete.mock.calls[0].arguments[0], certificateId);
+    assert.deepStrictEqual(certificateService.delete.mock.calls[0].arguments, [certificateId, 'test']);
   });
 
   it('should import a certificate', async () => {

--- a/backend/src/web-server/controllers/certificate.controller.ts
+++ b/backend/src/web-server/controllers/certificate.controller.ts
@@ -207,6 +207,6 @@ export class CertificateController extends Controller {
   @SuccessResponse(204, 'Certificate deleted successfully')
   delete(@Path() certificateId: string, @Request() request: CustomExpressRequest): void {
     const certificateService: CertificateService = request.services.certificateService;
-    certificateService.delete(certificateId);
+    certificateService.delete(certificateId, request.user.id);
   }
 }

--- a/backend/src/web-server/controllers/history-query.controller.spec.ts
+++ b/backend/src/web-server/controllers/history-query.controller.spec.ts
@@ -179,7 +179,7 @@ describe('HistoryQueryController', () => {
     await controller.delete(historyId, mockRequest as CustomExpressRequest);
 
     assert.strictEqual(historyQueryService.delete.mock.calls.length, 1);
-    assert.deepStrictEqual(historyQueryService.delete.mock.calls[0].arguments[0], historyId);
+    assert.deepStrictEqual(historyQueryService.delete.mock.calls[0].arguments, [historyId, 'test']);
   });
 
   it('should start a history query', async () => {
@@ -619,7 +619,7 @@ describe('HistoryQueryController', () => {
     await controller.deleteItems(historyId, { itemIds }, mockRequest as CustomExpressRequest);
 
     assert.strictEqual(historyQueryService.deleteItems.mock.calls.length, 1);
-    assert.deepStrictEqual(historyQueryService.deleteItems.mock.calls[0].arguments, [historyId, itemIds]);
+    assert.deepStrictEqual(historyQueryService.deleteItems.mock.calls[0].arguments, [historyId, itemIds, 'test']);
   });
 
   it('should delete a history query item', async () => {
@@ -630,7 +630,7 @@ describe('HistoryQueryController', () => {
     await controller.deleteItem(historyId, itemId, mockRequest as CustomExpressRequest);
 
     assert.strictEqual(historyQueryService.deleteItem.mock.calls.length, 1);
-    assert.deepStrictEqual(historyQueryService.deleteItem.mock.calls[0].arguments, [historyId, itemId]);
+    assert.deepStrictEqual(historyQueryService.deleteItem.mock.calls[0].arguments, [historyId, itemId, 'test']);
   });
 
   it('should delete all items from a history query', async () => {
@@ -640,7 +640,7 @@ describe('HistoryQueryController', () => {
     await controller.deleteAllItems(historyId, mockRequest as CustomExpressRequest);
 
     assert.strictEqual(historyQueryService.deleteAllItems.mock.calls.length, 1);
-    assert.deepStrictEqual(historyQueryService.deleteAllItems.mock.calls[0].arguments[0], historyId);
+    assert.deepStrictEqual(historyQueryService.deleteAllItems.mock.calls[0].arguments, [historyId, 'test']);
   });
 
   it('should convert items to CSV', async () => {
@@ -884,7 +884,7 @@ describe('HistoryQueryController', () => {
     await controller.addOrEditTransformer(historyId, command, mockRequest as CustomExpressRequest);
 
     assert.strictEqual(historyQueryService.addOrEditTransformer.mock.calls.length, 1);
-    assert.deepStrictEqual(historyQueryService.addOrEditTransformer.mock.calls[0].arguments, [historyId, command]);
+    assert.deepStrictEqual(historyQueryService.addOrEditTransformer.mock.calls[0].arguments, [historyId, command, 'test']);
   });
 
   it('should remove a transformer', async () => {
@@ -895,7 +895,7 @@ describe('HistoryQueryController', () => {
     await controller.removeTransformer(historyId, transformerId, mockRequest as CustomExpressRequest);
 
     assert.strictEqual(historyQueryService.removeTransformer.mock.calls.length, 1);
-    assert.deepStrictEqual(historyQueryService.removeTransformer.mock.calls[0].arguments, [historyId, transformerId]);
+    assert.deepStrictEqual(historyQueryService.removeTransformer.mock.calls[0].arguments, [historyId, transformerId, 'test']);
   });
 
   it('should search cache content with default params', async () => {

--- a/backend/src/web-server/controllers/history-query.controller.ts
+++ b/backend/src/web-server/controllers/history-query.controller.ts
@@ -167,7 +167,7 @@ export class HistoryQueryController extends Controller {
   @SuccessResponse(204, 'No Content')
   async delete(@Path() historyId: string, @Request() request: CustomExpressRequest): Promise<void> {
     const historyQueryService = request.services.historyQueryService as HistoryQueryService;
-    await historyQueryService.delete(historyId);
+    await historyQueryService.delete(historyId, request.user.id);
   }
 
   /**
@@ -471,7 +471,7 @@ export class HistoryQueryController extends Controller {
   @SuccessResponse(204, 'No Content')
   async deleteItem(@Path() historyId: string, @Path() itemId: string, @Request() request: CustomExpressRequest): Promise<void> {
     const historyQueryService = request.services.historyQueryService as HistoryQueryService;
-    await historyQueryService.deleteItem(historyId, itemId);
+    await historyQueryService.deleteItem(historyId, itemId, request.user.id);
   }
 
   /**
@@ -486,7 +486,7 @@ export class HistoryQueryController extends Controller {
     @Request() request: CustomExpressRequest
   ): Promise<void> {
     const historyQueryService = request.services.historyQueryService as HistoryQueryService;
-    await historyQueryService.deleteItems(historyId, command.itemIds);
+    await historyQueryService.deleteItems(historyId, command.itemIds, request.user.id);
   }
 
   /**
@@ -497,7 +497,7 @@ export class HistoryQueryController extends Controller {
   @SuccessResponse(204, 'No Content')
   async deleteAllItems(@Path() historyId: string, @Request() request: CustomExpressRequest): Promise<void> {
     const historyQueryService = request.services.historyQueryService as HistoryQueryService;
-    await historyQueryService.deleteAllItems(historyId);
+    await historyQueryService.deleteAllItems(historyId, request.user.id);
   }
 
   /**
@@ -644,7 +644,7 @@ export class HistoryQueryController extends Controller {
     @Request() request: CustomExpressRequest
   ): Promise<void> {
     const historyQueryService = request.services.historyQueryService as HistoryQueryService;
-    await historyQueryService.addOrEditTransformer(historyId, command as unknown as HistoryTransformerWithOptions);
+    await historyQueryService.addOrEditTransformer(historyId, command as unknown as HistoryTransformerWithOptions, request.user.id);
   }
 
   /**
@@ -659,7 +659,7 @@ export class HistoryQueryController extends Controller {
     @Request() request: CustomExpressRequest
   ): Promise<void> {
     const historyQueryService = request.services.historyQueryService as HistoryQueryService;
-    await historyQueryService.removeTransformer(historyId, transformerId);
+    await historyQueryService.removeTransformer(historyId, transformerId, request.user.id);
   }
 
   /**

--- a/backend/src/web-server/controllers/ip-filter.controller.spec.ts
+++ b/backend/src/web-server/controllers/ip-filter.controller.spec.ts
@@ -99,6 +99,6 @@ describe('IPFilterController', () => {
     await controller.delete(ipFilterId, mockRequest as CustomExpressRequest);
 
     assert.strictEqual(ipFilterService.delete.mock.calls.length, 1);
-    assert.deepStrictEqual(ipFilterService.delete.mock.calls[0].arguments[0], ipFilterId);
+    assert.deepStrictEqual(ipFilterService.delete.mock.calls[0].arguments, [ipFilterId, 'test']);
   });
 });

--- a/backend/src/web-server/controllers/ip-filter.controller.ts
+++ b/backend/src/web-server/controllers/ip-filter.controller.ts
@@ -65,6 +65,6 @@ export class IPFilterController extends Controller {
   @SuccessResponse(204, 'IP filter deleted successfully')
   delete(@Path() ipFilterId: string, @Request() request: CustomExpressRequest): void {
     const ipFilterService = request.services.ipFilterService;
-    ipFilterService.delete(ipFilterId);
+    ipFilterService.delete(ipFilterId, request.user.id);
   }
 }

--- a/backend/src/web-server/controllers/north-connector.controller.spec.ts
+++ b/backend/src/web-server/controllers/north-connector.controller.spec.ts
@@ -157,7 +157,7 @@ describe('NorthConnectorController', () => {
     await controller.delete(northId, mockRequest as CustomExpressRequest);
 
     assert.strictEqual(northService.delete.mock.calls.length, 1);
-    assert.deepStrictEqual(northService.delete.mock.calls[0].arguments[0], northId);
+    assert.deepStrictEqual(northService.delete.mock.calls[0].arguments, [northId, 'test']);
   });
 
   it('should start a north connector', async () => {
@@ -234,7 +234,7 @@ describe('NorthConnectorController', () => {
     await controller.addOrEditTransformer(northId, transformer, mockRequest as CustomExpressRequest);
 
     assert.strictEqual(northService.addOrEditTransformer.mock.calls.length, 1);
-    assert.deepStrictEqual(northService.addOrEditTransformer.mock.calls[0].arguments, [northId, transformer]);
+    assert.deepStrictEqual(northService.addOrEditTransformer.mock.calls[0].arguments, [northId, transformer, 'test']);
   });
 
   it('should remove a transformer', async () => {
@@ -245,7 +245,7 @@ describe('NorthConnectorController', () => {
     await controller.removeTransformer(northId, transformerId, mockRequest as CustomExpressRequest);
 
     assert.strictEqual(northService.removeTransformer.mock.calls.length, 1);
-    assert.deepStrictEqual(northService.removeTransformer.mock.calls[0].arguments, [northId, transformerId]);
+    assert.deepStrictEqual(northService.removeTransformer.mock.calls[0].arguments, [northId, transformerId, 'test']);
   });
 
   it('should search cache content with default params', async () => {

--- a/backend/src/web-server/controllers/north-connector.controller.ts
+++ b/backend/src/web-server/controllers/north-connector.controller.ts
@@ -135,7 +135,7 @@ export class NorthConnectorController extends Controller {
   @SuccessResponse(204, 'No Content')
   async delete(@Path() northId: string, @Request() request: CustomExpressRequest): Promise<void> {
     const northService = request.services.northService as NorthService;
-    await northService.delete(northId);
+    await northService.delete(northId, request.user.id);
   }
 
   /**
@@ -202,7 +202,7 @@ export class NorthConnectorController extends Controller {
     @Request() request: CustomExpressRequest
   ): void {
     const northService = request.services.northService as NorthService;
-    northService.addOrEditTransformer(northId, command as unknown as NorthTransformerWithOptions);
+    northService.addOrEditTransformer(northId, command as unknown as NorthTransformerWithOptions, request.user.id);
   }
 
   /**
@@ -213,7 +213,7 @@ export class NorthConnectorController extends Controller {
   @SuccessResponse(204, 'No Content')
   removeTransformer(@Path() northId: string, @Path() transformerId: string, @Request() request: CustomExpressRequest): void {
     const northService = request.services.northService as NorthService;
-    northService.removeTransformer(northId, transformerId);
+    northService.removeTransformer(northId, transformerId, request.user.id);
   }
 
   /**

--- a/backend/src/web-server/controllers/scan-mode.controller.spec.ts
+++ b/backend/src/web-server/controllers/scan-mode.controller.spec.ts
@@ -99,7 +99,7 @@ describe('ScanModeController', () => {
     await controller.delete(scanModeId, mockRequest as CustomExpressRequest);
 
     assert.strictEqual(scanModeService.delete.mock.calls.length, 1);
-    assert.deepStrictEqual(scanModeService.delete.mock.calls[0].arguments[0], scanModeId);
+    assert.deepStrictEqual(scanModeService.delete.mock.calls[0].arguments, [scanModeId, 'test']);
   });
 
   it('should validate a cron expression', async () => {

--- a/backend/src/web-server/controllers/scan-mode.controller.ts
+++ b/backend/src/web-server/controllers/scan-mode.controller.ts
@@ -63,7 +63,7 @@ export class ScanModeController extends Controller {
   @SuccessResponse(204, 'Scan mode deleted successfully')
   delete(@Path() scanModeId: string, @Request() request: CustomExpressRequest): void {
     const scanModeService: ScanModeService = request.services.scanModeService;
-    scanModeService.delete(scanModeId);
+    scanModeService.delete(scanModeId, request.user.id);
   }
 
   /**

--- a/backend/src/web-server/controllers/south-connector.controller.spec.ts
+++ b/backend/src/web-server/controllers/south-connector.controller.spec.ts
@@ -206,7 +206,7 @@ describe('SouthConnectorController', () => {
     await controller.delete(southId, mockRequest as CustomExpressRequest);
 
     assert.strictEqual(southService.delete.mock.calls.length, 1);
-    assert.deepStrictEqual(southService.delete.mock.calls[0].arguments[0], southId);
+    assert.deepStrictEqual(southService.delete.mock.calls[0].arguments, [southId, 'test']);
   });
 
   it('should start a south connector', async () => {
@@ -600,7 +600,7 @@ describe('SouthConnectorController', () => {
     await controller.deleteItems(southId, { itemIds }, mockRequest as CustomExpressRequest);
 
     assert.strictEqual(southService.deleteItems.mock.calls.length, 1);
-    assert.deepStrictEqual(southService.deleteItems.mock.calls[0].arguments, [southId, itemIds]);
+    assert.deepStrictEqual(southService.deleteItems.mock.calls[0].arguments, [southId, itemIds, 'test']);
   });
 
   it('should delete an item', async () => {
@@ -611,7 +611,7 @@ describe('SouthConnectorController', () => {
     await controller.deleteItem(southId, itemId, mockRequest as CustomExpressRequest);
 
     assert.strictEqual(southService.deleteItem.mock.calls.length, 1);
-    assert.deepStrictEqual(southService.deleteItem.mock.calls[0].arguments, [southId, itemId]);
+    assert.deepStrictEqual(southService.deleteItem.mock.calls[0].arguments, [southId, itemId, 'test']);
   });
 
   it('should delete all items from a south connector', async () => {
@@ -621,7 +621,7 @@ describe('SouthConnectorController', () => {
     await controller.deleteAllItems(southId, mockRequest as CustomExpressRequest);
 
     assert.strictEqual(southService.deleteAllItems.mock.calls.length, 1);
-    assert.deepStrictEqual(southService.deleteAllItems.mock.calls[0].arguments[0], southId);
+    assert.deepStrictEqual(southService.deleteAllItems.mock.calls[0].arguments, [southId, 'test']);
   });
 
   it('should convert items to CSV', async () => {
@@ -979,7 +979,7 @@ describe('SouthConnectorController', () => {
     await controller.deleteGroup(southId, groupId, mockRequest as CustomExpressRequest);
 
     assert.strictEqual(southService.deleteGroup.mock.calls.length, 1);
-    assert.deepStrictEqual(southService.deleteGroup.mock.calls[0].arguments, [southId, groupId]);
+    assert.deepStrictEqual(southService.deleteGroup.mock.calls[0].arguments, [southId, groupId, 'test']);
   });
 
   it('should move items to a group', async () => {

--- a/backend/src/web-server/controllers/south-connector.controller.ts
+++ b/backend/src/web-server/controllers/south-connector.controller.ts
@@ -178,7 +178,7 @@ export class SouthConnectorController extends Controller {
   @SuccessResponse(204, 'No Content')
   async delete(@Path() southId: string, @Request() request: CustomExpressRequest): Promise<void> {
     const southService = request.services.southService as SouthService;
-    await southService.delete(southId);
+    await southService.delete(southId, request.user.id);
   }
 
   /**
@@ -482,7 +482,7 @@ export class SouthConnectorController extends Controller {
   @SuccessResponse(204, 'No Content')
   async deleteItem(@Path() southId: string, @Path() itemId: string, @Request() request: CustomExpressRequest): Promise<void> {
     const southService = request.services.southService as SouthService;
-    await southService.deleteItem(southId, itemId);
+    await southService.deleteItem(southId, itemId, request.user.id);
   }
 
   /**
@@ -497,7 +497,7 @@ export class SouthConnectorController extends Controller {
     @Request() request: CustomExpressRequest
   ): Promise<void> {
     const southService = request.services.southService as SouthService;
-    await southService.deleteItems(southId, command.itemIds);
+    await southService.deleteItems(southId, command.itemIds, request.user.id);
   }
 
   /**
@@ -508,7 +508,7 @@ export class SouthConnectorController extends Controller {
   @SuccessResponse(204, 'No Content')
   async deleteAllItems(@Path() southId: string, @Request() request: CustomExpressRequest): Promise<void> {
     const southService = request.services.southService as SouthService;
-    await southService.deleteAllItems(southId);
+    await southService.deleteAllItems(southId, request.user.id);
   }
 
   /**
@@ -707,7 +707,7 @@ export class SouthConnectorController extends Controller {
   @SuccessResponse(204, 'No Content')
   async deleteGroup(@Path() southId: string, @Path() groupId: string, @Request() request: CustomExpressRequest): Promise<void> {
     const southService = request.services.southService as SouthService;
-    await southService.deleteGroup(southId, groupId);
+    await southService.deleteGroup(southId, groupId, request.user.id);
   }
 
   /**

--- a/backend/src/web-server/controllers/transformer.controller.spec.ts
+++ b/backend/src/web-server/controllers/transformer.controller.spec.ts
@@ -202,7 +202,7 @@ describe('TransformerController', () => {
     await controller.delete(transformerId, mockRequest as CustomExpressRequest);
 
     assert.strictEqual(transformerService.delete.mock.calls.length, 1);
-    assert.deepStrictEqual(transformerService.delete.mock.calls[0].arguments[0], transformerId);
+    assert.deepStrictEqual(transformerService.delete.mock.calls[0].arguments, [transformerId, 'test']);
   });
 
   it('should test a transformer', async () => {

--- a/backend/src/web-server/controllers/transformer.controller.ts
+++ b/backend/src/web-server/controllers/transformer.controller.ts
@@ -145,7 +145,7 @@ export class TransformerController extends Controller {
   @SuccessResponse(204, 'Transformer deleted successfully')
   async delete(@Path() transformerId: string, @Request() request: CustomExpressRequest): Promise<void> {
     const transformerService = request.services.transformerService;
-    await transformerService.delete(transformerId);
+    await transformerService.delete(transformerId, request.user.id);
   }
 
   /**

--- a/backend/src/web-server/controllers/user.controller.spec.ts
+++ b/backend/src/web-server/controllers/user.controller.spec.ts
@@ -104,7 +104,7 @@ describe('UserController', () => {
     await controller.update(userId, command, mockRequest as CustomExpressRequest);
 
     assert.strictEqual(userService.update.mock.calls.length, 1);
-    assert.deepStrictEqual(userService.update.mock.calls[0].arguments, [userId, command]);
+    assert.deepStrictEqual(userService.update.mock.calls[0].arguments, [userId, command, testData.users.list[0].id]);
   });
 
   it('should update user password', async () => {
@@ -128,6 +128,6 @@ describe('UserController', () => {
     await controller.delete(userId, mockRequest as CustomExpressRequest);
 
     assert.strictEqual(userService.delete.mock.calls.length, 1);
-    assert.deepStrictEqual(userService.delete.mock.calls[0].arguments[0], userId);
+    assert.deepStrictEqual(userService.delete.mock.calls[0].arguments, [userId, testData.users.list[0].id]);
   });
 });

--- a/backend/src/web-server/controllers/user.controller.ts
+++ b/backend/src/web-server/controllers/user.controller.ts
@@ -73,7 +73,7 @@ export class UserController extends Controller {
   @SuccessResponse(204, 'User updated successfully')
   async update(@Path() userId: string, @Body() command: UserCommandDTO, @Request() request: CustomExpressRequest): Promise<void> {
     const userService = request.services.userService;
-    await userService.update(userId, command);
+    await userService.update(userId, command, request.user.id);
   }
 
   /**
@@ -99,6 +99,6 @@ export class UserController extends Controller {
   @SuccessResponse(204, 'User deleted successfully')
   delete(@Path() userId: string, @Request() request: CustomExpressRequest): void {
     const userService = request.services.userService;
-    userService.delete(userId);
+    userService.delete(userId, request.user.id);
   }
 }

--- a/backend/src/web-server/controllers/validators/oibus-validation-schema.ts
+++ b/backend/src/web-server/controllers/validators/oibus-validation-schema.ts
@@ -82,6 +82,7 @@ const certificatePrivateKeyExportSchema: Joi.ObjectSchema = Joi.object({
 });
 
 const engineLoggerSchema = Joi.object({
+  auditRetentionDuration: Joi.number().integer().min(0).allow(null),
   console: Joi.object({
     level: Joi.string().required().allow('silent', 'error', 'warning', 'info', 'debug', 'trace')
   }),

--- a/backend/src/web-server/express.d.ts
+++ b/backend/src/web-server/express.d.ts
@@ -11,10 +11,12 @@ import UserService from '../service/user.service';
 import SouthService from '../service/south.service';
 import NorthService from '../service/north.service';
 import HistoryQueryService from '../service/history-query.service';
+import AuditService from '../service/audit.service';
 
 interface CustomExpressRequest extends Request {
   user: { id: string; login: string };
   services: {
+    auditService: AuditService;
     certificateService: CertificateService;
     historyQueryService: HistoryQueryService;
     ipFilterService: IPFilterService;

--- a/backend/src/web-server/middlewares/services.middleware.spec.ts
+++ b/backend/src/web-server/middlewares/services.middleware.spec.ts
@@ -5,10 +5,11 @@ import { createMockServices } from '../../tests/utils/test-utils';
 import type { CustomExpressRequest } from '../express';
 
 describe('createInjectServicesMiddleware', () => {
-  it('should inject all 12 services into req.services and call next()', () => {
+  it('should inject all 13 services into req.services and call next()', () => {
     const services = createMockServices();
     type LooseMiddlewareFn = (req: CustomExpressRequest, res: unknown, next: () => void) => void;
     const middleware = createInjectServicesMiddleware(
+      services.auditService,
       services.certificateService,
       services.historyQueryService,
       services.ipFilterService,
@@ -30,6 +31,7 @@ describe('createInjectServicesMiddleware', () => {
     });
 
     assert.strictEqual(nextCalled, true);
+    assert.strictEqual(req.services.auditService, services.auditService);
     assert.strictEqual(req.services.certificateService, services.certificateService);
     assert.strictEqual(req.services.historyQueryService, services.historyQueryService);
     assert.strictEqual(req.services.ipFilterService, services.ipFilterService);

--- a/backend/src/web-server/middlewares/services.middleware.ts
+++ b/backend/src/web-server/middlewares/services.middleware.ts
@@ -12,8 +12,10 @@ import UserService from '../../service/user.service';
 import SouthService from '../../service/south.service';
 import HistoryQueryService from '../../service/history-query.service';
 import NorthService from '../../service/north.service';
+import AuditService from '../../service/audit.service';
 
 export function createInjectServicesMiddleware(
+  auditService: AuditService,
   certificateService: CertificateService,
   historyQueryService: HistoryQueryService,
   ipFilterService: IPFilterService,
@@ -29,6 +31,7 @@ export function createInjectServicesMiddleware(
 ) {
   return (req: Request, res: Response, next: NextFunction) => {
     (req as CustomExpressRequest).services = {
+      auditService,
       certificateService,
       historyQueryService,
       ipFilterService,

--- a/backend/src/web-server/routes.integration.spec.ts
+++ b/backend/src/web-server/routes.integration.spec.ts
@@ -10,6 +10,7 @@ import { createInjectServicesMiddleware } from './middlewares/services.middlewar
 import { RegisterRoutes } from './routes';
 import { NotFoundError, OIBusTestingError, OIBusValidationError } from '../model/types';
 
+import AuditServiceMock from '../tests/__mocks__/service/audit-service.mock';
 import CertificateServiceMock from '../tests/__mocks__/service/certificate-service.mock';
 import HistoryQueryServiceMock from '../tests/__mocks__/service/history-query-service.mock';
 import IpFilterServiceMock from '../tests/__mocks__/service/ip-filter-service.mock';
@@ -23,6 +24,7 @@ import SouthServiceMock from '../tests/__mocks__/service/south-service.mock';
 import TransformerServiceMock from '../tests/__mocks__/service/transformer-service.mock';
 import UserServiceMock from '../tests/__mocks__/service/user-service.mock';
 
+import type AuditService from '../service/audit.service';
 import type CertificateService from '../service/certificate.service';
 import type HistoryQueryService from '../service/history-query.service';
 import type IPFilterService from '../service/ip-filter.service';
@@ -91,6 +93,7 @@ describe('routes.ts integration (real RegisterRoutes over HTTP)', () => {
   before(async () => {
     app = express();
 
+    const auditService = new AuditServiceMock();
     const certificateService = new CertificateServiceMock();
     const historyQueryService = new HistoryQueryServiceMock();
     const ipFilterService = new IpFilterServiceMock();
@@ -108,6 +111,7 @@ describe('routes.ts integration (real RegisterRoutes over HTTP)', () => {
     // handlers in routes.ts directly, so we mount only service injection + body parsing.
     app.use(
       createInjectServicesMiddleware(
+        auditService as unknown as AuditService,
         certificateService as unknown as CertificateService,
         historyQueryService as unknown as HistoryQueryService,
         ipFilterService as unknown as IPFilterService,

--- a/backend/src/web-server/routes.ts
+++ b/backend/src/web-server/routes.ts
@@ -28,6 +28,8 @@ import { EngineController } from './controllers/engine.controller';
 import { ContentController } from './controllers/content.controller';
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { CertificateController } from './controllers/certificate.controller';
+// WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+import { AuditController } from './controllers/audit.controller';
 import type { Request as ExRequest, Response as ExResponse, RequestHandler, Router } from 'express';
 const multer = require('multer');
 
@@ -8172,6 +8174,7 @@ const models: TsoaRoute.Models = {
             "updatedAt": {"ref":"Instant","required":true},
             "version": {"dataType":"string","required":true},
             "launcherVersion": {"dataType":"string","required":true},
+            "auditRetentionDuration": {"dataType":"union","subSchemas":[{"dataType":"double"},{"dataType":"enum","enums":[null]}],"required":true},
             "general": {"dataType":"nestedObjectLiteral","nestedProperties":{"name":{"dataType":"string","required":true}},"required":true},
             "webServer": {"dataType":"nestedObjectLiteral","nestedProperties":{"authTokenDuration":{"ref":"AuthTokenDuration","required":true},"port":{"dataType":"double","required":true}},"required":true},
             "proxyServer": {"dataType":"nestedObjectLiteral","nestedProperties":{"password":{"dataType":"union","subSchemas":[{"dataType":"string"},{"dataType":"enum","enums":[null]}],"required":true},"username":{"dataType":"union","subSchemas":[{"dataType":"string"},{"dataType":"enum","enums":[null]}],"required":true},"forward":{"dataType":"nestedObjectLiteral","nestedProperties":{"password":{"dataType":"union","subSchemas":[{"dataType":"string"},{"dataType":"enum","enums":[null]}],"required":true},"username":{"dataType":"union","subSchemas":[{"dataType":"string"},{"dataType":"enum","enums":[null]}],"required":true},"url":{"dataType":"union","subSchemas":[{"dataType":"string"},{"dataType":"enum","enums":[null]}],"required":true},"enabled":{"dataType":"boolean","required":true}},"required":true},"port":{"dataType":"union","subSchemas":[{"dataType":"double"},{"dataType":"enum","enums":[null]}],"required":true},"enabled":{"dataType":"boolean","required":true}},"required":true},
@@ -8196,6 +8199,7 @@ const models: TsoaRoute.Models = {
             "webServer": {"ref":"EngineWebServerCommandDTO","required":true},
             "proxyServer": {"ref":"EngineProxyCommandDTO","required":true},
             "logger": {"ref":"EngineLoggerCommandDTO","required":true},
+            "auditRetentionDuration": {"dataType":"union","subSchemas":[{"dataType":"double"},{"dataType":"enum","enums":[null]}],"required":true},
         },
         "additionalProperties": false,
     },
@@ -8247,6 +8251,43 @@ const models: TsoaRoute.Models = {
         "dataType": "refObject",
         "properties": {
             "passphrase": {"dataType":"string","required":true},
+        },
+        "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "AuditEntityType": {
+        "dataType": "refAlias",
+        "type": {"dataType":"union","subSchemas":[{"dataType":"enum","enums":["south_connector"]},{"dataType":"enum","enums":["south_item"]},{"dataType":"enum","enums":["south_item_group"]},{"dataType":"enum","enums":["north_connector"]},{"dataType":"enum","enums":["north_transformer"]},{"dataType":"enum","enums":["history_query"]},{"dataType":"enum","enums":["history_query_item"]},{"dataType":"enum","enums":["history_query_transformer"]},{"dataType":"enum","enums":["scan_mode"]},{"dataType":"enum","enums":["ip_filter"]},{"dataType":"enum","enums":["certificate"]},{"dataType":"enum","enums":["user"]},{"dataType":"enum","enums":["transformer"]},{"dataType":"enum","enums":["engine"]},{"dataType":"enum","enums":["oianalytics_registration"]}],"validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "AuditAction": {
+        "dataType": "refAlias",
+        "type": {"dataType":"union","subSchemas":[{"dataType":"enum","enums":["CREATE"]},{"dataType":"enum","enums":["UPDATE"]},{"dataType":"enum","enums":["DELETE"]}],"validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "AuditLogDTO": {
+        "dataType": "refObject",
+        "properties": {
+            "id": {"dataType":"string","required":true},
+            "entityType": {"ref":"AuditEntityType","required":true},
+            "entityId": {"dataType":"string","required":true},
+            "action": {"ref":"AuditAction","required":true},
+            "previousState": {"dataType":"union","subSchemas":[{"ref":"Record_string.unknown_"},{"dataType":"enum","enums":[null]}],"required":true},
+            "newState": {"dataType":"union","subSchemas":[{"ref":"Record_string.unknown_"},{"dataType":"enum","enums":[null]}],"required":true},
+            "userId": {"dataType":"string","required":true},
+            "createdAt": {"dataType":"string","required":true},
+        },
+        "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "Page_AuditLogDTO_": {
+        "dataType": "refObject",
+        "properties": {
+            "content": {"dataType":"array","array":{"dataType":"refObject","ref":"AuditLogDTO"},"required":true},
+            "totalElements": {"dataType":"double","required":true},
+            "size": {"dataType":"double","required":true},
+            "number": {"dataType":"double","required":true},
+            "totalPages": {"dataType":"double","required":true},
         },
         "additionalProperties": false,
     },
@@ -13135,6 +13176,74 @@ export function RegisterRoutes(app: Router,opts?:{multer?:ReturnType<typeof mult
                 next,
                 validatedArgs,
                 successStatus: 204,
+              });
+            } catch (err) {
+                return next(err);
+            }
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        const argsAuditController_search: Record<string, TsoaRoute.ParameterSchema> = {
+                request: {"in":"request","name":"request","required":true,"dataType":"object"},
+                entityType: {"in":"query","name":"entityType","dataType":"string"},
+                entityId: {"in":"query","name":"entityId","dataType":"string"},
+                action: {"in":"query","name":"action","dataType":"string"},
+                start: {"in":"query","name":"start","dataType":"string"},
+                end: {"in":"query","name":"end","dataType":"string"},
+                page: {"default":0,"in":"query","name":"page","dataType":"double"},
+        };
+        app.get('/api/audit',
+            ...(fetchMiddlewares<RequestHandler>(AuditController)),
+            ...(fetchMiddlewares<RequestHandler>(AuditController.prototype.search)),
+
+            async function AuditController_search(request: ExRequest, response: ExResponse, next: any) {
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({ args: argsAuditController_search, request, response });
+
+                const controller = new AuditController();
+
+              await templateService.apiHandler({
+                methodName: 'search',
+                controller,
+                response,
+                next,
+                validatedArgs,
+                successStatus: undefined,
+              });
+            } catch (err) {
+                return next(err);
+            }
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        const argsAuditController_history: Record<string, TsoaRoute.ParameterSchema> = {
+                request: {"in":"request","name":"request","required":true,"dataType":"object"},
+                entityType: {"in":"path","name":"entityType","required":true,"dataType":"string"},
+                entityId: {"in":"path","name":"entityId","required":true,"dataType":"string"},
+        };
+        app.get('/api/audit/:entityType/:entityId',
+            ...(fetchMiddlewares<RequestHandler>(AuditController)),
+            ...(fetchMiddlewares<RequestHandler>(AuditController.prototype.history)),
+
+            async function AuditController_history(request: ExRequest, response: ExResponse, next: any) {
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({ args: argsAuditController_history, request, response });
+
+                const controller = new AuditController();
+
+              await templateService.apiHandler({
+                methodName: 'history',
+                controller,
+                response,
+                next,
+                validatedArgs,
+                successStatus: undefined,
               });
             } catch (err) {
                 return next(err);

--- a/backend/src/web-server/web-server.spec.ts
+++ b/backend/src/web-server/web-server.spec.ts
@@ -4,6 +4,7 @@ import { createRequire } from 'node:module';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import AuditServiceMock from '../tests/__mocks__/service/audit-service.mock';
 import IpFilterServiceMock from '../tests/__mocks__/service/ip-filter-service.mock';
 import OIBusServiceMock from '../tests/__mocks__/service/oibus-service.mock';
 import ScanModeServiceMock from '../tests/__mocks__/service/scan-mode-service.mock';
@@ -33,6 +34,7 @@ import type TransformerService from '../service/transformer.service';
 import type HistoryQueryService from '../service/history-query.service';
 import type HomeMetricsService from '../service/metrics/home-metrics.service';
 import type EncryptionService from '../service/encryption.service';
+import type AuditService from '../service/audit.service';
 import { NotFoundError, OIBusTestingError, OIBusValidationError } from '../model/types';
 import os from 'node:os';
 
@@ -118,6 +120,7 @@ describe('WebServer', () => {
     return new WebServer(
       port,
       encryptionMock as unknown as EncryptionService,
+      new AuditServiceMock() as unknown as AuditService,
       new ScanModeServiceMock() as unknown as ScanModeService,
       ipFilterService as unknown as IPFilterService,
       new CertificateServiceMock() as unknown as CertificateService,
@@ -161,6 +164,7 @@ describe('WebServer', () => {
     const ws = new WebServer(
       TEST_PORT + 1,
       encryptionMock as unknown as EncryptionService,
+      new AuditServiceMock() as unknown as AuditService,
       new ScanModeServiceMock() as unknown as ScanModeService,
       ipFilterService as unknown as IPFilterService,
       new CertificateServiceMock() as unknown as CertificateService,

--- a/backend/src/web-server/web-server.ts
+++ b/backend/src/web-server/web-server.ts
@@ -24,6 +24,7 @@ import { Express } from 'express-serve-static-core';
 import IpFilterMiddleware from './middlewares/ip-filter.middleware';
 import { createInjectServicesMiddleware } from './middlewares/services.middleware';
 import { RegisterRoutes } from './routes';
+import AuditService from '../service/audit.service';
 import path from 'path';
 import multer from 'multer';
 import { ValidateError } from 'tsoa';
@@ -48,6 +49,7 @@ export default class WebServer {
   constructor(
     port: number,
     private readonly encryptionService: EncryptionService,
+    private readonly auditService: AuditService,
     private readonly scanModeService: ScanModeService,
     private readonly ipFilterService: IPFilterService,
     private readonly certificateService: CertificateService,
@@ -116,6 +118,7 @@ export default class WebServer {
 
     this.app.use(
       createInjectServicesMiddleware(
+        this.auditService,
         this.certificateService,
         this.historyQueryService,
         this.ipFilterService,

--- a/documentation/docs/api/openapi.json
+++ b/documentation/docs/api/openapi.json
@@ -34996,6 +34996,13 @@
 						"description": "The version of the launcher.",
 						"example": "3.7.0"
 					},
+					"auditRetentionDuration": {
+						"type": "number",
+						"format": "double",
+						"nullable": true,
+						"description": "Number of days audit log entries are kept before being pruned. `null` (or 0) means audit logs\nare kept forever.",
+						"example": 90
+					},
 					"general": {
 						"properties": {
 							"name": {
@@ -35280,6 +35287,7 @@
 					"updatedAt",
 					"version",
 					"launcherVersion",
+					"auditRetentionDuration",
 					"general",
 					"webServer",
 					"proxyServer",
@@ -35325,13 +35333,21 @@
 					},
 					"logger": {
 						"$ref": "#/components/schemas/EngineLoggerCommandDTO"
+					},
+					"auditRetentionDuration": {
+						"type": "number",
+						"format": "double",
+						"nullable": true,
+						"description": "Number of days audit log entries are kept before being pruned. `null` (or 0) means audit logs\nare kept forever.",
+						"example": 90
 					}
 				},
 				"required": [
 					"general",
 					"webServer",
 					"proxyServer",
-					"logger"
+					"logger",
+					"auditRetentionDuration"
 				],
 				"type": "object",
 				"additionalProperties": false
@@ -35513,6 +35529,141 @@
 				},
 				"required": [
 					"passphrase"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"AuditEntityType": {
+				"type": "string",
+				"enum": [
+					"south_connector",
+					"south_item",
+					"south_item_group",
+					"north_connector",
+					"north_transformer",
+					"history_query",
+					"history_query_item",
+					"history_query_transformer",
+					"scan_mode",
+					"ip_filter",
+					"certificate",
+					"user",
+					"transformer",
+					"engine",
+					"oianalytics_registration"
+				]
+			},
+			"AuditAction": {
+				"type": "string",
+				"enum": [
+					"CREATE",
+					"UPDATE",
+					"DELETE"
+				]
+			},
+			"AuditLogDTO": {
+				"description": "Data Transfer Object for an audit log entry.\nRepresents a single create/update/delete event recorded against an audited entity.",
+				"properties": {
+					"id": {
+						"type": "string",
+						"description": "The unique identifier of the audit log entry."
+					},
+					"entityType": {
+						"$ref": "#/components/schemas/AuditEntityType",
+						"description": "The type of entity this audit log entry relates to.",
+						"example": "south_connector"
+					},
+					"entityId": {
+						"type": "string",
+						"description": "The identifier of the entity this audit log entry relates to."
+					},
+					"action": {
+						"$ref": "#/components/schemas/AuditAction",
+						"description": "The kind of change performed on the entity.",
+						"example": "UPDATE"
+					},
+					"previousState": {
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/Record_string.unknown_"
+							}
+						],
+						"nullable": true,
+						"description": "A JSON snapshot of the entity before the change. `null` for `CREATE`."
+					},
+					"newState": {
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/Record_string.unknown_"
+							}
+						],
+						"nullable": true,
+						"description": "A JSON snapshot of the entity after the change. `null` for `DELETE`."
+					},
+					"userId": {
+						"type": "string",
+						"description": "The identifier of the user who performed the change."
+					},
+					"createdAt": {
+						"type": "string",
+						"description": "ISO timestamp of when the change was recorded.",
+						"example": "2026-01-01T00:00:00.000Z"
+					}
+				},
+				"required": [
+					"id",
+					"entityType",
+					"entityId",
+					"action",
+					"previousState",
+					"newState",
+					"userId",
+					"createdAt"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"Page_AuditLogDTO_": {
+				"description": "Represents a paginated response containing an array of elements.",
+				"properties": {
+					"content": {
+						"items": {
+							"$ref": "#/components/schemas/AuditLogDTO"
+						},
+						"type": "array",
+						"description": "The content of the page - an array of elements."
+					},
+					"totalElements": {
+						"type": "number",
+						"format": "double",
+						"description": "The total number of elements across all pages.",
+						"example": 2
+					},
+					"size": {
+						"type": "number",
+						"format": "double",
+						"description": "The size of the page, i.e., the maximum number of elements per page.",
+						"example": 10
+					},
+					"number": {
+						"type": "number",
+						"format": "double",
+						"description": "The number of the current page, starting at 0.",
+						"example": 0
+					},
+					"totalPages": {
+						"type": "number",
+						"format": "double",
+						"description": "The total number of pages (which can be 0 if there are no elements).",
+						"example": 1
+					}
+				},
+				"required": [
+					"content",
+					"totalElements",
+					"size",
+					"number",
+					"totalPages"
 				],
 				"type": "object",
 				"additionalProperties": false
@@ -41276,6 +41427,132 @@
 						}
 					}
 				}
+			}
+		},
+		"/api/audit": {
+			"get": {
+				"operationId": "Search",
+				"responses": {
+					"200": {
+						"description": "Paginated list of audit log entries",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Page_AuditLogDTO_"
+								}
+							}
+						}
+					}
+				},
+				"description": "Searches audit log entries with optional filtering by entity type, entity id, action, and time range.",
+				"summary": "Search audit log entries",
+				"tags": [
+					"Audit"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"description": "Filter by entity type (e.g. `south_connector`).",
+						"in": "query",
+						"name": "entityType",
+						"required": false,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"description": "Filter by the identifier of the audited entity.",
+						"in": "query",
+						"name": "entityId",
+						"required": false,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"description": "Filter by the kind of change performed. Valid values: `CREATE`, `UPDATE`, `DELETE`.",
+						"in": "query",
+						"name": "action",
+						"required": false,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"description": "ISO 8601 start of the time range.",
+						"in": "query",
+						"name": "start",
+						"required": false,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"description": "ISO 8601 end of the time range.",
+						"in": "query",
+						"name": "end",
+						"required": false,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "page",
+						"required": false,
+						"schema": {
+							"default": 0,
+							"format": "double",
+							"type": "number"
+						}
+					}
+				]
+			}
+		},
+		"/api/audit/{entityType}/{entityId}": {
+			"get": {
+				"operationId": "History",
+				"responses": {
+					"200": {
+						"description": "Array of audit log entries for the entity",
+						"content": {
+							"application/json": {
+								"schema": {
+									"items": {
+										"$ref": "#/components/schemas/AuditLogDTO"
+									},
+									"type": "array"
+								}
+							}
+						}
+					}
+				},
+				"description": "Retrieves the full audit history recorded for a single entity, most recent first.",
+				"summary": "Get audit history for an entity",
+				"tags": [
+					"Audit"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"description": "The type of the audited entity (e.g. `south_connector`).",
+						"in": "path",
+						"name": "entityType",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"description": "The identifier of the audited entity.",
+						"in": "path",
+						"name": "entityId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				]
 			}
 		}
 	},

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -20,6 +20,7 @@
         "@codemirror/lang-javascript": "6.2.5",
         "@codemirror/lang-json": "6.0.2",
         "@codemirror/lang-sql": "6.10.0",
+        "@codemirror/merge": "6.12.2",
         "@codemirror/state": "6.7.1",
         "@codemirror/view": "6.43.8",
         "@ng-bootstrap/ng-bootstrap": "21.0.0",
@@ -923,6 +924,19 @@
         "@codemirror/state": "^6.0.0",
         "@codemirror/view": "^6.42.0",
         "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/merge": {
+      "version": "6.12.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/merge/-/merge-6.12.2.tgz",
+      "integrity": "sha512-V8JvyAPjHbPupqP7BeMcsdsYCbyPij74jxIbaIJDORI+VZzW44zFmon8bF+oxGWvOKhcRmkiUMXd8MxHr3YA2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/highlight": "^1.0.0",
+        "style-mod": "^4.1.0"
       }
     },
     "node_modules/@codemirror/search": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -32,6 +32,7 @@
     "@codemirror/lang-javascript": "6.2.5",
     "@codemirror/lang-json": "6.0.2",
     "@codemirror/lang-sql": "6.10.0",
+    "@codemirror/merge": "6.12.2",
     "@codemirror/state": "6.7.1",
     "@codemirror/view": "6.43.8",
     "@ng-bootstrap/ng-bootstrap": "21.0.0",

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -19,6 +19,7 @@ import { OIARegistrationComponent } from './engine/oia-registration/oia-registra
 import { UnsavedChangesGuard } from './shared/unsaved-changes.guard';
 import { ExploreNorthCacheComponent } from './north/explore-north-cache/explore-north-cache.component';
 import { ExploreHistoryCacheComponent } from './history-query/explore-history-cache/explore-history-cache.component';
+import { AuditListComponent } from './audit/audit-list.component';
 
 export const ROUTES: Routes = [
   { path: 'login', component: LoginComponent },
@@ -103,6 +104,10 @@ export const ROUTES: Routes = [
       {
         path: 'logs',
         component: LogsComponent
+      },
+      {
+        path: 'audit',
+        component: AuditListComponent
       },
       {
         path: 'about',

--- a/frontend/src/app/audit/audit-list.component.html
+++ b/frontend/src/app/audit/audit-list.component.html
@@ -1,0 +1,107 @@
+<div class="oib-padded-container">
+  <div class="oib-header-container">
+    <div class="row mb-3">
+      <div class="col d-flex">
+        <div class="oib-block-title">
+          <span class="fa fa-history fa-2x pt-2"></span>
+        </div>
+        <h1 class="oib-title" translate="audit.title"></h1>
+      </div>
+    </div>
+
+    <form class="p-3 oib-search-form mb-3" id="audit-form" [formGroup]="searchForm" (ngSubmit)="triggerSearch()">
+      <div class="d-flex flex-wrap align-items-center gap-3">
+        <div class="d-flex align-items-center gap-2">
+          <label for="entity-type" class="col-form-label text-nowrap" translate="audit.search.entity-type"></label>
+          <select class="form-select" id="entity-type" formControlName="entityType">
+            <option [ngValue]="null" translate="audit.search.all-entity-types"></option>
+            @for (entityType of entityTypes; track entityType) {
+              <option [ngValue]="entityType">{{ entityType | auditEntityTypesEnum }}</option>
+            }
+          </select>
+        </div>
+
+        <div class="d-flex align-items-center gap-2">
+          <label for="action" class="col-form-label text-nowrap" translate="audit.search.action"></label>
+          <select class="form-select" id="action" formControlName="action">
+            <option [ngValue]="null" translate="audit.search.all-actions"></option>
+            @for (action of actions; track action) {
+              <option [ngValue]="action">{{ 'audit.actions.' + action | translate }}</option>
+            }
+          </select>
+        </div>
+
+        <div class="d-flex align-items-center gap-2">
+          <label for="start" class="col-form-label text-nowrap" translate="audit.search.start"></label>
+          <oib-datetimepicker formControlName="start" id="start" />
+        </div>
+
+        <div class="d-flex align-items-center gap-2">
+          <label for="end" class="col-form-label text-nowrap" translate="audit.search.end"></label>
+          <div>
+            <oib-datetimepicker formControlName="end" id="end" />
+            <val-errors [control]="searchForm" />
+          </div>
+        </div>
+
+        <div class="search-buttons ms-auto d-flex gap-2 align-items-center flex-shrink-0">
+          <button class="btn btn-primary" id="search-button" [disabled]="loading()">
+            @if (loading()) {
+              <span class="fa fa-spin fa-spinner"></span>
+            } @else {
+              <span translate="common.search"></span>
+            }
+          </button>
+        </div>
+      </div>
+    </form>
+
+    @if (entries().totalElements !== 0) {
+      <div class="d-flex justify-content-end mb-2">
+        <oib-pagination [page]="entries()" [navigate]="true" />
+      </div>
+    }
+    @if (entries().totalElements !== 0) {
+      <div class="table-container">
+        <table class="table table-sm table-hover">
+          <thead>
+            <tr>
+              <th translate="audit.entity-type"></th>
+              <th translate="audit.entity-id"></th>
+              <th translate="audit.action"></th>
+              <th translate="audit.user"></th>
+              <th translate="audit.date"></th>
+              <th style="width: 1%" translate="audit.details"></th>
+            </tr>
+          </thead>
+          <tbody>
+            @for (entry of entries().content; track entry.id) {
+              <tr class="data">
+                <td>{{ entry.entityType | auditEntityTypesEnum }}</td>
+                <td>{{ entry.entityId }}</td>
+                <td>
+                  <span
+                    class="badge"
+                    [class.bg-success]="entry.action === 'CREATE'"
+                    [class.bg-primary]="entry.action === 'UPDATE'"
+                    [class.bg-danger]="entry.action === 'DELETE'"
+                    [translate]="'audit.actions.' + entry.action"
+                  ></span>
+                </td>
+                <td>{{ entry.userId }}</td>
+                <td class="text-nowrap">{{ entry.createdAt | datetime: 'ff' }}</td>
+                <td>
+                  <button type="button" class="btn btn-link" id="view-details-button" (click)="showHistory(entry)">
+                    <span class="fa fa-eye"></span>
+                  </button>
+                </td>
+              </tr>
+            }
+          </tbody>
+        </table>
+      </div>
+    } @else {
+      <div class="oi-details empty" translate="audit.none"></div>
+    }
+  </div>
+</div>

--- a/frontend/src/app/audit/audit-list.component.html
+++ b/frontend/src/app/audit/audit-list.component.html
@@ -1,11 +1,8 @@
 <div class="oib-padded-container">
   <div class="oib-header-container">
     <div class="row mb-3">
-      <div class="col d-flex">
-        <div class="oib-block-title">
-          <span class="fa fa-history fa-2x pt-2"></span>
-        </div>
-        <h1 class="oib-title" translate="audit.title"></h1>
+      <div class="col">
+        <h1 id="title" translate="audit.title"></h1>
       </div>
     </div>
 
@@ -63,7 +60,7 @@
     }
     @if (entries().totalElements !== 0) {
       <div class="table-container">
-        <table class="table table-sm table-hover">
+        <table class="table table-sm table-hover oib-table">
           <thead>
             <tr>
               <th translate="audit.entity-type"></th>
@@ -71,7 +68,7 @@
               <th translate="audit.action"></th>
               <th translate="audit.user"></th>
               <th translate="audit.date"></th>
-              <th style="width: 1%" translate="audit.details"></th>
+              <th></th>
             </tr>
           </thead>
           <tbody>
@@ -91,8 +88,14 @@
                 <td>{{ entry.userId }}</td>
                 <td class="text-nowrap">{{ entry.createdAt | datetime: 'ff' }}</td>
                 <td>
-                  <button type="button" class="btn btn-link" id="view-details-button" (click)="showHistory(entry)">
-                    <span class="fa fa-eye"></span>
+                  <button
+                    type="button"
+                    class="btn btn-link"
+                    id="view-details-button"
+                    [ngbTooltip]="'audit.tooltips.view' | translate"
+                    (click)="showHistory(entry)"
+                  >
+                    <span class="fa fa-search"></span>
                   </button>
                 </td>
               </tr>

--- a/frontend/src/app/audit/audit-list.component.scss
+++ b/frontend/src/app/audit/audit-list.component.scss
@@ -1,0 +1,5 @@
+.oib-search-form {
+  .row {
+    align-items: center;
+  }
+}

--- a/frontend/src/app/audit/audit-list.component.spec.ts
+++ b/frontend/src/app/audit/audit-list.component.spec.ts
@@ -1,0 +1,169 @@
+import { TestBed } from '@angular/core/testing';
+import { ActivatedRoute, provideRouter, Router } from '@angular/router';
+import { BehaviorSubject, of } from 'rxjs';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { page } from 'vitest/browser';
+
+import { AuditListComponent } from './audit-list.component';
+import { provideI18nTesting } from '../../i18n/mock-i18n';
+import { AuditService } from '../services/audit.service';
+import { ModalService, Modal } from '../shared/modal.service';
+import { PageLoader } from '../shared/page-loader.service';
+import { AuditLogDTO } from '../../../../backend/shared/model/audit.model';
+import { Page } from '../../../../backend/shared/model/types';
+import { emptyPage, toPage } from '../shared/test-utils';
+import { createMock, MockObject, stubRoute } from '../../test/vitest-create-mock';
+import { provideNgbConfigTesting } from '../shared/form/oi-ngb-testing';
+import { AuditHistoryModalComponent } from '../shared/audit-history-modal/audit-history-modal.component';
+
+class AuditListComponentTester {
+  readonly fixture = TestBed.createComponent(AuditListComponent);
+  readonly component = this.fixture.componentInstance;
+  readonly root = page.elementLocator(this.fixture.nativeElement);
+  readonly emptyContainer = this.root.getByCss('.empty');
+  readonly rows = this.root.getByCss('tbody tr');
+  readonly searchButton = this.root.getByCss('#search-button');
+  readonly entityTypeSelect = this.root.getByCss('#entity-type');
+  readonly viewDetailsButtons = this.root.getByCss('#view-details-button');
+
+  cells(rowIndex: number) {
+    return this.rows.nth(rowIndex).getByCss('td');
+  }
+}
+
+describe('AuditListComponent', () => {
+  let tester: AuditListComponentTester;
+  let auditService: MockObject<AuditService>;
+  let modalService: MockObject<ModalService>;
+  let pageLoader: MockObject<PageLoader>;
+  let pageLoads$: BehaviorSubject<number>;
+
+  const emptyAuditPage: Page<AuditLogDTO> = emptyPage();
+  const auditPage: Page<AuditLogDTO> = toPage([
+    {
+      id: '1',
+      entityType: 'south_connector',
+      entityId: 'south1',
+      action: 'CREATE',
+      previousState: null,
+      newState: { name: 'My South' },
+      userId: 'admin',
+      createdAt: '2023-01-01T00:00:00.000Z'
+    },
+    {
+      id: '2',
+      entityType: 'north_connector',
+      entityId: 'north1',
+      action: 'UPDATE',
+      previousState: { name: 'Old' },
+      newState: { name: 'New' },
+      userId: 'admin',
+      createdAt: '2023-01-02T00:00:00.000Z'
+    }
+  ]);
+
+  const route = stubRoute({
+    queryParams: {
+      start: '2023-01-01T00:00:00.000Z',
+      page: '0'
+    }
+  });
+
+  beforeEach(() => {
+    auditService = createMock(AuditService);
+    modalService = createMock(ModalService);
+    pageLoader = createMock(PageLoader);
+    pageLoads$ = new BehaviorSubject<number>(0);
+    pageLoader.pageLoads$ = pageLoads$.asObservable();
+
+    TestBed.configureTestingModule({
+      providers: [
+        provideI18nTesting(),
+        provideRouter([]),
+        provideHttpClientTesting(),
+        provideNgbConfigTesting(),
+        { provide: AuditService, useValue: auditService },
+        { provide: ModalService, useValue: modalService },
+        { provide: PageLoader, useValue: pageLoader },
+        { provide: ActivatedRoute, useValue: route }
+      ]
+    });
+
+    tester = new AuditListComponentTester();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test('should have empty page', async () => {
+    auditService.search.mockReturnValue(of(emptyAuditPage));
+    tester.fixture.detectChanges();
+
+    await expect.element(tester.emptyContainer).toHaveTextContent('No audit log found');
+  });
+
+  test('should load the default search on init and render results', async () => {
+    auditService.search.mockReturnValue(of(auditPage));
+    tester.fixture.detectChanges();
+
+    await vi.waitFor(() => {
+      expect(auditService.search).toHaveBeenCalledWith({
+        entityType: undefined,
+        action: undefined,
+        start: '2023-01-01T00:00:00.000Z',
+        end: undefined,
+        page: 0
+      });
+    });
+    tester.fixture.detectChanges();
+
+    await expect.element(tester.rows).toHaveLength(2);
+    await expect.element(tester.cells(0).nth(0)).toHaveTextContent('South connector');
+    await expect.element(tester.cells(0).nth(1)).toHaveTextContent('south1');
+    await expect.element(tester.cells(0).nth(3)).toHaveTextContent('admin');
+  });
+
+  test('should trigger a new search with the selected entity type filter', () => {
+    auditService.search.mockReturnValue(of(auditPage));
+    tester.fixture.detectChanges();
+
+    const router = TestBed.inject(Router);
+    const navigateSpy = vi.spyOn(router, 'navigate').mockImplementation(() => Promise.resolve(true));
+
+    tester.component.searchForm.controls.entityType.setValue('north_connector');
+    tester.component.triggerSearch();
+
+    expect(navigateSpy).toHaveBeenCalledWith(
+      [],
+      expect.objectContaining({ queryParams: expect.objectContaining({ entityType: 'north_connector', page: 0 }) })
+    );
+  });
+
+  test('should open the history modal with the entry entity type and id when viewing details', async () => {
+    auditService.search.mockReturnValue(of(auditPage));
+
+    const modalInstance = { prepare: vi.fn() };
+    const modalRef = { componentInstance: modalInstance } as unknown as Modal<AuditHistoryModalComponent>;
+    modalService.open.mockReturnValue(modalRef);
+
+    tester.fixture.detectChanges();
+    await vi.waitFor(() => {
+      expect(auditService.search).toHaveBeenCalled();
+    });
+    tester.fixture.detectChanges();
+
+    await tester.viewDetailsButtons.first().click();
+
+    expect(modalService.open).toHaveBeenCalledWith(AuditHistoryModalComponent);
+    expect(modalInstance.prepare).toHaveBeenCalledWith('south_connector', 'south1');
+  });
+
+  test('ngOnDestroy should unsubscribe the subscription', () => {
+    const sub = tester.component.subscription;
+    expect(sub.closed).toBe(false);
+    tester.component.ngOnDestroy();
+    expect(sub.closed).toBe(true);
+  });
+});

--- a/frontend/src/app/audit/audit-list.component.spec.ts
+++ b/frontend/src/app/audit/audit-list.component.spec.ts
@@ -156,7 +156,7 @@ describe('AuditListComponent', () => {
 
     await tester.viewDetailsButtons.first().click();
 
-    expect(modalService.open).toHaveBeenCalledWith(AuditHistoryModalComponent);
+    expect(modalService.open).toHaveBeenCalledWith(AuditHistoryModalComponent, { size: 'xl' });
     expect(modalInstance.prepare).toHaveBeenCalledWith('south_connector', 'south1');
   });
 

--- a/frontend/src/app/audit/audit-list.component.ts
+++ b/frontend/src/app/audit/audit-list.component.ts
@@ -1,0 +1,129 @@
+import { ChangeDetectionStrategy, Component, inject, OnDestroy, OnInit, signal } from '@angular/core';
+import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
+import { ActivatedRoute, Router } from '@angular/router';
+import { NonNullableFormBuilder, ReactiveFormsModule } from '@angular/forms';
+import { catchError, EMPTY, Subscription, switchMap } from 'rxjs';
+import { DateTime } from 'luxon';
+import { AuditAction, AuditEntityType, AuditLogDTO, AUDIT_ACTIONS, AUDIT_ENTITY_TYPES } from '../../../../backend/shared/model/audit.model';
+import { Instant, Page } from '../../../../backend/shared/model/types';
+import { PageLoader } from '../shared/page-loader.service';
+import { ascendingDates } from '../shared/form/validators';
+import { emptyPage } from '../shared/test-utils';
+import { AuditService, AuditSearchParam } from '../services/audit.service';
+import { PaginationComponent } from '../shared/pagination/pagination.component';
+import { DatetimepickerComponent } from '../shared/datetimepicker/datetimepicker.component';
+import { DatetimePipe } from '../shared/datetime.pipe';
+import { AuditEntityTypesEnumPipe } from '../shared/audit-entity-types-enum.pipe';
+import { OI_FORM_VALIDATION_DIRECTIVES } from '../shared/form/form-validation-directives';
+import { ModalService } from '../shared/modal.service';
+import { AuditHistoryModalComponent } from '../shared/audit-history-modal/audit-history-modal.component';
+
+/**
+ * Standalone, server-paginated page listing every recorded audit log entry, with filters on
+ * entity type, action and a date range. Clicking a row opens the full history for that entity
+ * in the shared `AuditHistoryModalComponent`.
+ */
+@Component({
+  selector: 'oib-audit-list',
+  imports: [
+    ReactiveFormsModule,
+    TranslateDirective,
+    TranslatePipe,
+    PaginationComponent,
+    DatetimepickerComponent,
+    DatetimePipe,
+    AuditEntityTypesEnumPipe,
+    OI_FORM_VALIDATION_DIRECTIVES
+  ],
+  templateUrl: './audit-list.component.html',
+  styleUrl: './audit-list.component.scss',
+  changeDetection: ChangeDetectionStrategy.Eager,
+  providers: [PageLoader]
+})
+export class AuditListComponent implements OnInit, OnDestroy {
+  private route = inject(ActivatedRoute);
+  private router = inject(Router);
+  private pageLoader = inject(PageLoader);
+  private auditService = inject(AuditService);
+  private modalService = inject(ModalService);
+
+  // Kept in sync with AuditEntityType in backend/shared/model/audit.model.ts
+  readonly entityTypes: ReadonlyArray<AuditEntityType> = AUDIT_ENTITY_TYPES;
+  readonly actions: ReadonlyArray<AuditAction> = AUDIT_ACTIONS;
+
+  readonly searchForm = inject(NonNullableFormBuilder).group(
+    {
+      entityType: null as AuditEntityType | null,
+      action: null as AuditAction | null,
+      start: null as Instant | null,
+      end: null as Instant | null,
+      page: null as number | null
+    },
+    { validators: [ascendingDates] }
+  );
+
+  loading = signal(false);
+  entries = signal<Page<AuditLogDTO>>(emptyPage());
+  subscription = new Subscription();
+
+  ngOnInit(): void {
+    const searchParams = this.toSearchParams(this.route);
+    this.searchForm.setValue({
+      entityType: searchParams.entityType ?? null,
+      action: searchParams.action ?? null,
+      start: searchParams.start ?? null,
+      end: searchParams.end ?? null,
+      page: searchParams.page ?? null
+    });
+
+    this.subscription.add(
+      this.pageLoader.pageLoads$
+        .pipe(
+          switchMap(page => {
+            this.loading.set(true);
+            const criteria: AuditSearchParam = { ...this.toSearchParams(this.route), page };
+            return this.auditService.search(criteria).pipe(catchError(() => EMPTY));
+          })
+        )
+        .subscribe(entries => {
+          this.entries.set(entries);
+          this.loading.set(false);
+        })
+    );
+  }
+
+  ngOnDestroy(): void {
+    this.subscription.unsubscribe();
+  }
+
+  toSearchParams(route: ActivatedRoute): AuditSearchParam {
+    const now = DateTime.now().endOf('minute');
+    const queryParamMap = route.snapshot.queryParamMap;
+    const entityType = (queryParamMap.get('entityType') as AuditEntityType | null) || undefined;
+    const action = (queryParamMap.get('action') as AuditAction | null) || undefined;
+    const start = queryParamMap.get('start') ?? now.minus({ days: 1 }).toISO();
+    const end = queryParamMap.get('end') || undefined;
+    const page = queryParamMap.get('page') ? parseInt(queryParamMap.get('page')!, 10) : 0;
+    return { entityType, action, start: start ?? undefined, end, page };
+  }
+
+  triggerSearch(): void {
+    if (!this.searchForm.valid) {
+      return;
+    }
+    const formValue = this.searchForm.value;
+    const criteria: AuditSearchParam = {
+      entityType: formValue.entityType ?? undefined,
+      action: formValue.action ?? undefined,
+      start: formValue.start ?? undefined,
+      end: formValue.end ?? undefined,
+      page: 0
+    };
+    this.router.navigate([], { queryParams: criteria });
+  }
+
+  showHistory(entry: AuditLogDTO): void {
+    const modalRef = this.modalService.open(AuditHistoryModalComponent);
+    modalRef.componentInstance.prepare(entry.entityType, entry.entityId);
+  }
+}

--- a/frontend/src/app/audit/audit-list.component.ts
+++ b/frontend/src/app/audit/audit-list.component.ts
@@ -1,4 +1,5 @@
 import { ChangeDetectionStrategy, Component, inject, OnDestroy, OnInit, signal } from '@angular/core';
+import { NgbTooltip } from '@ng-bootstrap/ng-bootstrap';
 import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { NonNullableFormBuilder, ReactiveFormsModule } from '@angular/forms';
@@ -33,7 +34,8 @@ import { AuditHistoryModalComponent } from '../shared/audit-history-modal/audit-
     DatetimepickerComponent,
     DatetimePipe,
     AuditEntityTypesEnumPipe,
-    OI_FORM_VALIDATION_DIRECTIVES
+    OI_FORM_VALIDATION_DIRECTIVES,
+    NgbTooltip
   ],
   templateUrl: './audit-list.component.html',
   styleUrl: './audit-list.component.scss',
@@ -123,7 +125,7 @@ export class AuditListComponent implements OnInit, OnDestroy {
   }
 
   showHistory(entry: AuditLogDTO): void {
-    const modalRef = this.modalService.open(AuditHistoryModalComponent);
+    const modalRef = this.modalService.open(AuditHistoryModalComponent, { size: 'xl' });
     modalRef.componentInstance.prepare(entry.entityType, entry.entityId);
   }
 }

--- a/frontend/src/app/engine/certificate-list/certificate-list.component.html
+++ b/frontend/src/app/engine/certificate-list/certificate-list.component.html
@@ -105,6 +105,15 @@
             </td>
             <td class="text-nowrap action-buttons">
               <div class="pull-right">
+                <!-- Audit history button -->
+                <button
+                  type="button"
+                  class="btn btn-link show-audit-certificate px-1 py-0"
+                  [ngbTooltip]="'engine.certificate.tooltips.audit' | translate"
+                  (click)="showAudit(certificate)"
+                >
+                  <span class="fa fa-history"></span>
+                </button>
                 <!-- Edit button -->
                 <button
                   type="button"

--- a/frontend/src/app/engine/certificate-list/certificate-list.component.html
+++ b/frontend/src/app/engine/certificate-list/certificate-list.component.html
@@ -105,15 +105,6 @@
             </td>
             <td class="text-nowrap action-buttons">
               <div class="pull-right">
-                <!-- Audit history button -->
-                <button
-                  type="button"
-                  class="btn btn-link show-audit-certificate px-1 py-0"
-                  [ngbTooltip]="'engine.certificate.tooltips.audit' | translate"
-                  (click)="showAudit(certificate)"
-                >
-                  <span class="fa fa-history"></span>
-                </button>
                 <!-- Edit button -->
                 <button
                   type="button"
@@ -131,6 +122,15 @@
                   (click)="deleteCertificate(certificate)"
                 >
                   <span class="fa fa-trash"></span>
+                </button>
+                <!-- Audit history button -->
+                <button
+                  type="button"
+                  class="btn btn-link show-audit-certificate px-1 py-0"
+                  [ngbTooltip]="'engine.certificate.tooltips.audit' | translate"
+                  (click)="showAudit(certificate)"
+                >
+                  <span class="fa fa-history"></span>
                 </button>
               </div>
             </td>

--- a/frontend/src/app/engine/certificate-list/certificate-list.component.spec.ts
+++ b/frontend/src/app/engine/certificate-list/certificate-list.component.spec.ts
@@ -16,6 +16,7 @@ import { MockModalService, provideModalTesting } from '../../shared/mock-modal.s
 import testData from '../../../../../backend/src/tests/utils/test-data';
 import { CertificateDTO } from '../../../../../backend/shared/model/certificate.model';
 import { createMock, MockObject } from '../../../test/vitest-create-mock';
+import { AuditHistoryModalComponent } from '../../shared/audit-history-modal/audit-history-modal.component';
 
 class CertificateListComponentTester {
   readonly fixture = TestBed.createComponent(CertificateListComponent);
@@ -26,6 +27,7 @@ class CertificateListComponentTester {
   readonly deleteButtons = this.root.getByCss('.delete-certificate');
   readonly editButtons = this.root.getByCss('.edit-certificate');
   readonly exportButtons = this.root.getByCss('.export-certificate');
+  readonly auditButtons = this.root.getByCss('.show-audit-certificate');
   readonly noCertificate = this.root.getByCss('#no-certificate');
   readonly certificates = this.root.getByCss('tbody tr');
 
@@ -39,7 +41,9 @@ describe('CertificateListComponent', () => {
   let certificateService: MockObject<CertificateService>;
   let confirmationService: MockObject<ConfirmationService>;
   let notificationService: MockObject<NotificationService>;
-  let modalService: MockModalService<EditCertificateModalComponent | ImportCertificateModalComponent | ExportCertificateModalComponent>;
+  let modalService: MockModalService<
+    EditCertificateModalComponent | ImportCertificateModalComponent | ExportCertificateModalComponent | AuditHistoryModalComponent
+  >;
 
   beforeEach(() => {
     certificateService = createMock(CertificateService);
@@ -133,6 +137,15 @@ describe('CertificateListComponent', () => {
       await tester.exportButtons.nth(0).click();
 
       expect(fakeExportComponent.prepare).toHaveBeenCalledWith(testData.certificates.list[0]);
+    });
+
+    test('should open the audit history modal with the certificate entity type and id', async () => {
+      const fakeAuditComponent = createMock(AuditHistoryModalComponent);
+      modalService.mockClosedModal(fakeAuditComponent);
+
+      await tester.auditButtons.nth(0).click();
+
+      expect(fakeAuditComponent.prepare).toHaveBeenCalledWith('certificate', testData.certificates.list[0].id);
     });
   });
 

--- a/frontend/src/app/engine/certificate-list/certificate-list.component.ts
+++ b/frontend/src/app/engine/certificate-list/certificate-list.component.ts
@@ -19,6 +19,7 @@ import { createPageFromArray, Page } from '../../../../../backend/shared/model/t
 import { emptyPage } from '../../shared/test-utils';
 import { PaginationComponent } from '../../shared/pagination/pagination.component';
 import { AuditInfoComponent } from '../../shared/audit-info/audit-info.component';
+import { AuditHistoryModalComponent } from '../../shared/audit-history-modal/audit-history-modal.component';
 
 type CertificateSortField = 'createdAt' | 'updatedAt' | null;
 type SortDirection = 'asc' | 'desc';
@@ -142,6 +143,14 @@ export class CertificateListComponent {
         name: certificate.name
       });
     });
+  }
+
+  /**
+   * Open a modal to view the audit history of a certificate
+   */
+  showAudit(certificate: CertificateDTO) {
+    const modalRef = this.modalService.open(AuditHistoryModalComponent);
+    modalRef.componentInstance.prepare('certificate', certificate.id);
   }
 
   deleteCertificate(certificate: CertificateDTO) {

--- a/frontend/src/app/engine/certificate-list/certificate-list.component.ts
+++ b/frontend/src/app/engine/certificate-list/certificate-list.component.ts
@@ -149,7 +149,7 @@ export class CertificateListComponent {
    * Open a modal to view the audit history of a certificate
    */
   showAudit(certificate: CertificateDTO) {
-    const modalRef = this.modalService.open(AuditHistoryModalComponent);
+    const modalRef = this.modalService.open(AuditHistoryModalComponent, { size: 'xl' });
     modalRef.componentInstance.prepare('certificate', certificate.id);
   }
 

--- a/frontend/src/app/engine/edit-engine-logger-modal/edit-engine-logger-modal.component.html
+++ b/frontend/src/app/engine/edit-engine-logger-modal/edit-engine-logger-modal.component.html
@@ -3,6 +3,21 @@
 </div>
 <div class="modal-body">
   <form id="engine-logger-form" [formGroup]="form" (ngSubmit)="save()">
+    <!-- Audit trail settings -->
+    <div class="row">
+      <div class="col-4">
+        <div class="form-group">
+          <label class="form-label" for="audit-retention-duration" translate="engine.logger.audit-retention-duration"></label>
+          <div class="input-group">
+            <input type="number" formControlName="auditRetentionDuration" id="audit-retention-duration" class="form-control" />
+            <span class="input-group-text" translate="common.unit.days"></span>
+          </div>
+          <val-errors controlName="auditRetentionDuration" />
+          <div class="form-text" translate="engine.logger.audit-retention-duration-hint"></div>
+        </div>
+      </div>
+    </div>
+
     <div formGroupName="logParameters">
       <!-- OIAnalytics settings -->
       <ng-container formGroupName="oia">

--- a/frontend/src/app/engine/edit-engine-logger-modal/edit-engine-logger-modal.component.spec.ts
+++ b/frontend/src/app/engine/edit-engine-logger-modal/edit-engine-logger-modal.component.spec.ts
@@ -12,6 +12,7 @@ import { NotificationService } from '../../shared/notification.service';
 import { EngineSettingsDTO } from '../../../../../backend/shared/model/engine.model';
 
 const engineSettings = {
+  auditRetentionDuration: 90,
   logger: {
     console: { level: 'silent' },
     file: { level: 'info', maxFileSize: 50, numberOfFiles: 5 },
@@ -29,6 +30,7 @@ class EditEngineLoggerModalTester {
   readonly fileLevelSelect = this.root.getByCss('#file-level');
   readonly databaseLevelSelect = this.root.getByCss('#database-level');
   readonly oiaLevelSelect = this.root.getByCss('#oia-level');
+  readonly auditRetentionDurationInput = this.root.getByCss('#audit-retention-duration');
   readonly saveButton = this.root.getByCss('#save-logger-button');
   readonly cancelButton = this.root.getByCss('#cancel-logger-button');
 }
@@ -60,6 +62,14 @@ describe('EditEngineLoggerModalComponent', () => {
     tester.fixture.componentInstance.initialize(engineSettings);
     tester.fixture.detectChanges();
     await expect.element(tester.consoleLevelSelect).toHaveValue('0: silent');
+    await expect.element(tester.auditRetentionDurationInput).toHaveValue(90);
+  });
+
+  test('should initialize the audit retention duration to 0 when not set', async () => {
+    const tester = new EditEngineLoggerModalTester();
+    tester.fixture.componentInstance.initialize({ ...engineSettings, auditRetentionDuration: null });
+    tester.fixture.detectChanges();
+    await expect.element(tester.auditRetentionDurationInput).toHaveValue(0);
   });
 
   test('should save logger settings and close modal', async () => {
@@ -69,8 +79,17 @@ describe('EditEngineLoggerModalComponent', () => {
     tester.fixture.detectChanges();
     await tester.saveButton.click();
     expect(engineService.updateEngineLogger).toHaveBeenCalled();
+    expect(engineService.updateEngineLogger).toHaveBeenCalledWith(expect.objectContaining({ auditRetentionDuration: 90 }));
     expect(notificationService.success).toHaveBeenCalledWith('engine.updated');
     expect(activeModal.close).toHaveBeenCalled();
+  });
+
+  test('should reject a negative audit retention duration', async () => {
+    const tester = new EditEngineLoggerModalTester();
+    tester.fixture.componentInstance.initialize(engineSettings);
+    tester.fixture.detectChanges();
+    await tester.auditRetentionDurationInput.fill('-1');
+    expect(tester.fixture.componentInstance.form.controls.auditRetentionDuration.valid).toBe(false);
   });
 
   test('should dismiss modal on cancel', async () => {

--- a/frontend/src/app/engine/edit-engine-logger-modal/edit-engine-logger-modal.component.ts
+++ b/frontend/src/app/engine/edit-engine-logger-modal/edit-engine-logger-modal.component.ts
@@ -24,6 +24,7 @@ export class EditEngineLoggerModalComponent {
   private fb = inject(NonNullableFormBuilder);
 
   form = this.fb.group({
+    auditRetentionDuration: [0 as number | null, [Validators.required, Validators.min(0)]],
     logParameters: this.fb.group({
       console: this.fb.group({
         level: ['silent' as LogLevel, Validators.required]
@@ -126,7 +127,7 @@ export class EditEngineLoggerModalComponent {
   }
 
   initialize(settings: EngineSettingsDTO) {
-    this.form.patchValue({ logParameters: settings.logger });
+    this.form.patchValue({ auditRetentionDuration: settings.auditRetentionDuration ?? 0, logParameters: settings.logger });
     this.initializeValidators();
   }
 
@@ -191,6 +192,7 @@ export class EditEngineLoggerModalComponent {
     const formValue = this.form.getRawValue();
     this.engineService
       .updateEngineLogger({
+        auditRetentionDuration: formValue.auditRetentionDuration,
         console: { level: formValue.logParameters.console.level },
         file: {
           level: formValue.logParameters.file.level,

--- a/frontend/src/app/engine/engine-detail.component.html
+++ b/frontend/src/app/engine/engine-detail.component.html
@@ -154,6 +154,10 @@
                   <span translate="engine.general-settings.oia" [translateParams]="{ level: settings.logger.oia.level }"></span>
                 </td>
               </tr>
+              <tr>
+                <td class="first-column-body" translate="engine.logger.audit-retention-duration"></td>
+                <td class="last-column-body">{{ settings.auditRetentionDuration || 0 }} {{ 'common.unit.days' | translate }}</td>
+              </tr>
             </tbody>
           </table>
         </oib-box>

--- a/frontend/src/app/engine/engine-detail.component.ts
+++ b/frontend/src/app/engine/engine-detail.component.ts
@@ -92,7 +92,7 @@ export class EngineDetailComponent {
   }
 
   openLoggerModal() {
-    const modal = this.modalService.open(EditEngineLoggerModalComponent);
+    const modal = this.modalService.open(EditEngineLoggerModalComponent, { size: 'lg' });
     modal.componentInstance.initialize(this.engineSettings()!);
     modal.result.subscribe(() => this.refresh$.next());
   }

--- a/frontend/src/app/engine/ip-filter-list/ip-filter-list.component.html
+++ b/frontend/src/app/engine/ip-filter-list/ip-filter-list.component.html
@@ -72,6 +72,15 @@
             </td>
             <td class="text-nowrap action-buttons">
               <div class="pull-right">
+                <!-- Audit history button -->
+                <button
+                  type="button"
+                  class="btn btn-link show-audit-ip-filter px-1 py-0"
+                  [ngbTooltip]="'engine.ip-filter.tooltips.audit' | translate"
+                  (click)="showAudit(ipFilter)"
+                >
+                  <span class="fa fa-history"></span>
+                </button>
                 <!-- Edit button -->
                 <button
                   type="button"

--- a/frontend/src/app/engine/ip-filter-list/ip-filter-list.component.html
+++ b/frontend/src/app/engine/ip-filter-list/ip-filter-list.component.html
@@ -72,15 +72,6 @@
             </td>
             <td class="text-nowrap action-buttons">
               <div class="pull-right">
-                <!-- Audit history button -->
-                <button
-                  type="button"
-                  class="btn btn-link show-audit-ip-filter px-1 py-0"
-                  [ngbTooltip]="'engine.ip-filter.tooltips.audit' | translate"
-                  (click)="showAudit(ipFilter)"
-                >
-                  <span class="fa fa-history"></span>
-                </button>
                 <!-- Edit button -->
                 <button
                   type="button"
@@ -98,6 +89,15 @@
                   (click)="deleteIpFilter(ipFilter)"
                 >
                   <span class="fa fa-trash"></span>
+                </button>
+                <!-- Audit history button -->
+                <button
+                  type="button"
+                  class="btn btn-link show-audit-ip-filter px-1 py-0"
+                  [ngbTooltip]="'engine.ip-filter.tooltips.audit' | translate"
+                  (click)="showAudit(ipFilter)"
+                >
+                  <span class="fa fa-history"></span>
                 </button>
               </div>
             </td>

--- a/frontend/src/app/engine/ip-filter-list/ip-filter-list.component.spec.ts
+++ b/frontend/src/app/engine/ip-filter-list/ip-filter-list.component.spec.ts
@@ -14,6 +14,7 @@ import { MockModalService, provideModalTesting } from '../../shared/mock-modal.s
 import testData from '../../../../../backend/src/tests/utils/test-data';
 import { IPFilterDTO } from '../../../../../backend/shared/model/ip-filter.model';
 import { createMock, MockObject } from '../../../test/vitest-create-mock';
+import { AuditHistoryModalComponent } from '../../shared/audit-history-modal/audit-history-modal.component';
 
 class IpFilterListComponentTester {
   readonly fixture = TestBed.createComponent(IpFilterListComponent);
@@ -21,6 +22,7 @@ class IpFilterListComponentTester {
   readonly ipFilters = this.root.getByCss('tbody tr');
   readonly deleteButtons = this.root.getByCss('.delete-ip-filter');
   readonly editButtons = this.root.getByCss('.edit-ip-filter');
+  readonly auditButtons = this.root.getByCss('.show-audit-ip-filter');
   readonly addIpFilter = this.root.getByCss('#add-ip-filter');
   readonly noIpFilter = this.root.getByCss('#no-ip-filter');
   readonly disabledMessage = this.root.getByCss('#ip-filter-disabled');
@@ -36,7 +38,7 @@ describe('IpFilterListComponent', () => {
   let engineService: MockObject<EngineService>;
   let confirmationService: MockObject<ConfirmationService>;
   let notificationService: MockObject<NotificationService>;
-  let modalService: MockModalService<EditIpFilterModalComponent>;
+  let modalService: MockModalService<EditIpFilterModalComponent | AuditHistoryModalComponent>;
 
   beforeEach(() => {
     ipFilterService = createMock(IpFilterService);
@@ -107,6 +109,15 @@ describe('IpFilterListComponent', () => {
       expect(fakeEditComponent.prepareForCreation).toHaveBeenCalled();
       expect(ipFilterService.list).toHaveBeenCalledTimes(1);
       expect(notificationService.success).toHaveBeenCalledWith('engine.ip-filter.created', { address: 'new-address' });
+    });
+
+    test('should open the audit history modal with the ip filter entity type and id', async () => {
+      const fakeAuditComponent = createMock(AuditHistoryModalComponent);
+      modalService.mockClosedModal(fakeAuditComponent);
+
+      await tester.auditButtons.nth(0).click();
+
+      expect(fakeAuditComponent.prepare).toHaveBeenCalledWith('ip_filter', testData.ipFilters.list[0].id);
     });
   });
 

--- a/frontend/src/app/engine/ip-filter-list/ip-filter-list.component.ts
+++ b/frontend/src/app/engine/ip-filter-list/ip-filter-list.component.ts
@@ -16,6 +16,7 @@ import { createPageFromArray, Page } from '../../../../../backend/shared/model/t
 import { emptyPage } from '../../shared/test-utils';
 import { PaginationComponent } from '../../shared/pagination/pagination.component';
 import { AuditInfoComponent } from '../../shared/audit-info/audit-info.component';
+import { AuditHistoryModalComponent } from '../../shared/audit-history-modal/audit-history-modal.component';
 
 type IpFilterSortField = 'address' | 'createdAt' | 'updatedAt' | null;
 type SortDirection = 'asc' | 'desc';
@@ -127,6 +128,14 @@ export class IpFilterListComponent {
           address: ipFilter.address
         });
       });
+  }
+
+  /**
+   * Open a modal to view the audit history of an IP filter
+   */
+  showAudit(ipFilter: IPFilterDTO) {
+    const modalRef = this.modalService.open(AuditHistoryModalComponent);
+    modalRef.componentInstance.prepare('ip_filter', ipFilter.id);
   }
 
   toggleSort(field: IpFilterSortField) {

--- a/frontend/src/app/engine/ip-filter-list/ip-filter-list.component.ts
+++ b/frontend/src/app/engine/ip-filter-list/ip-filter-list.component.ts
@@ -134,7 +134,7 @@ export class IpFilterListComponent {
    * Open a modal to view the audit history of an IP filter
    */
   showAudit(ipFilter: IPFilterDTO) {
-    const modalRef = this.modalService.open(AuditHistoryModalComponent);
+    const modalRef = this.modalService.open(AuditHistoryModalComponent, { size: 'xl' });
     modalRef.componentInstance.prepare('ip_filter', ipFilter.id);
   }
 

--- a/frontend/src/app/engine/scan-mode-list/scan-mode-list.component.html
+++ b/frontend/src/app/engine/scan-mode-list/scan-mode-list.component.html
@@ -78,15 +78,6 @@
             </td>
             <td class="text-nowrap action-buttons">
               <div class="pull-right">
-                <!-- Audit history button -->
-                <button
-                  type="button"
-                  class="btn btn-link show-audit-scan-mode px-1 py-0"
-                  [ngbTooltip]="'engine.scan-mode.tooltips.audit' | translate"
-                  (click)="showAudit(scanMode)"
-                >
-                  <span class="fa fa-history"></span>
-                </button>
                 <!-- Edit button -->
                 <button
                   type="button"
@@ -104,6 +95,15 @@
                   (click)="deleteScanMode(scanMode)"
                 >
                   <span class="fa fa-trash"></span>
+                </button>
+                <!-- Audit history button -->
+                <button
+                  type="button"
+                  class="btn btn-link show-audit-scan-mode px-1 py-0"
+                  [ngbTooltip]="'engine.scan-mode.tooltips.audit' | translate"
+                  (click)="showAudit(scanMode)"
+                >
+                  <span class="fa fa-history"></span>
                 </button>
               </div>
             </td>

--- a/frontend/src/app/engine/scan-mode-list/scan-mode-list.component.html
+++ b/frontend/src/app/engine/scan-mode-list/scan-mode-list.component.html
@@ -78,6 +78,15 @@
             </td>
             <td class="text-nowrap action-buttons">
               <div class="pull-right">
+                <!-- Audit history button -->
+                <button
+                  type="button"
+                  class="btn btn-link show-audit-scan-mode px-1 py-0"
+                  [ngbTooltip]="'engine.scan-mode.tooltips.audit' | translate"
+                  (click)="showAudit(scanMode)"
+                >
+                  <span class="fa fa-history"></span>
+                </button>
                 <!-- Edit button -->
                 <button
                   type="button"

--- a/frontend/src/app/engine/scan-mode-list/scan-mode-list.component.spec.ts
+++ b/frontend/src/app/engine/scan-mode-list/scan-mode-list.component.spec.ts
@@ -13,6 +13,7 @@ import { MockModalService, provideModalTesting } from '../../shared/mock-modal.s
 import testData from '../../../../../backend/src/tests/utils/test-data';
 import { ScanModeDTO } from '../../../../../backend/shared/model/scan-mode.model';
 import { createMock, MockObject } from '../../../test/vitest-create-mock';
+import { AuditHistoryModalComponent } from '../../shared/audit-history-modal/audit-history-modal.component';
 
 class ScanModeListComponentTester {
   readonly fixture = TestBed.createComponent(ScanModeListComponent);
@@ -20,6 +21,7 @@ class ScanModeListComponentTester {
   readonly scanModes = this.root.getByCss('tbody tr');
   readonly deleteButtons = this.root.getByCss('.delete-scan-mode');
   readonly editButtons = this.root.getByCss('.edit-scan-mode');
+  readonly auditButtons = this.root.getByCss('.show-audit-scan-mode');
   readonly addScanMode = this.root.getByCss('#add-scan-mode');
   readonly noScanMode = this.root.getByCss('#no-scan-mode');
 
@@ -33,7 +35,7 @@ describe('ScanModeListComponent', () => {
   let scanModeService: MockObject<ScanModeService>;
   let confirmationService: MockObject<ConfirmationService>;
   let notificationService: MockObject<NotificationService>;
-  let modalService: MockModalService<EditScanModeModalComponent>;
+  let modalService: MockModalService<EditScanModeModalComponent | AuditHistoryModalComponent>;
 
   beforeEach(() => {
     scanModeService = createMock(ScanModeService);
@@ -95,6 +97,16 @@ describe('ScanModeListComponent', () => {
 
       expect(fakeEditComponent.prepareForCreation).toHaveBeenCalled();
       expect(notificationService.success).toHaveBeenCalledWith('engine.scan-mode.created', { name: 'new-scan-mode' });
+    });
+
+    test('should open the audit history modal with the scan mode entity type and id', async () => {
+      const nonSubscriptionScanModes = testData.scanMode.list.filter(s => s.id !== 'subscription');
+      const fakeAuditComponent = createMock(AuditHistoryModalComponent);
+      modalService.mockClosedModal(fakeAuditComponent);
+
+      await tester.auditButtons.nth(0).click();
+
+      expect(fakeAuditComponent.prepare).toHaveBeenCalledWith('scan_mode', nonSubscriptionScanModes[0].id);
     });
   });
 

--- a/frontend/src/app/engine/scan-mode-list/scan-mode-list.component.ts
+++ b/frontend/src/app/engine/scan-mode-list/scan-mode-list.component.ts
@@ -127,7 +127,7 @@ export class ScanModeListComponent {
    * Open a modal to view the audit history of a scan mode
    */
   showAudit(scanMode: ScanModeDTO) {
-    const modalRef = this.modalService.open(AuditHistoryModalComponent);
+    const modalRef = this.modalService.open(AuditHistoryModalComponent, { size: 'xl' });
     modalRef.componentInstance.prepare('scan_mode', scanMode.id);
   }
 

--- a/frontend/src/app/engine/scan-mode-list/scan-mode-list.component.ts
+++ b/frontend/src/app/engine/scan-mode-list/scan-mode-list.component.ts
@@ -16,6 +16,7 @@ import { emptyPage } from '../../shared/test-utils';
 import { PaginationComponent } from '../../shared/pagination/pagination.component';
 import { AuditInfoComponent } from '../../shared/audit-info/audit-info.component';
 import { isScanModeWindowExpired, ScanModeSchedulePipe } from '../../shared/scan-mode-schedule.pipe';
+import { AuditHistoryModalComponent } from '../../shared/audit-history-modal/audit-history-modal.component';
 
 type ScanModeSortField = 'name' | 'createdAt' | 'updatedAt' | null;
 type SortDirection = 'asc' | 'desc';
@@ -120,6 +121,14 @@ export class ScanModeListComponent {
         )
       )
       .subscribe();
+  }
+
+  /**
+   * Open a modal to view the audit history of a scan mode
+   */
+  showAudit(scanMode: ScanModeDTO) {
+    const modalRef = this.modalService.open(AuditHistoryModalComponent);
+    modalRef.componentInstance.prepare('scan_mode', scanMode.id);
   }
 
   isWindowExpired(scanMode: ScanModeDTO): boolean {

--- a/frontend/src/app/engine/transformer-list/transformer-list.component.html
+++ b/frontend/src/app/engine/transformer-list/transformer-list.component.html
@@ -69,6 +69,15 @@
             </td>
             <td class="text-nowrap action-buttons">
               <div class="pull-right">
+                <!-- Audit history button -->
+                <button
+                  type="button"
+                  class="btn btn-link show-audit-transformer px-1 py-0"
+                  [ngbTooltip]="'configuration.oibus.manifest.transformers.edit-transformer-modal.tooltips.audit' | translate"
+                  (click)="showAudit(transformer)"
+                >
+                  <span class="fa fa-history"></span>
+                </button>
                 <!-- Edit button -->
                 <button
                   type="button"

--- a/frontend/src/app/engine/transformer-list/transformer-list.component.html
+++ b/frontend/src/app/engine/transformer-list/transformer-list.component.html
@@ -69,15 +69,6 @@
             </td>
             <td class="text-nowrap action-buttons">
               <div class="pull-right">
-                <!-- Audit history button -->
-                <button
-                  type="button"
-                  class="btn btn-link show-audit-transformer px-1 py-0"
-                  [ngbTooltip]="'configuration.oibus.manifest.transformers.edit-transformer-modal.tooltips.audit' | translate"
-                  (click)="showAudit(transformer)"
-                >
-                  <span class="fa fa-history"></span>
-                </button>
                 <!-- Edit button -->
                 <button
                   type="button"
@@ -95,6 +86,15 @@
                   (click)="deleteTransformer(transformer)"
                 >
                   <span class="fa fa-trash"></span>
+                </button>
+                <!-- Audit history button -->
+                <button
+                  type="button"
+                  class="btn btn-link show-audit-transformer px-1 py-0"
+                  [ngbTooltip]="'configuration.oibus.manifest.transformers.edit-transformer-modal.tooltips.audit' | translate"
+                  (click)="showAudit(transformer)"
+                >
+                  <span class="fa fa-history"></span>
                 </button>
               </div>
             </td>

--- a/frontend/src/app/engine/transformer-list/transformer-list.component.spec.ts
+++ b/frontend/src/app/engine/transformer-list/transformer-list.component.spec.ts
@@ -13,6 +13,7 @@ import { MockModalService, provideModalTesting } from '../../shared/mock-modal.s
 import testData from '../../../../../backend/src/tests/utils/test-data';
 import { createMock, MockObject } from '../../../test/vitest-create-mock';
 import { CustomTransformerDTO, TransformerDTO } from '../../../../../backend/shared/model/transformer.model';
+import { AuditHistoryModalComponent } from '../../shared/audit-history-modal/audit-history-modal.component';
 
 class TransformerListComponentTester {
   readonly fixture = TestBed.createComponent(TransformerListComponent);
@@ -20,6 +21,7 @@ class TransformerListComponentTester {
   readonly transformers = this.root.getByCss('tbody tr');
   readonly deleteButtons = this.root.getByCss('.delete-transformer');
   readonly addTransformer = this.root.getByCss('#add-transformer');
+  readonly auditButtons = this.root.getByCss('.show-audit-transformer');
   readonly noTransformer = this.root.getByCss('#no-transformer');
 
   constructor() {
@@ -32,7 +34,7 @@ describe('TransformerListComponent', () => {
   let transformerService: MockObject<TransformerService>;
   let confirmationService: MockObject<ConfirmationService>;
   let notificationService: MockObject<NotificationService>;
-  let modalService: MockModalService<EditTransformerModalComponent>;
+  let modalService: MockModalService<EditTransformerModalComponent | AuditHistoryModalComponent>;
 
   beforeEach(() => {
     transformerService = createMock(TransformerService);
@@ -89,6 +91,16 @@ describe('TransformerListComponent', () => {
       expect(notificationService.success).toHaveBeenCalledWith('configuration.oibus.manifest.transformers.created', {
         name: newTransformer.name
       });
+    });
+
+    test('should open the audit history modal with the transformer entity type and id', async () => {
+      const transformer = testData.transformers.customList[0] as unknown as CustomTransformerDTO;
+      const fakeAuditComponent = createMock(AuditHistoryModalComponent);
+      modalService.mockClosedModal(fakeAuditComponent);
+
+      await tester.auditButtons.nth(0).click();
+
+      expect(fakeAuditComponent.prepare).toHaveBeenCalledWith('transformer', transformer.id);
     });
   });
 

--- a/frontend/src/app/engine/transformer-list/transformer-list.component.ts
+++ b/frontend/src/app/engine/transformer-list/transformer-list.component.ts
@@ -105,7 +105,7 @@ export class TransformerListComponent {
    * Open a modal to view the audit history of a custom transformer
    */
   showAudit(transformer: CustomTransformerDTO) {
-    const modalRef = this.modalService.open(AuditHistoryModalComponent);
+    const modalRef = this.modalService.open(AuditHistoryModalComponent, { size: 'xl' });
     modalRef.componentInstance.prepare('transformer', transformer.id);
   }
 

--- a/frontend/src/app/engine/transformer-list/transformer-list.component.ts
+++ b/frontend/src/app/engine/transformer-list/transformer-list.component.ts
@@ -15,6 +15,7 @@ import { createPageFromArray, Page } from '../../../../../backend/shared/model/t
 import { emptyPage } from '../../shared/test-utils';
 import { PaginationComponent } from '../../shared/pagination/pagination.component';
 import { AuditInfoComponent } from '../../shared/audit-info/audit-info.component';
+import { AuditHistoryModalComponent } from '../../shared/audit-history-modal/audit-history-modal.component';
 
 type TransformerSortField = 'name' | 'createdAt' | 'updatedAt' | null;
 type SortDirection = 'asc' | 'desc';
@@ -98,6 +99,14 @@ export class TransformerListComponent {
         this.allTransformers = transformers.filter(element => element.type === 'custom') as Array<CustomTransformerDTO>;
         this.updateList(0);
       });
+  }
+
+  /**
+   * Open a modal to view the audit history of a custom transformer
+   */
+  showAudit(transformer: CustomTransformerDTO) {
+    const modalRef = this.modalService.open(AuditHistoryModalComponent);
+    modalRef.componentInstance.prepare('transformer', transformer.id);
   }
 
   deleteTransformer(transformer: CustomTransformerDTO) {

--- a/frontend/src/app/history-query/edit-history-query/edit-history-query.component.spec.ts
+++ b/frontend/src/app/history-query/edit-history-query/edit-history-query.component.spec.ts
@@ -22,6 +22,14 @@ import { createMock, MockObject } from '../../../test/vitest-create-mock';
 import testData from '../../../../../backend/src/tests/utils/test-data';
 import { HistoryQueryDTO } from '../../../../../backend/shared/model/history-query.model';
 
+// Deep-cloned: `EditHistoryQueryComponent` deliberately mutates `historyQuery.caching.trigger.scanMode`
+// in place (to align its reference with an entry in the fetched scan mode list for form binding).
+// Passing the shared `testData` fixture directly would permanently corrupt it for every other spec
+// file relying on the same object under Vitest's browser-mode test runner.
+function cloneHistoryQuery(): HistoryQueryDTO {
+  return JSON.parse(JSON.stringify(testData.historyQueries.list[0]));
+}
+
 function configure(activatedRouteValue: object): {
   historyQueryService: MockObject<HistoryQueryService>;
   modalService: MockObject<ModalService>;
@@ -88,7 +96,7 @@ describe('EditHistoryQueryComponent', () => {
       snapshot: { queryParamMap: { get: () => null, getAll: () => [] } }
     });
 
-    historyQueryService.findById.mockReturnValue(of(testData.historyQueries.list[0] as unknown as HistoryQueryDTO));
+    historyQueryService.findById.mockReturnValue(of(cloneHistoryQuery()));
 
     const fixture = TestBed.createComponent(EditHistoryQueryComponent);
     fixture.detectChanges();
@@ -101,7 +109,7 @@ describe('EditHistoryQueryComponent', () => {
       queryParamMap: of({ get: () => null, getAll: () => [] }),
       snapshot: { queryParamMap: { get: () => null, getAll: () => [] } }
     });
-    historyQueryService.findById.mockReturnValue(of(testData.historyQueries.list[0] as unknown as HistoryQueryDTO));
+    historyQueryService.findById.mockReturnValue(of(cloneHistoryQuery()));
 
     const fixture = TestBed.createComponent(EditHistoryQueryComponent);
     fixture.detectChanges();
@@ -116,7 +124,7 @@ describe('EditHistoryQueryComponent', () => {
       queryParamMap: of({ get: () => null, getAll: () => [] }),
       snapshot: { queryParamMap: { get: () => null, getAll: () => [] } }
     });
-    const historyQuery = testData.historyQueries.list[0] as unknown as HistoryQueryDTO;
+    const historyQuery = cloneHistoryQuery();
     historyQueryService.findById.mockReturnValue(of(historyQuery));
     historyQueryService.startExplore.mockReturnValue(of({ sessionId: 'sessionId', entries: [] }));
     historyQueryService.browseExplore.mockReturnValue(of({ entries: [] }));

--- a/frontend/src/app/history-query/history-query-detail/history-query-detail.component.spec.ts
+++ b/frontend/src/app/history-query/history-query-detail/history-query-detail.component.spec.ts
@@ -26,7 +26,11 @@ import { NorthConnectorManifest } from '../../../../../backend/shared/model/nort
 import { SouthConnectorManifest } from '../../../../../backend/shared/model/south-connector.model';
 import { OIBusInfo } from '../../../../../backend/shared/model/engine.model';
 
-const historyQuery = testData.historyQueries.list[0];
+// Deep-cloned: `testData` fixtures share object references across entities (e.g. multiple
+// connectors point at the same `scanModes[0]` instance), so holding a live reference here makes
+// this suite vulnerable to mutations performed by unrelated spec files sharing the same module
+// instance under Vitest's browser-mode test runner.
+const historyQuery: HistoryQueryDTO = JSON.parse(JSON.stringify(testData.historyQueries.list[0]));
 
 describe('HistoryQueryDetailComponent', () => {
   let historyQueryService: MockObject<HistoryQueryService>;

--- a/frontend/src/app/history-query/history-query-list.component.html
+++ b/frontend/src/app/history-query/history-query-list.component.html
@@ -280,6 +280,15 @@
                     >
                       <span class="fa fa-search"></span>
                     </a>
+                    <!-- Audit history button -->
+                    <button
+                      type="button"
+                      class="btn btn-link show-audit-history-query px-1 py-0"
+                      [ngbTooltip]="'history-query.tooltips.audit' | translate"
+                      (click)="showAudit(query)"
+                    >
+                      <span class="fa fa-history"></span>
+                    </button>
                     <!-- Edit button -->
                     <a
                       class="btn btn-link edit-history-query px-1 py-0"

--- a/frontend/src/app/history-query/history-query-list.component.html
+++ b/frontend/src/app/history-query/history-query-list.component.html
@@ -280,15 +280,6 @@
                     >
                       <span class="fa fa-search"></span>
                     </a>
-                    <!-- Audit history button -->
-                    <button
-                      type="button"
-                      class="btn btn-link show-audit-history-query px-1 py-0"
-                      [ngbTooltip]="'history-query.tooltips.audit' | translate"
-                      (click)="showAudit(query)"
-                    >
-                      <span class="fa fa-history"></span>
-                    </button>
                     <!-- Edit button -->
                     <a
                       class="btn btn-link edit-history-query px-1 py-0"
@@ -315,6 +306,15 @@
                       (click)="delete(query)"
                     >
                       <span class="fa fa-trash"></span>
+                    </button>
+                    <!-- Audit history button -->
+                    <button
+                      type="button"
+                      class="btn btn-link show-audit-history-query px-1 py-0"
+                      [ngbTooltip]="'history-query.tooltips.audit' | translate"
+                      (click)="showAudit(query)"
+                    >
+                      <span class="fa fa-history"></span>
                     </button>
                   </div>
                 </td>

--- a/frontend/src/app/history-query/history-query-list.component.spec.ts
+++ b/frontend/src/app/history-query/history-query-list.component.spec.ts
@@ -9,18 +9,21 @@ import { HistoryQueryListComponent } from './history-query-list.component';
 import { HistoryQueryService } from '../services/history-query.service';
 import { NotificationService } from '../shared/notification.service';
 import { ConfirmationService } from '../shared/confirmation.service';
-import { ModalService } from '../shared/modal.service';
+import { Modal, ModalService } from '../shared/modal.service';
 import { provideI18nTesting } from '../../i18n/mock-i18n';
 import { createMock, MockObject } from '../../test/vitest-create-mock';
 import { provideModalTesting } from '../shared/mock-modal.service.testing';
 import testData from '../../../../backend/src/tests/utils/test-data';
 import { HistoryQueryLightDTO } from '../../../../backend/shared/model/history-query.model';
+import { AuditHistoryModalComponent } from '../shared/audit-history-modal/audit-history-modal.component';
 
 describe('HistoryQueryListComponent', () => {
   let historyQueryService: MockObject<HistoryQueryService>;
+  let modalService: MockObject<ModalService>;
 
   beforeEach(() => {
     historyQueryService = createMock(HistoryQueryService);
+    modalService = createMock(ModalService);
 
     historyQueryService.list.mockReturnValue(of(testData.historyQueries.listLight as unknown as Array<HistoryQueryLightDTO>));
     historyQueryService.start.mockReturnValue(of(undefined));
@@ -35,7 +38,7 @@ describe('HistoryQueryListComponent', () => {
         { provide: HistoryQueryService, useValue: historyQueryService },
         { provide: NotificationService, useValue: createMock(NotificationService) },
         { provide: ConfirmationService, useValue: createMock(ConfirmationService) },
-        { provide: ModalService, useValue: createMock(ModalService) }
+        { provide: ModalService, useValue: modalService }
       ]
     });
   });
@@ -164,5 +167,21 @@ describe('HistoryQueryListComponent', () => {
 
     fixture.componentInstance.toggleSort('southType');
     expect(fixture.componentInstance.sortDirection).toBe('desc');
+  });
+
+  test('should open the audit history modal with the history query entity type and id', async () => {
+    const fixture = TestBed.createComponent(HistoryQueryListComponent);
+    fixture.detectChanges();
+
+    const fakeModalComponent = createMock(AuditHistoryModalComponent);
+    const modalRef = { componentInstance: fakeModalComponent } as unknown as Modal<AuditHistoryModalComponent>;
+    modalService.open.mockReturnValue(modalRef);
+
+    const root = page.elementLocator(fixture.nativeElement);
+    await root.getByCss('.show-audit-history-query').nth(0).click();
+
+    const query = testData.historyQueries.listLight[0] as unknown as HistoryQueryLightDTO;
+    expect(modalService.open).toHaveBeenCalledWith(AuditHistoryModalComponent);
+    expect(fakeModalComponent.prepare).toHaveBeenCalledWith('history_query', query.id);
   });
 });

--- a/frontend/src/app/history-query/history-query-list.component.spec.ts
+++ b/frontend/src/app/history-query/history-query-list.component.spec.ts
@@ -181,7 +181,7 @@ describe('HistoryQueryListComponent', () => {
     await root.getByCss('.show-audit-history-query').nth(0).click();
 
     const query = testData.historyQueries.listLight[0] as unknown as HistoryQueryLightDTO;
-    expect(modalService.open).toHaveBeenCalledWith(AuditHistoryModalComponent);
+    expect(modalService.open).toHaveBeenCalledWith(AuditHistoryModalComponent, { size: 'xl' });
     expect(fakeModalComponent.prepare).toHaveBeenCalledWith('history_query', query.id);
   });
 });

--- a/frontend/src/app/history-query/history-query-list.component.ts
+++ b/frontend/src/app/history-query/history-query-list.component.ts
@@ -157,7 +157,7 @@ export class HistoryQueryListComponent {
    * Open a modal to view the audit history of a history query
    */
   showAudit(historyQuery: HistoryQueryLightDTO) {
-    const modalRef = this.modalService.open(AuditHistoryModalComponent);
+    const modalRef = this.modalService.open(AuditHistoryModalComponent, { size: 'xl' });
     modalRef.componentInstance.prepare('history_query', historyQuery.id);
   }
 

--- a/frontend/src/app/history-query/history-query-list.component.ts
+++ b/frontend/src/app/history-query/history-query-list.component.ts
@@ -23,6 +23,7 @@ import { NgbTooltip } from '@ng-bootstrap/ng-bootstrap';
 import { AuditInfoComponent } from '../shared/audit-info/audit-info.component';
 import { OIBusSouthTypeEnumPipe } from '../shared/oibus-south-type-enum.pipe';
 import { OIBusNorthTypeEnumPipe } from '../shared/oibus-north-type-enum.pipe';
+import { AuditHistoryModalComponent } from '../shared/audit-history-modal/audit-history-modal.component';
 
 type HistorySortField = 'name' | 'interval' | 'southType' | 'northType' | 'createdAt' | 'updatedAt' | null;
 type SortDirection = 'asc' | 'desc';
@@ -150,6 +151,14 @@ export class HistoryQueryListComponent {
     modalRef.result.subscribe(queryParams => {
       this.router.navigate(['/history-queries', 'create'], { queryParams });
     });
+  }
+
+  /**
+   * Open a modal to view the audit history of a history query
+   */
+  showAudit(historyQuery: HistoryQueryLightDTO) {
+    const modalRef = this.modalService.open(AuditHistoryModalComponent);
+    modalRef.componentInstance.prepare('history_query', historyQuery.id);
   }
 
   toggleSort(field: HistorySortField) {

--- a/frontend/src/app/navbar/navbar.component.html
+++ b/frontend/src/app/navbar/navbar.component.html
@@ -30,6 +30,7 @@
           ></a>
           <div ngbDropdownMenu aria-labelledby="accountDropDown">
             <a class="dropdown-item" routerLink="/user-settings" translate="nav.account.settings"></a>
+            <a class="dropdown-item" routerLink="/audit" translate="nav.account.audit"></a>
             <a
               class="dropdown-item"
               role="button"
@@ -80,6 +81,7 @@
           ></a>
           <div ngbDropdownMenu aria-labelledby="accountMobileDropDown" class="dropdown-menu-right">
             <a class="dropdown-item" routerLink="/user-settings" translate="nav.account.settings"></a>
+            <a class="dropdown-item" routerLink="/audit" translate="nav.account.audit"></a>
             <a
               class="dropdown-item"
               role="button"

--- a/frontend/src/app/north/north-list.component.html
+++ b/frontend/src/app/north/north-list.component.html
@@ -179,15 +179,6 @@
                     >
                       <span class="fa fa-search"></span>
                     </a>
-                    <!-- Audit history button -->
-                    <button
-                      type="button"
-                      class="btn btn-link show-audit-north px-1 py-0"
-                      [ngbTooltip]="'north.tooltips.audit' | translate"
-                      (click)="showAudit(north)"
-                    >
-                      <span class="fa fa-history"></span>
-                    </button>
                     <!-- Edit button -->
                     <a
                       class="btn btn-link edit-north px-1 py-0"
@@ -214,6 +205,15 @@
                       (click)="deleteNorth(north)"
                     >
                       <span class="fa fa-trash"></span>
+                    </button>
+                    <!-- Audit history button -->
+                    <button
+                      type="button"
+                      class="btn btn-link show-audit-north px-1 py-0"
+                      [ngbTooltip]="'north.tooltips.audit' | translate"
+                      (click)="showAudit(north)"
+                    >
+                      <span class="fa fa-history"></span>
                     </button>
                   </div>
                 </td>

--- a/frontend/src/app/north/north-list.component.html
+++ b/frontend/src/app/north/north-list.component.html
@@ -179,6 +179,15 @@
                     >
                       <span class="fa fa-search"></span>
                     </a>
+                    <!-- Audit history button -->
+                    <button
+                      type="button"
+                      class="btn btn-link show-audit-north px-1 py-0"
+                      [ngbTooltip]="'north.tooltips.audit' | translate"
+                      (click)="showAudit(north)"
+                    >
+                      <span class="fa fa-history"></span>
+                    </button>
                     <!-- Edit button -->
                     <a
                       class="btn btn-link edit-north px-1 py-0"

--- a/frontend/src/app/north/north-list.component.spec.ts
+++ b/frontend/src/app/north/north-list.component.spec.ts
@@ -9,14 +9,16 @@ import { NorthConnectorService } from '../services/north-connector.service';
 import { NotificationService } from '../shared/notification.service';
 import { provideI18nTesting } from '../../i18n/mock-i18n';
 import { createMock, MockObject } from '../../test/vitest-create-mock';
-import { provideModalTesting } from '../shared/mock-modal.service.testing';
+import { MockModalService, provideModalTesting } from '../shared/mock-modal.service.testing';
 import { provideRouter } from '@angular/router';
 import testData from '../../../../backend/src/tests/utils/test-data';
 import { NorthConnectorLightDTO } from '../../../../backend/shared/model/north-connector.model';
+import { AuditHistoryModalComponent } from '../shared/audit-history-modal/audit-history-modal.component';
 
 describe('NorthListComponent', () => {
   let northConnectorService: MockObject<NorthConnectorService>;
   let notificationService: MockObject<NotificationService>;
+  let modalService: MockModalService<AuditHistoryModalComponent>;
 
   beforeEach(() => {
     northConnectorService = createMock(NorthConnectorService);
@@ -36,6 +38,7 @@ describe('NorthListComponent', () => {
         { provide: NotificationService, useValue: notificationService }
       ]
     });
+    modalService = TestBed.inject(MockModalService);
   });
 
   test('should display the north list', async () => {
@@ -66,5 +69,19 @@ describe('NorthListComponent', () => {
       expect(northConnectorService.start).toHaveBeenCalledWith(north.id);
       expect(notificationService.success).toHaveBeenCalledWith('north.started', { name: north.name });
     }
+  });
+
+  test('should open the audit history modal with the north connector entity type and id', async () => {
+    const fixture = TestBed.createComponent(NorthListComponent);
+    fixture.detectChanges();
+
+    const fakeModalComponent = createMock(AuditHistoryModalComponent);
+    modalService.mockClosedModal(fakeModalComponent);
+
+    const root = page.elementLocator(fixture.nativeElement);
+    await root.getByCss('.show-audit-north').nth(0).click();
+
+    const north = testData.north.list[0] as unknown as NorthConnectorLightDTO;
+    expect(fakeModalComponent.prepare).toHaveBeenCalledWith('north_connector', north.id);
   });
 });

--- a/frontend/src/app/north/north-list.component.ts
+++ b/frontend/src/app/north/north-list.component.ts
@@ -18,6 +18,7 @@ import { ObservableState } from '../shared/save-button/save-button.component';
 import { OIBusNorthTypeEnumPipe } from '../shared/oibus-north-type-enum.pipe';
 import { NgbTooltip } from '@ng-bootstrap/ng-bootstrap';
 import { AuditInfoComponent } from '../shared/audit-info/audit-info.component';
+import { AuditHistoryModalComponent } from '../shared/audit-history-modal/audit-history-modal.component';
 
 type NorthSortField = 'name' | 'type' | 'createdAt' | 'updatedAt' | null;
 type SortDirection = 'asc' | 'desc';
@@ -132,6 +133,14 @@ export class NorthListComponent {
   createNorth() {
     const modalRef = this.modalService.open(ChooseNorthConnectorTypeModalComponent, { size: 'xl', backdrop: 'static' });
     modalRef.result.subscribe();
+  }
+
+  /**
+   * Open a modal to view the audit history of a North connector
+   */
+  showAudit(north: NorthConnectorLightDTO) {
+    const modalRef = this.modalService.open(AuditHistoryModalComponent);
+    modalRef.componentInstance.prepare('north_connector', north.id);
   }
 
   toggleSort(field: NorthSortField) {

--- a/frontend/src/app/north/north-list.component.ts
+++ b/frontend/src/app/north/north-list.component.ts
@@ -139,7 +139,7 @@ export class NorthListComponent {
    * Open a modal to view the audit history of a North connector
    */
   showAudit(north: NorthConnectorLightDTO) {
-    const modalRef = this.modalService.open(AuditHistoryModalComponent);
+    const modalRef = this.modalService.open(AuditHistoryModalComponent, { size: 'xl' });
     modalRef.componentInstance.prepare('north_connector', north.id);
   }
 

--- a/frontend/src/app/services/audit.service.spec.ts
+++ b/frontend/src/app/services/audit.service.spec.ts
@@ -1,0 +1,99 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+
+import { Page } from '../../../../backend/shared/model/types';
+import { toPage } from '../shared/test-utils';
+import { AuditService } from './audit.service';
+import { AuditLogDTO } from '../../../../backend/shared/model/audit.model';
+
+describe('AuditService', () => {
+  let http: HttpTestingController;
+  let service: AuditService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideHttpClientTesting()]
+    });
+    http = TestBed.inject(HttpTestingController);
+    service = TestBed.inject(AuditService);
+  });
+
+  afterEach(() => http.verify());
+
+  test('should search audit logs with all filters', () => {
+    let expectedAuditLogs: Page<AuditLogDTO> | null = null;
+    const auditLogs = toPage<AuditLogDTO>([
+      {
+        id: 'id1',
+        entityType: 'south_connector',
+        entityId: 'entityId1',
+        action: 'CREATE',
+        previousState: null,
+        newState: { name: 'my south' },
+        userId: 'userId1',
+        createdAt: '2023-01-01T00:00:00.000Z'
+      }
+    ]);
+
+    service
+      .search({
+        page: 0,
+        entityType: 'south_connector',
+        entityId: 'entityId1',
+        action: 'CREATE',
+        start: '2023-01-01T00:00:00.000Z',
+        end: '2023-01-02T00:00:00.000Z'
+      })
+      .subscribe(c => (expectedAuditLogs = c));
+
+    http
+      .expectOne({
+        url: '/api/audit?page=0&entityType=south_connector&entityId=entityId1&action=CREATE&start=2023-01-01T00:00:00.000Z&end=2023-01-02T00:00:00.000Z',
+        method: 'GET'
+      })
+      .flush(auditLogs);
+    expect(expectedAuditLogs!).toEqual(auditLogs);
+  });
+
+  test('should search audit logs without optional filters', () => {
+    let expectedAuditLogs: Page<AuditLogDTO> | null = null;
+    const auditLogs = toPage<AuditLogDTO>([]);
+
+    service.search({}).subscribe(c => (expectedAuditLogs = c));
+
+    http
+      .expectOne({
+        url: '/api/audit?page=0',
+        method: 'GET'
+      })
+      .flush(auditLogs);
+    expect(expectedAuditLogs!).toEqual(auditLogs);
+  });
+
+  test('should get history for an entity', () => {
+    let expectedHistory: Array<AuditLogDTO> = [];
+    const history: Array<AuditLogDTO> = [
+      {
+        id: 'id1',
+        entityType: 'south_connector',
+        entityId: 'entityId1',
+        action: 'UPDATE',
+        previousState: { name: 'old' },
+        newState: { name: 'new' },
+        userId: 'userId1',
+        createdAt: '2023-01-01T00:00:00.000Z'
+      }
+    ];
+
+    service.getHistory('south_connector', 'entityId1').subscribe(c => (expectedHistory = c));
+
+    http
+      .expectOne({
+        url: '/api/audit/south_connector/entityId1',
+        method: 'GET'
+      })
+      .flush(history);
+    expect(expectedHistory!).toEqual(history);
+  });
+});

--- a/frontend/src/app/services/audit.service.ts
+++ b/frontend/src/app/services/audit.service.ts
@@ -1,0 +1,55 @@
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { Service, inject } from '@angular/core';
+import { Page } from '../../../../backend/shared/model/types';
+import { AuditAction, AuditEntityType, AuditLogDTO } from '../../../../backend/shared/model/audit.model';
+
+export interface AuditSearchParam {
+  entityType?: AuditEntityType;
+  entityId?: string;
+  action?: AuditAction;
+  start?: string;
+  end?: string;
+  page?: number;
+}
+
+/**
+ * Service used to interact with the backend Audit repository
+ */
+@Service()
+export class AuditService {
+  private http = inject(HttpClient);
+
+  /**
+   * Retrieve the Audit logs from search params
+   * @param searchParams - The search params
+   */
+  search(searchParams: AuditSearchParam): Observable<Page<AuditLogDTO>> {
+    const params: Record<string, string> = {
+      page: `${searchParams.page || 0}`
+    };
+    if (searchParams.entityType) {
+      params['entityType'] = searchParams.entityType;
+    }
+    if (searchParams.entityId) {
+      params['entityId'] = searchParams.entityId;
+    }
+    if (searchParams.action) {
+      params['action'] = searchParams.action;
+    }
+    if (searchParams.start) {
+      params['start'] = searchParams.start;
+    }
+    if (searchParams.end) {
+      params['end'] = searchParams.end;
+    }
+    return this.http.get<Page<AuditLogDTO>>('/api/audit', { params });
+  }
+
+  /**
+   * Retrieve the full audit history for a single entity
+   */
+  getHistory(entityType: AuditEntityType, entityId: string): Observable<Array<AuditLogDTO>> {
+    return this.http.get<Array<AuditLogDTO>>(`/api/audit/${entityType}/${entityId}`);
+  }
+}

--- a/frontend/src/app/shared/audit-diff/audit-diff.component.html
+++ b/frontend/src/app/shared/audit-diff/audit-diff.component.html
@@ -8,7 +8,7 @@
   </thead>
   <tbody>
     @for (row of rows(); track row.key) {
-      <tr [class.audit-diff-changed]="row.changed" [class.table-warning]="row.changed">
+      <tr [class.table-warning]="row.changed">
         <td>{{ row.key }}</td>
         <td>{{ formatValue(row.before) }}</td>
         <td>{{ formatValue(row.after) }}</td>

--- a/frontend/src/app/shared/audit-diff/audit-diff.component.html
+++ b/frontend/src/app/shared/audit-diff/audit-diff.component.html
@@ -1,0 +1,18 @@
+<table class="table table-sm audit-diff-table">
+  <thead>
+    <tr>
+      <th translate="audit.diff.field"></th>
+      <th translate="audit.diff.before"></th>
+      <th translate="audit.diff.after"></th>
+    </tr>
+  </thead>
+  <tbody>
+    @for (row of rows(); track row.key) {
+      <tr [class.audit-diff-changed]="row.changed" [class.table-warning]="row.changed">
+        <td>{{ row.key }}</td>
+        <td>{{ formatValue(row.before) }}</td>
+        <td>{{ formatValue(row.after) }}</td>
+      </tr>
+    }
+  </tbody>
+</table>

--- a/frontend/src/app/shared/audit-diff/audit-diff.component.scss
+++ b/frontend/src/app/shared/audit-diff/audit-diff.component.scss
@@ -1,0 +1,9 @@
+.audit-diff-table {
+  margin-bottom: 0;
+
+  td,
+  th {
+    word-break: break-word;
+  }
+}
+

--- a/frontend/src/app/shared/audit-diff/audit-diff.component.spec.ts
+++ b/frontend/src/app/shared/audit-diff/audit-diff.component.spec.ts
@@ -32,10 +32,10 @@ describe('AuditDiffComponent', () => {
     await expect.element(tester.rows.nth(0)).toHaveTextContent('name');
     await expect.element(tester.rows.nth(0)).toHaveTextContent('old-name');
     await expect.element(tester.rows.nth(0)).toHaveTextContent('new-name');
-    await expect.element(tester.rows.nth(0)).toHaveClass('audit-diff-changed');
+    await expect.element(tester.rows.nth(0)).toHaveClass('table-warning');
 
     await expect.element(tester.rows.nth(1)).toHaveTextContent('settings');
-    await expect.element(tester.rows.nth(1)).not.toHaveClass('audit-diff-changed');
+    await expect.element(tester.rows.nth(1)).not.toHaveClass('table-warning');
   });
 
   test('should render a dash for every "before" cell on CREATE (previousState is null)', async () => {

--- a/frontend/src/app/shared/audit-diff/audit-diff.component.spec.ts
+++ b/frontend/src/app/shared/audit-diff/audit-diff.component.spec.ts
@@ -1,0 +1,55 @@
+import { TestBed } from '@angular/core/testing';
+import { page } from 'vitest/browser';
+import { beforeEach, describe, expect, test } from 'vitest';
+import { provideI18nTesting } from '../../../i18n/mock-i18n';
+import { AuditDiffComponent } from './audit-diff.component';
+
+class AuditDiffComponentTester {
+  readonly fixture = TestBed.createComponent(AuditDiffComponent);
+  readonly root = page.elementLocator(this.fixture.nativeElement);
+  readonly rows = this.root.getByCss('tbody tr');
+}
+
+describe('AuditDiffComponent', () => {
+  let tester: AuditDiffComponentTester;
+
+  const setInputs = (previousState: Record<string, unknown> | null, newState: Record<string, unknown> | null) => {
+    tester = new AuditDiffComponentTester();
+    tester.fixture.componentRef.setInput('previousState', previousState);
+    tester.fixture.componentRef.setInput('newState', newState);
+    tester.fixture.detectChanges();
+  };
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideI18nTesting()]
+    });
+  });
+
+  test('should render a diff with one changed and one unchanged field', async () => {
+    setInputs({ name: 'old-name', settings: 'same' }, { name: 'new-name', settings: 'same' });
+
+    await expect.element(tester.rows.nth(0)).toHaveTextContent('name');
+    await expect.element(tester.rows.nth(0)).toHaveTextContent('old-name');
+    await expect.element(tester.rows.nth(0)).toHaveTextContent('new-name');
+    await expect.element(tester.rows.nth(0)).toHaveClass('audit-diff-changed');
+
+    await expect.element(tester.rows.nth(1)).toHaveTextContent('settings');
+    await expect.element(tester.rows.nth(1)).not.toHaveClass('audit-diff-changed');
+  });
+
+  test('should render a dash for every "before" cell on CREATE (previousState is null)', async () => {
+    setInputs(null, { name: 'new-name', settings: 'same' });
+
+    await expect.element(tester.rows.nth(0)).toHaveTextContent('—');
+    await expect.element(tester.rows.nth(1)).toHaveTextContent('—');
+  });
+
+  test('should render a dash for every "after" cell on DELETE (newState is null)', async () => {
+    setInputs({ name: 'old-name', settings: 'same' }, null);
+
+    const cells = tester.root.getByCss('tbody tr td:last-child');
+    await expect.element(cells.nth(0)).toHaveTextContent('—');
+    await expect.element(cells.nth(1)).toHaveTextContent('—');
+  });
+});

--- a/frontend/src/app/shared/audit-diff/audit-diff.component.ts
+++ b/frontend/src/app/shared/audit-diff/audit-diff.component.ts
@@ -1,0 +1,47 @@
+import { ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
+import { TranslateDirective } from '@ngx-translate/core';
+
+interface AuditDiffRow {
+  key: string;
+  before: unknown;
+  after: unknown;
+  changed: boolean;
+}
+
+/**
+ * Displays a key-level diff between the previous and new state of an audited entity.
+ * `previousState` is `null` for a CREATE action, `newState` is `null` for a DELETE action.
+ */
+@Component({
+  selector: 'oib-audit-diff',
+  templateUrl: './audit-diff.component.html',
+  styleUrl: './audit-diff.component.scss',
+  imports: [TranslateDirective],
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class AuditDiffComponent {
+  readonly previousState = input.required<Record<string, unknown> | null>();
+  readonly newState = input.required<Record<string, unknown> | null>();
+
+  readonly rows = computed<Array<AuditDiffRow>>(() => {
+    const before = this.previousState() ?? {};
+    const after = this.newState() ?? {};
+    const keys = Array.from(new Set([...Object.keys(before), ...Object.keys(after)])).sort();
+    return keys.map(key => ({
+      key,
+      before: key in before ? before[key] : undefined,
+      after: key in after ? after[key] : undefined,
+      changed: JSON.stringify(before[key]) !== JSON.stringify(after[key])
+    }));
+  });
+
+  formatValue(value: unknown): string {
+    if (value === undefined) {
+      return '—';
+    }
+    if (value === null) {
+      return 'null';
+    }
+    return typeof value === 'object' ? JSON.stringify(value) : String(value);
+  }
+}

--- a/frontend/src/app/shared/audit-diff/audit-json-diff.component.html
+++ b/frontend/src/app/shared/audit-diff/audit-json-diff.component.html
@@ -1,0 +1,1 @@
+<div #editor class="audit-json-editor" tabindex="0" (keydown)="$event.stopPropagation()" (keyup)="$event.stopPropagation()"></div>

--- a/frontend/src/app/shared/audit-diff/audit-json-diff.component.scss
+++ b/frontend/src/app/shared/audit-diff/audit-json-diff.component.scss
@@ -1,0 +1,5 @@
+.audit-json-editor {
+  width: 100%;
+  max-height: 60vh;
+  overflow: auto;
+}

--- a/frontend/src/app/shared/audit-diff/audit-json-diff.component.spec.ts
+++ b/frontend/src/app/shared/audit-diff/audit-json-diff.component.spec.ts
@@ -1,0 +1,72 @@
+import { TestBed } from '@angular/core/testing';
+import { page } from 'vitest/browser';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { EditorView } from '@codemirror/view';
+import { AuditJsonDiffComponent } from './audit-json-diff.component';
+
+class AuditJsonDiffComponentTester {
+  readonly fixture = TestBed.createComponent(AuditJsonDiffComponent);
+  readonly root = page.elementLocator(this.fixture.nativeElement);
+}
+
+describe('AuditJsonDiffComponent', () => {
+  let tester: AuditJsonDiffComponentTester;
+
+  const setInputs = (previousState: Record<string, unknown> | null, newState: Record<string, unknown> | null) => {
+    tester = new AuditJsonDiffComponentTester();
+    tester.fixture.componentRef.setInput('previousState', previousState);
+    tester.fixture.componentRef.setInput('newState', newState);
+    tester.fixture.detectChanges();
+  };
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+  });
+
+  test('should render both the removed and added values for an update', async () => {
+    setInputs({ name: 'old-name' }, { name: 'new-name' });
+
+    await expect.element(tester.root.getByCss('.cm-editor')).toHaveTextContent('old-name');
+    await expect.element(tester.root.getByCss('.cm-editor')).toHaveTextContent('new-name');
+  });
+
+  test('should render only the new state on CREATE (previousState is null)', async () => {
+    setInputs(null, { name: 'new-name' });
+
+    await expect.element(tester.root.getByCss('.cm-editor')).toHaveTextContent('new-name');
+  });
+
+  test('should render only the previous state on DELETE (newState is null)', async () => {
+    setInputs({ name: 'old-name' }, null);
+
+    await expect.element(tester.root.getByCss('.cm-editor')).toHaveTextContent('old-name');
+  });
+
+  test('should destroy the previous editor view and render the new content when inputs change on a mounted instance', async () => {
+    setInputs({ name: 'alpha-value' }, { name: 'beta-value' });
+    await expect.element(tester.root.getByCss('.cm-editor')).toHaveTextContent('beta-value');
+
+    const destroySpy = vi.spyOn(EditorView.prototype, 'destroy');
+
+    tester.fixture.componentRef.setInput('previousState', { name: 'gamma-value' });
+    tester.fixture.componentRef.setInput('newState', { name: 'delta-value' });
+    tester.fixture.detectChanges();
+
+    expect(destroySpy).toHaveBeenCalledTimes(1);
+    await expect.element(tester.root.getByCss('.cm-editor')).toHaveTextContent('gamma-value');
+    await expect.element(tester.root.getByCss('.cm-editor')).toHaveTextContent('delta-value');
+    await expect.element(tester.root.getByCss('.cm-editor')).not.toHaveTextContent('alpha-value');
+
+    destroySpy.mockRestore();
+  });
+
+  test('should destroy the editor view when the component is destroyed', () => {
+    setInputs({ name: 'old-name' }, { name: 'new-name' });
+
+    const destroySpy = vi.spyOn(EditorView.prototype, 'destroy');
+    tester.fixture.destroy();
+
+    expect(destroySpy).toHaveBeenCalledTimes(1);
+    destroySpy.mockRestore();
+  });
+});

--- a/frontend/src/app/shared/audit-diff/audit-json-diff.component.ts
+++ b/frontend/src/app/shared/audit-diff/audit-json-diff.component.ts
@@ -1,0 +1,53 @@
+import { ChangeDetectionStrategy, Component, DestroyRef, ElementRef, afterRenderEffect, inject, input, viewChild } from '@angular/core';
+import { EditorView } from '@codemirror/view';
+import { EditorState } from '@codemirror/state';
+import { basicSetup } from 'codemirror';
+import { json } from '@codemirror/lang-json';
+import { unifiedMergeView } from '@codemirror/merge';
+
+function toPrettyJson(state: Record<string, unknown> | null): string {
+  return JSON.stringify(state ?? {}, null, 2);
+}
+
+/**
+ * Displays a git-style unified diff between the previous and new state of an audited entity.
+ * `previousState` is `null` for a CREATE action (renders fully green), `newState` is `null` for
+ * a DELETE action (renders fully red).
+ */
+@Component({
+  selector: 'oib-audit-json-diff',
+  templateUrl: './audit-json-diff.component.html',
+  styleUrl: './audit-json-diff.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class AuditJsonDiffComponent {
+  readonly previousState = input.required<Record<string, unknown> | null>();
+  readonly newState = input.required<Record<string, unknown> | null>();
+
+  private readonly editorContainer = viewChild.required<ElementRef<HTMLDivElement>>('editor');
+  private editorView: EditorView | null = null;
+
+  constructor() {
+    inject(DestroyRef).onDestroy(() => this.editorView?.destroy());
+
+    afterRenderEffect(() => {
+      const container = this.editorContainer().nativeElement;
+      const originalText = toPrettyJson(this.previousState());
+      const newText = toPrettyJson(this.newState());
+
+      this.editorView?.destroy();
+      this.editorView = new EditorView({
+        state: EditorState.create({
+          doc: newText,
+          extensions: [
+            basicSetup,
+            EditorView.editable.of(false),
+            json(),
+            unifiedMergeView({ original: originalText, mergeControls: false, gutter: true })
+          ]
+        }),
+        parent: container
+      });
+    });
+  }
+}

--- a/frontend/src/app/shared/audit-diff/audit-json-side-by-side.component.html
+++ b/frontend/src/app/shared/audit-diff/audit-json-side-by-side.component.html
@@ -1,0 +1,1 @@
+<div #editor class="audit-json-side-by-side" tabindex="0" (keydown)="$event.stopPropagation()" (keyup)="$event.stopPropagation()"></div>

--- a/frontend/src/app/shared/audit-diff/audit-json-side-by-side.component.scss
+++ b/frontend/src/app/shared/audit-diff/audit-json-side-by-side.component.scss
@@ -1,0 +1,9 @@
+.audit-json-side-by-side {
+  width: 100%;
+  max-height: 60vh;
+  overflow: auto;
+
+  ::ng-deep .cm-mergeView {
+    height: 100%;
+  }
+}

--- a/frontend/src/app/shared/audit-diff/audit-json-side-by-side.component.spec.ts
+++ b/frontend/src/app/shared/audit-diff/audit-json-side-by-side.component.spec.ts
@@ -1,0 +1,76 @@
+import { TestBed } from '@angular/core/testing';
+import { page } from 'vitest/browser';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { MergeView } from '@codemirror/merge';
+import { AuditJsonSideBySideComponent } from './audit-json-side-by-side.component';
+
+class AuditJsonSideBySideComponentTester {
+  readonly fixture = TestBed.createComponent(AuditJsonSideBySideComponent);
+  readonly root = page.elementLocator(this.fixture.nativeElement);
+}
+
+describe('AuditJsonSideBySideComponent', () => {
+  let tester: AuditJsonSideBySideComponentTester;
+
+  const setInputs = (previousState: Record<string, unknown> | null, newState: Record<string, unknown> | null) => {
+    tester = new AuditJsonSideBySideComponentTester();
+    tester.fixture.componentRef.setInput('previousState', previousState);
+    tester.fixture.componentRef.setInput('newState', newState);
+    tester.fixture.detectChanges();
+  };
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+  });
+
+  test('should render both editors, previous state on the left and new state on the right', async () => {
+    setInputs({ name: 'old-name' }, { name: 'new-name' });
+
+    const editors = tester.root.getByCss('.cm-editor');
+    await expect.element(editors.nth(0)).toHaveTextContent('old-name');
+    await expect.element(editors.nth(1)).toHaveTextContent('new-name');
+  });
+
+  test('should render an empty object on the left for CREATE (previousState is null)', async () => {
+    setInputs(null, { name: 'new-name' });
+
+    const editors = tester.root.getByCss('.cm-editor');
+    await expect.element(editors.nth(1)).toHaveTextContent('new-name');
+  });
+
+  test('should render an empty object on the right for DELETE (newState is null)', async () => {
+    setInputs({ name: 'old-name' }, null);
+
+    const editors = tester.root.getByCss('.cm-editor');
+    await expect.element(editors.nth(0)).toHaveTextContent('old-name');
+  });
+
+  test('should destroy the previous merge view and render the new content when inputs change on a mounted instance', async () => {
+    setInputs({ name: 'alpha-value' }, { name: 'beta-value' });
+    const editors = tester.root.getByCss('.cm-editor');
+    await expect.element(editors.nth(1)).toHaveTextContent('beta-value');
+
+    const destroySpy = vi.spyOn(MergeView.prototype, 'destroy');
+
+    tester.fixture.componentRef.setInput('previousState', { name: 'gamma-value' });
+    tester.fixture.componentRef.setInput('newState', { name: 'delta-value' });
+    tester.fixture.detectChanges();
+
+    expect(destroySpy).toHaveBeenCalledTimes(1);
+    await expect.element(editors.nth(0)).toHaveTextContent('gamma-value');
+    await expect.element(editors.nth(1)).toHaveTextContent('delta-value');
+    await expect.element(editors.nth(0)).not.toHaveTextContent('alpha-value');
+
+    destroySpy.mockRestore();
+  });
+
+  test('should destroy the merge view when the component is destroyed', () => {
+    setInputs({ name: 'old-name' }, { name: 'new-name' });
+
+    const destroySpy = vi.spyOn(MergeView.prototype, 'destroy');
+    tester.fixture.destroy();
+
+    expect(destroySpy).toHaveBeenCalledTimes(1);
+    destroySpy.mockRestore();
+  });
+});

--- a/frontend/src/app/shared/audit-diff/audit-json-side-by-side.component.ts
+++ b/frontend/src/app/shared/audit-diff/audit-json-side-by-side.component.ts
@@ -1,0 +1,45 @@
+import { ChangeDetectionStrategy, Component, DestroyRef, ElementRef, afterRenderEffect, inject, input, viewChild } from '@angular/core';
+import { EditorView } from '@codemirror/view';
+import { basicSetup } from 'codemirror';
+import { json } from '@codemirror/lang-json';
+import { MergeView } from '@codemirror/merge';
+
+function toPrettyJson(state: Record<string, unknown> | null): string {
+  return JSON.stringify(state ?? {}, null, 2);
+}
+
+/**
+ * Displays the previous and new state of an audited entity as two full JSON panes side by side,
+ * with differences between them highlighted.
+ */
+@Component({
+  selector: 'oib-audit-json-side-by-side',
+  templateUrl: './audit-json-side-by-side.component.html',
+  styleUrl: './audit-json-side-by-side.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class AuditJsonSideBySideComponent {
+  readonly previousState = input.required<Record<string, unknown> | null>();
+  readonly newState = input.required<Record<string, unknown> | null>();
+
+  private readonly editorContainer = viewChild.required<ElementRef<HTMLDivElement>>('editor');
+  private mergeView: MergeView | null = null;
+
+  constructor() {
+    inject(DestroyRef).onDestroy(() => this.mergeView?.destroy());
+
+    afterRenderEffect(() => {
+      const container = this.editorContainer().nativeElement;
+      const originalText = toPrettyJson(this.previousState());
+      const newText = toPrettyJson(this.newState());
+
+      this.mergeView?.destroy();
+      this.mergeView = new MergeView({
+        a: { doc: originalText, extensions: [basicSetup, EditorView.editable.of(false), json()] },
+        b: { doc: newText, extensions: [basicSetup, EditorView.editable.of(false), json()] },
+        gutter: true,
+        parent: container
+      });
+    });
+  }
+}

--- a/frontend/src/app/shared/audit-entity-types-enum.pipe.spec.ts
+++ b/frontend/src/app/shared/audit-entity-types-enum.pipe.spec.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from 'vitest';
+import { TestBed } from '@angular/core/testing';
+import { provideI18nTesting } from '../../i18n/mock-i18n';
+import { AuditEntityTypesEnumPipe } from './audit-entity-types-enum.pipe';
+import { AUDIT_ENTITY_TYPES } from '../../../../backend/shared/model/audit.model';
+
+describe('AuditEntityTypesEnumPipe', () => {
+  test('should translate every audit entity type', () => {
+    TestBed.configureTestingModule({ providers: [provideI18nTesting()] });
+    const pipe = TestBed.runInInjectionContext(() => new AuditEntityTypesEnumPipe());
+    for (const entityType of AUDIT_ENTITY_TYPES) {
+      expect(pipe.transform(entityType)).toBeTruthy();
+    }
+  });
+
+  test('should translate south connector', () => {
+    TestBed.configureTestingModule({ providers: [provideI18nTesting()] });
+    const pipe = TestBed.runInInjectionContext(() => new AuditEntityTypesEnumPipe());
+    expect(pipe.transform('south_connector')).toBe('South connector');
+  });
+});

--- a/frontend/src/app/shared/audit-entity-types-enum.pipe.ts
+++ b/frontend/src/app/shared/audit-entity-types-enum.pipe.ts
@@ -1,0 +1,13 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { BaseEnumPipe } from './base-enum-pipe';
+import { AuditEntityType } from '../../../../backend/shared/model/audit.model';
+
+@Pipe({
+  name: 'auditEntityTypesEnum',
+  pure: false
+})
+export class AuditEntityTypesEnumPipe extends BaseEnumPipe<AuditEntityType> implements PipeTransform {
+  constructor() {
+    super('audit-entity-types');
+  }
+}

--- a/frontend/src/app/shared/audit-history-modal/audit-history-modal.component.html
+++ b/frontend/src/app/shared/audit-history-modal/audit-history-modal.component.html
@@ -1,0 +1,50 @@
+<div class="modal-header">
+  <h4 class="modal-title" translate="audit.history-modal.title"></h4>
+</div>
+<div class="modal-body">
+  @if (loading()) {
+    <div class="text-center">
+      <oib-loading-spinner />
+      <div translate="audit.history-modal.loading"></div>
+    </div>
+  } @else if (history().length === 0) {
+    <div class="oi-details empty" translate="audit.history-modal.none"></div>
+  } @else {
+    <div class="list-group">
+      @for (row of history(); track row.id) {
+        <div class="list-group-item">
+          <div class="d-flex align-items-center justify-content-between audit-history-row">
+            <div class="d-flex align-items-center gap-2">
+              <span
+                class="badge"
+                [class.bg-success]="row.action === 'CREATE'"
+                [class.bg-primary]="row.action === 'UPDATE'"
+                [class.bg-danger]="row.action === 'DELETE'"
+                [translate]="'audit.actions.' + row.action"
+              ></span>
+              <span>{{ row.createdAt | datetime: 'ff' }}</span>
+              <span class="text-muted">{{ row.userId }}</span>
+            </div>
+            <button type="button" class="btn btn-link" [attr.aria-expanded]="expandedRowId() === row.id" (click)="toggleRow(row.id)">
+              @if (expandedRowId() === row.id) {
+                <span class="fa fa-chevron-up"></span>
+              } @else {
+                <span class="fa fa-chevron-down"></span>
+              }
+            </button>
+          </div>
+          @if (expandedRowId() === row.id) {
+            <div class="mt-2">
+              <oib-audit-diff [previousState]="row.previousState" [newState]="row.newState" />
+            </div>
+          }
+        </div>
+      }
+    </div>
+  }
+</div>
+<div class="modal-footer">
+  <div class="btn-group">
+    <button type="button" class="btn btn-cancel" (click)="close()" translate="common.close" id="close-button"></button>
+  </div>
+</div>

--- a/frontend/src/app/shared/audit-history-modal/audit-history-modal.component.html
+++ b/frontend/src/app/shared/audit-history-modal/audit-history-modal.component.html
@@ -2,6 +2,24 @@
   <h4 class="modal-title" translate="audit.history-modal.title"></h4>
 </div>
 <div class="modal-body">
+  @if (!loading() && history().length > 0) {
+    <div class="d-flex justify-content-end mb-2">
+      <div ngbDropdown class="d-inline-block">
+        <button type="button" class="btn btn-outline-secondary btn-sm" ngbDropdownToggle>
+          <span class="fa {{ modeIcons[mode()] }}"></span>
+          <span class="ms-1">{{ 'audit.history-modal.modes.' + mode() | translate }}</span>
+        </button>
+        <div ngbDropdownMenu>
+          @for (m of modes; track m) {
+            <button ngbDropdownItem [class.active]="mode() === m" (click)="changeMode(m)">
+              <span class="fa {{ modeIcons[m] }}"></span>
+              <span class="ms-1">{{ 'audit.history-modal.modes.' + m | translate }}</span>
+            </button>
+          }
+        </div>
+      </div>
+    </div>
+  }
   @if (loading()) {
     <div class="text-center">
       <oib-loading-spinner />
@@ -25,7 +43,15 @@
               <span>{{ row.createdAt | datetime: 'ff' }}</span>
               <span class="text-muted">{{ row.userId }}</span>
             </div>
-            <button type="button" class="btn btn-link" [attr.aria-expanded]="expandedRowId() === row.id" (click)="toggleRow(row.id)">
+            <button
+              type="button"
+              class="btn btn-link"
+              [attr.aria-expanded]="expandedRowId() === row.id"
+              [ngbTooltip]="
+                (expandedRowId() === row.id ? 'audit.history-modal.tooltips.collapse' : 'audit.history-modal.tooltips.expand') | translate
+              "
+              (click)="toggleRow(row.id)"
+            >
               @if (expandedRowId() === row.id) {
                 <span class="fa fa-chevron-up"></span>
               } @else {
@@ -35,7 +61,17 @@
           </div>
           @if (expandedRowId() === row.id) {
             <div class="mt-2">
-              <oib-audit-diff [previousState]="row.previousState" [newState]="row.newState" />
+              @switch (mode()) {
+                @case ('json-diff') {
+                  <oib-audit-json-diff [previousState]="row.previousState" [newState]="row.newState" />
+                }
+                @case ('json-side-by-side') {
+                  <oib-audit-json-side-by-side [previousState]="row.previousState" [newState]="row.newState" />
+                }
+                @default {
+                  <oib-audit-diff [previousState]="row.previousState" [newState]="row.newState" />
+                }
+              }
             </div>
           }
         </div>

--- a/frontend/src/app/shared/audit-history-modal/audit-history-modal.component.scss
+++ b/frontend/src/app/shared/audit-history-modal/audit-history-modal.component.scss
@@ -1,0 +1,12 @@
+@import '../../../common.scss';
+
+// This button isn't inside an .oib-table (it's a list-group row, not a <tr>), so it doesn't
+// pick up the app-wide "table action icon" color rule (tbody tr .btn { color: $blue }) —
+// apply the same resting color directly so it's visible without hovering.
+.audit-history-row .btn-link {
+  color: $blue;
+
+  &:hover {
+    color: $yellow;
+  }
+}

--- a/frontend/src/app/shared/audit-history-modal/audit-history-modal.component.spec.ts
+++ b/frontend/src/app/shared/audit-history-modal/audit-history-modal.component.spec.ts
@@ -1,0 +1,104 @@
+import { TestBed } from '@angular/core/testing';
+import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
+import { page } from 'vitest/browser';
+import { beforeEach, describe, expect, test } from 'vitest';
+import { of } from 'rxjs';
+import { AuditHistoryModalComponent } from './audit-history-modal.component';
+import { AuditService } from '../../services/audit.service';
+import { AuditLogDTO } from '../../../../../backend/shared/model/audit.model';
+import { provideI18nTesting } from '../../../i18n/mock-i18n';
+import { createMock, MockObject } from '../../../test/vitest-create-mock';
+
+class AuditHistoryModalComponentTester {
+  readonly fixture = TestBed.createComponent(AuditHistoryModalComponent);
+  readonly root = page.elementLocator(this.fixture.nativeElement);
+  readonly rows = this.root.getByCss('.list-group-item');
+  readonly closeButton = page.getByCss('#close-button');
+}
+
+describe('AuditHistoryModalComponent', () => {
+  let tester: AuditHistoryModalComponentTester;
+  let fakeActiveModal: MockObject<NgbActiveModal>;
+  let auditService: MockObject<AuditService>;
+
+  const history: Array<AuditLogDTO> = [
+    {
+      id: 'id2',
+      entityType: 'south_connector',
+      entityId: 'entityId1',
+      action: 'UPDATE',
+      previousState: { name: 'old-name' },
+      newState: { name: 'new-name' },
+      userId: 'userId1',
+      createdAt: '2024-02-02T09:00:00.000Z'
+    },
+    {
+      id: 'id1',
+      entityType: 'south_connector',
+      entityId: 'entityId1',
+      action: 'CREATE',
+      previousState: null,
+      newState: { name: 'old-name' },
+      userId: 'userId1',
+      createdAt: '2024-01-01T08:00:00.000Z'
+    }
+  ];
+
+  beforeEach(() => {
+    fakeActiveModal = createMock(NgbActiveModal);
+    auditService = createMock(AuditService);
+
+    TestBed.configureTestingModule({
+      providers: [
+        provideI18nTesting(),
+        { provide: NgbActiveModal, useValue: fakeActiveModal },
+        { provide: AuditService, useValue: auditService }
+      ]
+    });
+    tester = new AuditHistoryModalComponentTester();
+  });
+
+  test('should load and display the history rows', async () => {
+    auditService.getHistory.mockReturnValue(of(history));
+    tester.fixture.componentInstance.prepare('south_connector', 'entityId1');
+    tester.fixture.detectChanges();
+
+    expect(auditService.getHistory).toHaveBeenCalledWith('south_connector', 'entityId1');
+    await expect.element(tester.rows.nth(0)).toBeInTheDocument();
+    await expect.element(tester.rows.nth(1)).toBeInTheDocument();
+  });
+
+  test('should display an empty state message when there is no history', async () => {
+    auditService.getHistory.mockReturnValue(of([]));
+    tester.fixture.componentInstance.prepare('south_connector', 'entityId1');
+    tester.fixture.detectChanges();
+
+    await expect.element(tester.root.getByCss('.empty')).toBeInTheDocument();
+  });
+
+  test('should expand and collapse the diff view when a row is toggled', async () => {
+    auditService.getHistory.mockReturnValue(of(history));
+    tester.fixture.componentInstance.prepare('south_connector', 'entityId1');
+    tester.fixture.detectChanges();
+
+    expect(tester.fixture.componentInstance.expandedRowId()).toEqual(null);
+
+    tester.fixture.componentInstance.toggleRow('id1');
+    tester.fixture.detectChanges();
+    expect(tester.fixture.componentInstance.expandedRowId()).toEqual('id1');
+    await expect.element(tester.root.getByCss('oib-audit-diff')).toBeInTheDocument();
+
+    tester.fixture.componentInstance.toggleRow('id1');
+    tester.fixture.detectChanges();
+    expect(tester.fixture.componentInstance.expandedRowId()).toEqual(null);
+  });
+
+  test('should close the modal', async () => {
+    auditService.getHistory.mockReturnValue(of([]));
+    tester.fixture.componentInstance.prepare('south_connector', 'entityId1');
+    tester.fixture.detectChanges();
+
+    await tester.closeButton.click();
+    expect(fakeActiveModal.close).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/app/shared/audit-history-modal/audit-history-modal.component.spec.ts
+++ b/frontend/src/app/shared/audit-history-modal/audit-history-modal.component.spec.ts
@@ -93,6 +93,32 @@ describe('AuditHistoryModalComponent', () => {
     expect(tester.fixture.componentInstance.expandedRowId()).toEqual(null);
   });
 
+  test('should switch the diff view mode when a mode is selected from the dropdown', async () => {
+    auditService.getHistory.mockReturnValue(of(history));
+    tester.fixture.componentInstance.prepare('south_connector', 'entityId1');
+    tester.fixture.detectChanges();
+
+    tester.fixture.componentInstance.toggleRow('id1');
+    tester.fixture.detectChanges();
+    await expect.element(tester.root.getByCss('oib-audit-diff')).toBeInTheDocument();
+
+    tester.fixture.componentInstance.changeMode('json-diff');
+    tester.fixture.detectChanges();
+    await expect.element(tester.root.getByCss('oib-audit-json-diff')).toBeInTheDocument();
+
+    tester.fixture.componentInstance.changeMode('json-side-by-side');
+    tester.fixture.detectChanges();
+    await expect.element(tester.root.getByCss('oib-audit-json-side-by-side')).toBeInTheDocument();
+  });
+
+  test('should not show the mode dropdown when there is no history', async () => {
+    auditService.getHistory.mockReturnValue(of([]));
+    tester.fixture.componentInstance.prepare('south_connector', 'entityId1');
+    tester.fixture.detectChanges();
+
+    await expect.element(tester.root.getByCss('[ngbDropdown]')).not.toBeInTheDocument();
+  });
+
   test('should close the modal', async () => {
     auditService.getHistory.mockReturnValue(of([]));
     tester.fixture.componentInstance.prepare('south_connector', 'entityId1');

--- a/frontend/src/app/shared/audit-history-modal/audit-history-modal.component.ts
+++ b/frontend/src/app/shared/audit-history-modal/audit-history-modal.component.ts
@@ -1,0 +1,42 @@
+import { ChangeDetectionStrategy, Component, inject, signal } from '@angular/core';
+import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
+import { TranslateDirective } from '@ngx-translate/core';
+import { AuditService } from '../../services/audit.service';
+import { AuditEntityType, AuditLogDTO } from '../../../../../backend/shared/model/audit.model';
+import { DatetimePipe } from '../datetime.pipe';
+import { LoadingSpinnerComponent } from '../loading-spinner/loading-spinner.component';
+import { AuditDiffComponent } from '../audit-diff/audit-diff.component';
+
+/**
+ * Modal displaying the full audit history (create/update/delete trail) of a single entity.
+ */
+@Component({
+  selector: 'oib-audit-history-modal',
+  templateUrl: './audit-history-modal.component.html',
+  styleUrl: './audit-history-modal.component.scss',
+  imports: [TranslateDirective, DatetimePipe, LoadingSpinnerComponent, AuditDiffComponent],
+  changeDetection: ChangeDetectionStrategy.Eager
+})
+export class AuditHistoryModalComponent {
+  private modal = inject(NgbActiveModal);
+  private auditService = inject(AuditService);
+
+  readonly history = signal<Array<AuditLogDTO>>([]);
+  readonly loading = signal(true);
+  readonly expandedRowId = signal<string | null>(null);
+
+  prepare(entityType: AuditEntityType, entityId: string): void {
+    this.auditService.getHistory(entityType, entityId).subscribe(history => {
+      this.history.set(history);
+      this.loading.set(false);
+    });
+  }
+
+  toggleRow(id: string): void {
+    this.expandedRowId.set(this.expandedRowId() === id ? null : id);
+  }
+
+  close(): void {
+    this.modal.close();
+  }
+}

--- a/frontend/src/app/shared/audit-history-modal/audit-history-modal.component.ts
+++ b/frontend/src/app/shared/audit-history-modal/audit-history-modal.component.ts
@@ -1,11 +1,15 @@
 import { ChangeDetectionStrategy, Component, inject, signal } from '@angular/core';
-import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
-import { TranslateDirective } from '@ngx-translate/core';
+import { NgbActiveModal, NgbDropdownModule, NgbTooltip } from '@ng-bootstrap/ng-bootstrap';
+import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { AuditService } from '../../services/audit.service';
 import { AuditEntityType, AuditLogDTO } from '../../../../../backend/shared/model/audit.model';
 import { DatetimePipe } from '../datetime.pipe';
 import { LoadingSpinnerComponent } from '../loading-spinner/loading-spinner.component';
 import { AuditDiffComponent } from '../audit-diff/audit-diff.component';
+import { AuditJsonDiffComponent } from '../audit-diff/audit-json-diff.component';
+import { AuditJsonSideBySideComponent } from '../audit-diff/audit-json-side-by-side.component';
+
+export type AuditDiffMode = 'table' | 'json-diff' | 'json-side-by-side';
 
 /**
  * Modal displaying the full audit history (create/update/delete trail) of a single entity.
@@ -14,7 +18,17 @@ import { AuditDiffComponent } from '../audit-diff/audit-diff.component';
   selector: 'oib-audit-history-modal',
   templateUrl: './audit-history-modal.component.html',
   styleUrl: './audit-history-modal.component.scss',
-  imports: [TranslateDirective, DatetimePipe, LoadingSpinnerComponent, AuditDiffComponent],
+  imports: [
+    TranslateDirective,
+    TranslatePipe,
+    DatetimePipe,
+    LoadingSpinnerComponent,
+    AuditDiffComponent,
+    AuditJsonDiffComponent,
+    AuditJsonSideBySideComponent,
+    NgbTooltip,
+    NgbDropdownModule
+  ],
   changeDetection: ChangeDetectionStrategy.Eager
 })
 export class AuditHistoryModalComponent {
@@ -24,6 +38,14 @@ export class AuditHistoryModalComponent {
   readonly history = signal<Array<AuditLogDTO>>([]);
   readonly loading = signal(true);
   readonly expandedRowId = signal<string | null>(null);
+  readonly mode = signal<AuditDiffMode>('table');
+
+  readonly modes: Array<AuditDiffMode> = ['table', 'json-diff', 'json-side-by-side'];
+  readonly modeIcons: Record<AuditDiffMode, string> = {
+    table: 'fa-table',
+    'json-diff': 'fa-code',
+    'json-side-by-side': 'fa-columns'
+  };
 
   prepare(entityType: AuditEntityType, entityId: string): void {
     this.auditService.getHistory(entityType, entityId).subscribe(history => {
@@ -34,6 +56,10 @@ export class AuditHistoryModalComponent {
 
   toggleRow(id: string): void {
     this.expandedRowId.set(this.expandedRowId() === id ? null : id);
+  }
+
+  changeMode(mode: AuditDiffMode): void {
+    this.mode.set(mode);
   }
 
   close(): void {

--- a/frontend/src/app/south/south-list.component.html
+++ b/frontend/src/app/south/south-list.component.html
@@ -179,6 +179,15 @@
                     >
                       <span class="fa fa-search"></span>
                     </a>
+                    <!-- Audit history button -->
+                    <button
+                      type="button"
+                      class="btn btn-link show-audit-south px-1 py-0"
+                      [ngbTooltip]="'south.tooltips.audit' | translate"
+                      (click)="showAudit(south)"
+                    >
+                      <span class="fa fa-history"></span>
+                    </button>
                     <!-- Edit button -->
                     <a
                       class="btn btn-link edit-south px-1 py-0"

--- a/frontend/src/app/south/south-list.component.html
+++ b/frontend/src/app/south/south-list.component.html
@@ -179,15 +179,6 @@
                     >
                       <span class="fa fa-search"></span>
                     </a>
-                    <!-- Audit history button -->
-                    <button
-                      type="button"
-                      class="btn btn-link show-audit-south px-1 py-0"
-                      [ngbTooltip]="'south.tooltips.audit' | translate"
-                      (click)="showAudit(south)"
-                    >
-                      <span class="fa fa-history"></span>
-                    </button>
                     <!-- Edit button -->
                     <a
                       class="btn btn-link edit-south px-1 py-0"
@@ -214,6 +205,15 @@
                       (click)="deleteSouth(south)"
                     >
                       <span class="fa fa-trash"></span>
+                    </button>
+                    <!-- Audit history button -->
+                    <button
+                      type="button"
+                      class="btn btn-link show-audit-south px-1 py-0"
+                      [ngbTooltip]="'south.tooltips.audit' | translate"
+                      (click)="showAudit(south)"
+                    >
+                      <span class="fa fa-history"></span>
                     </button>
                   </div>
                 </td>

--- a/frontend/src/app/south/south-list.component.spec.ts
+++ b/frontend/src/app/south/south-list.component.spec.ts
@@ -85,7 +85,7 @@ describe('SouthListComponent', () => {
     const root = page.elementLocator(fixture.nativeElement);
     await root.getByCss('.show-audit-south').nth(0).click();
 
-    expect(modalServiceMock.open).toHaveBeenCalledWith(AuditHistoryModalComponent);
+    expect(modalServiceMock.open).toHaveBeenCalledWith(AuditHistoryModalComponent, { size: 'xl' });
     expect(fakeModalComponent.prepare).toHaveBeenCalledWith('south_connector', southConnectors[0].id);
   });
 });

--- a/frontend/src/app/south/south-list.component.spec.ts
+++ b/frontend/src/app/south/south-list.component.spec.ts
@@ -8,11 +8,12 @@ import { SouthListComponent } from './south-list.component';
 import { SouthConnectorService } from '../services/south-connector.service';
 import { ConfirmationService } from '../shared/confirmation.service';
 import { NotificationService } from '../shared/notification.service';
-import { ModalService } from '../shared/modal.service';
+import { Modal, ModalService } from '../shared/modal.service';
 import { provideI18nTesting } from '../../i18n/mock-i18n';
 import { createMock, MockObject } from '../../test/vitest-create-mock';
 import { SouthConnectorLightDTO } from '../../../../backend/shared/model/south-connector.model';
 import testData from '../../../../backend/src/tests/utils/test-data';
+import { AuditHistoryModalComponent } from '../shared/audit-history-modal/audit-history-modal.component';
 
 const southConnectors = testData.south.list as unknown as Array<SouthConnectorLightDTO>;
 
@@ -70,5 +71,21 @@ describe('SouthListComponent', () => {
 
     expect(southConnectorService.start).toHaveBeenCalledWith(southConnectors[1].id);
     expect(notificationService.success).toHaveBeenCalledWith('south.started', { name: southConnectors[1].name });
+  });
+
+  test('should open the audit history modal with the south connector entity type and id', async () => {
+    const fixture = TestBed.createComponent(SouthListComponent);
+    fixture.detectChanges();
+
+    const fakeModalComponent = createMock(AuditHistoryModalComponent);
+    const modalRef = { componentInstance: fakeModalComponent } as unknown as Modal<AuditHistoryModalComponent>;
+    const modalServiceMock = TestBed.inject(ModalService) as unknown as MockObject<ModalService>;
+    modalServiceMock.open.mockReturnValue(modalRef);
+
+    const root = page.elementLocator(fixture.nativeElement);
+    await root.getByCss('.show-audit-south').nth(0).click();
+
+    expect(modalServiceMock.open).toHaveBeenCalledWith(AuditHistoryModalComponent);
+    expect(fakeModalComponent.prepare).toHaveBeenCalledWith('south_connector', southConnectors[0].id);
   });
 });

--- a/frontend/src/app/south/south-list.component.ts
+++ b/frontend/src/app/south/south-list.component.ts
@@ -141,7 +141,7 @@ export class SouthListComponent {
    * Open a modal to view the audit history of a South connector
    */
   showAudit(south: SouthConnectorLightDTO) {
-    const modalRef = this.modalService.open(AuditHistoryModalComponent);
+    const modalRef = this.modalService.open(AuditHistoryModalComponent, { size: 'xl' });
     modalRef.componentInstance.prepare('south_connector', south.id);
   }
 

--- a/frontend/src/app/south/south-list.component.ts
+++ b/frontend/src/app/south/south-list.component.ts
@@ -19,6 +19,7 @@ import { OIBusSouthTypeEnumPipe } from '../shared/oibus-south-type-enum.pipe';
 import { FormControlValidationDirective } from '../shared/form/form-control-validation.directive';
 import { NgbTooltip } from '@ng-bootstrap/ng-bootstrap';
 import { AuditInfoComponent } from '../shared/audit-info/audit-info.component';
+import { AuditHistoryModalComponent } from '../shared/audit-history-modal/audit-history-modal.component';
 
 type SouthSortField = 'name' | 'type' | 'createdAt' | 'updatedAt' | null;
 type SortDirection = 'asc' | 'desc';
@@ -134,6 +135,14 @@ export class SouthListComponent {
   createSouth() {
     const modalRef = this.modalService.open(ChooseSouthConnectorTypeModalComponent, { size: 'xl', backdrop: 'static' });
     modalRef.result.subscribe();
+  }
+
+  /**
+   * Open a modal to view the audit history of a South connector
+   */
+  showAudit(south: SouthConnectorLightDTO) {
+    const modalRef = this.modalService.open(AuditHistoryModalComponent);
+    modalRef.componentInstance.prepare('south_connector', south.id);
   }
 
   toggleSort(field: SouthSortField) {

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -2889,7 +2889,19 @@
     "history-modal": {
       "title": "Audit history",
       "loading": "Loading audit history…",
-      "none": "No history found"
+      "none": "No history found",
+      "tooltips": {
+        "expand": "Show details",
+        "collapse": "Hide details"
+      },
+      "modes": {
+        "table": "Table",
+        "json-diff": "JSON diff",
+        "json-side-by-side": "JSON side by side"
+      }
+    },
+    "tooltips": {
+      "view": "View audit log details"
     },
     "actions": {
       "CREATE": "Create",
@@ -2913,8 +2925,7 @@
     "entity-id": "Entity ID",
     "action": "Action",
     "user": "User",
-    "date": "Date",
-    "details": "Details"
+    "date": "Date"
   },
   "logs": {
     "title": "Logs",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -162,6 +162,23 @@
       "history-query": "History query",
       "internal": "Internal"
     },
+    "audit-entity-types": {
+      "south_connector": "South connector",
+      "south_item": "South item",
+      "south_item_group": "South item group",
+      "north_connector": "North connector",
+      "north_transformer": "North transformer",
+      "history_query": "History query",
+      "history_query_item": "History query item",
+      "history_query_transformer": "History query transformer",
+      "scan_mode": "Scan mode",
+      "ip_filter": "IP filter",
+      "certificate": "Certificate",
+      "user": "User",
+      "transformer": "Transformer",
+      "engine": "Engine",
+      "oianalytics_registration": "OIAnalytics registration"
+    },
     "internal-scope-ids": {
       "engine": "Engine",
       "web-server": "Web Server",
@@ -371,7 +388,8 @@
     "version": "Version: {{ version }}",
     "account": {
       "logout": "Logout",
-      "settings": "Settings"
+      "settings": "Settings",
+      "audit": "Audit"
     },
     "tooltips": {
       "documentation": "Documentation"
@@ -708,7 +726,8 @@
         "add": "Add a new scan mode",
         "edit": "Edit scan mode",
         "delete": "Delete scan mode",
-        "overnight": "The end time is on the following day"
+        "overnight": "The end time is on the following day",
+        "audit": "View scan mode audit history"
       }
     },
     "certificate": {
@@ -743,7 +762,8 @@
         "edit": "Edit certificate",
         "delete": "Delete certificate",
         "copy-public-key": "Copy public key to clipboard",
-        "copy-certificate": "Copy certificate to clipboard"
+        "copy-certificate": "Copy certificate to clipboard",
+        "audit": "View certificate audit history"
       },
       "import": {
         "button": "Import",
@@ -786,7 +806,8 @@
       "tooltips": {
         "add": "Add a new IP filter",
         "edit": "Edit IP filter",
-        "delete": "Delete IP filter"
+        "delete": "Delete IP filter",
+        "audit": "View IP filter audit history"
       }
     },
     "transformer": {
@@ -1162,7 +1183,8 @@
             "tooltips": {
               "add": "Add a Custom Transformer",
               "edit": "Edit this Custom Transformer",
-              "delete": "Delete this Custom Transformer"
+              "delete": "Delete this Custom Transformer",
+              "audit": "View this Custom Transformer's audit history"
             }
           },
           "test-transformer-modal": {
@@ -2735,7 +2757,8 @@
       "duplicate": "Duplicate south connector",
       "delete": "Delete south connector",
       "view-metrics": "View south connector metrics",
-      "copy-cache-path": "Copy cache path to clipboard"
+      "copy-cache-path": "Copy cache path to clipboard",
+      "audit": "View south connector audit history"
     }
   },
   "north": {
@@ -2853,8 +2876,42 @@
       "duplicate": "Duplicate north connector",
       "delete": "Delete north connector",
       "copy-cache-path": "Copy cache path to clipboard",
-      "view-metrics": "View north connector metrics"
+      "view-metrics": "View north connector metrics",
+      "audit": "View north connector audit history"
     }
+  },
+  "audit": {
+    "title": "Audit",
+    "none": "No audit log found",
+    "history-modal": {
+      "title": "Audit history",
+      "loading": "Loading audit history…",
+      "none": "No history found"
+    },
+    "actions": {
+      "CREATE": "Create",
+      "UPDATE": "Update",
+      "DELETE": "Delete"
+    },
+    "diff": {
+      "field": "Field",
+      "before": "Before",
+      "after": "After"
+    },
+    "search": {
+      "entity-type": "Entity type",
+      "action": "Action",
+      "start": "Start",
+      "end": "End",
+      "all-entity-types": "All entity types",
+      "all-actions": "All actions"
+    },
+    "entity-type": "Entity type",
+    "entity-id": "Entity ID",
+    "action": "Action",
+    "user": "User",
+    "date": "Date",
+    "details": "Details"
   },
   "logs": {
     "title": "Logs",
@@ -3066,7 +3123,8 @@
       "edit": "Edit history query",
       "duplicate": "Duplicate history query",
       "delete": "Delete history query",
-      "copy-cache-path": "Copy cache path to clipboard"
+      "copy-cache-path": "Copy cache path to clipboard",
+      "audit": "View history query audit history"
     }
   },
   "explore-cache": {

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -88,7 +88,8 @@
       "ms": "ms",
       "s": "s",
       "hr": "hr",
-      "MB": "MB"
+      "MB": "MB",
+      "days": "days"
     },
     "tooltips": {
       "help": "Help",
@@ -608,7 +609,9 @@
       "forward-proxy-password": "Password"
     },
     "logger": {
-      "title": "Logger",
+      "title": "Logging and audit",
+      "audit-retention-duration": "Audit log retention",
+      "audit-retention-duration-hint": "Number of days audit log entries are kept before being pruned. 0 = keep forever.",
       "console": {
         "level": "Console level"
       },


### PR DESCRIPTION
UI changes:
<img width="1440" height="900" alt="01-navbar-account-dropdown" src="https://github.com/user-attachments/assets/1a6d2127-4fc8-4e95-8a24-3941ccdcb7e6" />
<img width="1440" height="900" alt="02-ip-filter-list-with-audit-button" src="https://github.com/user-attachments/assets/0cfe03f1-83e2-43f4-b01a-37cfc1267a2d" />
<img width="1440" height="900" alt="03-global-audit-page-populated" src="https://github.com/user-attachments/assets/2ebd9bc6-b0f1-4a67-b2f5-bd8a077b8048" />
<img width="1440" height="900" alt="04-audit-history-modal" src="https://github.com/user-attachments/assets/0dbed6af-3a1e-4af2-8261-f76ef5e59e68" />
<img width="1440" height="900" alt="05-audit-diff-expanded" src="https://github.com/user-attachments/assets/b2c9b0b9-1ad4-49d6-9b7b-68f23c3269a2" />
<img width="1440" height="900" alt="06-logging-and-audit-modal" src="https://github.com/user-attachments/assets/0ba76df4-f01b-4f2f-a5e0-73d5b638ea0b" />


Closes #4856 